### PR TITLE
stable/jenkins - Feature: Add cache section under agent for cache vol…

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -5,6 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 2.6.0 cache section under agent to define volumes for caching build artifacts
+
+Added the definitions under `agent` to define `cache.persistence` volumes.
+Volumes of type `PVC` are created by the chart and cleared on a schedule defined under the `cache.clear` section.
+
 ## 2.5.2
 
 Fix as per JENKINS-47112

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.5.2
+version: 2.6.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -418,23 +418,29 @@ $ helm install my-release -f values.yaml stable/jenkins
 
 #### Defining Caches for your agent pods
 
-Its possible to define a set of cache volumes that can be mounted by agent pods for storing libraries and other artifacts for build. The volume defined, under `persistence`, will be created as a new `PVC` by the chart. The volume has to be mounted under the `volumes` section. Along with the cache, a `CronJob` can be defined under the `clear` section to perform cache activies, including clearing old libraries, on a periodic basis. The `CronJob` is required both to prevent unused libraries from accumulating over time and to avoid security issues.
+Its possible to define a set of cache volumes that can be mounted by agent pods for storing libraries and other artifacts for build.
+- The volume defined, under `pvc`, will be created by the chart.
+- The volume has to be mounted under the `volumes` section.
+- Along with the cache, a `CronJob` can be defined under the `clearJob` section to perform cache activities, including clearing old libraries, on a periodic basis.
+- The `CronJob` is required both to prevent unused libraries from accumulating over time and to avoid security issues.
 
-> **Tip**: Ensure a PVC and CronJob with a given `componentName` is defined only once
+> **Tip**: For jobs that are running frequently during the day it may be easier just to configure `idleMinutes` which keeps the agent container running between jobs
+
+> **Note**: Ensure a PVC and CronJob with a given `componentName` is created only once, else template rendering will fail with a `"<componentName>" already exists` error
 
 The cache is defined in the format below:
 
 ```
     cache:
       # create PVC
-      persistence:
-        enabled: true
+      pvc:
+        create: true
         componentName: "{{ .Release.Name }}-maven-cache"
         storageClass:
         size: "8Gi"
       # create CronJob (which mounts all agent volumes)
-      clear:
-        enabled: true
+      clearJob:
+        create: true
         componentName: "{{ .Release.Name }}-clear-maven-cache"
         claimName: "{{ .Release.Name }}-maven-cache"
         mountPath: "/home/jenkins/agent/.m2/repository"

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -132,7 +132,7 @@ jenkins:
       {{- $agent := .Values.agent }}
       {{- range $name, $additionalAgent := .Values.additionalAgents }}
         {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
-        {{- $additionalAgent := merge $additionalAgent $agent }}
+        {{- $additionalAgent := mergeOverwrite (deepCopy $agent) $additionalAgent }}
         {{- /* set .Values.agent to $additionalAgent */}}
         {{- $_ := set $.Values "agent" $additionalAgent }}
         {{- include "jenkins.casc.podTemplate" $ | nindent 8 }}
@@ -241,6 +241,11 @@ Returns kubernetes pod template configuration as code
         {{ $key }}: {{ if kindIs "string" $value }}{{ tpl $value $ | quote }}{{ else }}{{ $value }}{{ end }}
       {{- end }}
     {{- end }}
+  {{- end }}
+  {{- if .Values.agent.cache.volume }}
+    - persistentVolumeClaim:
+        claimName: {{ .Release.Name }}-{{ .Values.agent.cache.volume.pvcComponentName }}
+        mountPath: {{ .Values.agent.cache.volume.mountPath }}
   {{- end }}
 {{- end }}
 {{- if .Values.agent.yamlTemplate }}

--- a/charts/jenkins/templates/cache-cronjobs.yaml
+++ b/charts/jenkins/templates/cache-cronjobs.yaml
@@ -1,16 +1,27 @@
-{{- /* create list of agents */}}
-{{- $_ := set .Values "agentList" (list .Values.agent) }}
+{{- /* create map of agents by clearJob.componentName */}}
+{{- if .Values.agent.cache.clearJob.create }}
+  {{- $_ := set .Values "agentMap" (dict .Values.agent.cache.clearJob.componentName .Values.agent) }}
+{{- else }}
+  {{- $_ := set .Values "agentMap" (dict) }}
+{{- end }}
 {{- range $name, $additionalAgent := .Values.additionalAgents }}
     {{- /* merge .Values.agent into additional agent to ensure it at least has the default values */}}
-    {{- $_ := set $.Values "agentList" (append $.Values.agentList (merge $additionalAgent $.Values.agent)) }}
+    {{- $mergedAgent := (merge $additionalAgent $.Values.agent) }}
+    {{- if $mergedAgent.cache.clearJob.create }}
+      {{- if get $.Values.agentMap $mergedAgent.cache.clearJob.componentName }}
+        {{- fail "Cannot create more than one clearJob with a given componentName" }}
+      {{- else }}
+        {{- $_ := set $.Values.agentMap $mergedAgent.cache.clearJob.componentName $mergedAgent }}
+      {{- end }}
+    {{- end }}
 {{- end }}
-{{- range $agent := .Values.agentList }}
-{{- if $agent.cache.clear.enabled }}
+{{- range $_, $agent := .Values.agentMap }}
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ tpl ($agent.cache.clear.componentName | required "cache clear componentName is required") $ }}
+  name: {{ tpl ($agent.cache.clearJob.componentName | required "cache clearJob componentName is required") $ }}
+  namespace: {{ template "jenkins.master.slaveKubernetesNamespace" $ }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" $ }}'
     "helm.sh/chart": "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
@@ -21,7 +32,7 @@ spec:
   concurrencyPolicy : "Forbid"
   failedJobsHistoryLimit : 5
   successfulJobsHistoryLimit: 5
-  schedule: "{{ $agent.cache.clear.schedule }}"
+  schedule: "{{ $agent.cache.clearJob.schedule }}"
   jobTemplate:
     spec:
       backoffLimit: 6
@@ -37,12 +48,12 @@ spec:
           volumes:
           - name: cache-volume
             persistentVolumeClaim:
-              claimName: {{ tpl ($agent.cache.clear.claimName | required "cache clear.claimName is required") $ }}
+              claimName: {{ tpl ($agent.cache.clearJob.claimName | required "cache clear.claimName is required") $ }}
           containers:
-          - name: {{ tpl ($agent.cache.clear.componentName | required "cache clear componentName is required") $ }}
-            image: "docker-registry.default.svc:5000/{{ $agent.cache.clear.image }}:{{ $agent.cache.clear.tag }}"
+          - name: {{ tpl ($agent.cache.clearJob.componentName | required "cache clear componentName is required") $ }}
+            image: "{{ $agent.cache.clearJob.image }}:{{ $agent.cache.clearJob.tag }}"
             volumeMounts:
-            - mountPath: {{ tpl ($agent.cache.clear.mountPath | required "cache mountPath is required") $ }}
+            - mountPath: {{ tpl ($agent.cache.clearJob.mountPath | required "cache mountPath is required") $ }}
               name: cache-volume
             resources:
               limits:
@@ -55,9 +66,8 @@ spec:
             - /bin/sh
             - -c
             - |
-              cd {{ tpl ($agent.cache.clear.mountPath | required "cache mountPath is required") $ }}
-              {{- tpl $agent.cache.clear.command $ | nindent 14 }}
+              cd {{ tpl ($agent.cache.clearJob.mountPath | required "cache mountPath is required") $ }}
+              {{- tpl $agent.cache.clearJob.command $ | nindent 14 }}
           restartPolicy: OnFailure
-{{- end }}
 {{- end }}
 {{- $_ := unset .Values "agentList" }}

--- a/charts/jenkins/templates/cache-cronjobs.yaml
+++ b/charts/jenkins/templates/cache-cronjobs.yaml
@@ -1,38 +1,32 @@
-{{- /* create map of agents by clearJob.componentName */}}
-{{- if .Values.agent.cache.clearJob.create }}
-  {{- $_ := set .Values "agentMap" (dict .Values.agent.cache.clearJob.componentName .Values.agent) }}
-{{- else }}
-  {{- $_ := set .Values "agentMap" (dict) }}
-{{- end }}
+{{- /* create agent map */}}
+{{- /* merge .Values.agent into additional agent(s) to propogate values except cache.clearJob.create */}}
+{{- $_ := set .Values "agentMap" (dict "agent" .Values.agent) }}
+{{- $agentCopy := deepCopy .Values.agentMap.agent }}
+{{- $_ := set $agentCopy.cache.clearJob "create" false }}
 {{- range $name, $additionalAgent := .Values.additionalAgents }}
-    {{- /* merge .Values.agent into additional agent to ensure it at least has the default values */}}
-    {{- $mergedAgent := (merge $additionalAgent $.Values.agent) }}
-    {{- if $mergedAgent.cache.clearJob.create }}
-      {{- if get $.Values.agentMap $mergedAgent.cache.clearJob.componentName }}
-        {{- fail "Cannot create more than one clearJob with a given componentName" }}
-      {{- else }}
-        {{- $_ := set $.Values.agentMap $mergedAgent.cache.clearJob.componentName $mergedAgent }}
-      {{- end }}
-    {{- end }}
+    {{- /* use mergeOverwrite - see helm issue 7313 */}}
+    {{- $_ := set $.Values.agentMap $name (mergeOverwrite (deepCopy $agentCopy) $additionalAgent) }}
 {{- end }}
-{{- range $_, $agent := .Values.agentMap }}
+{{- range $name, $agent := .Values.agentMap }}
+{{- if and $agent.cache.clearJob.create $agent.cache.volume }}
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ tpl ($agent.cache.clearJob.componentName | required "cache clearJob componentName is required") $ }}
+  name: {{ include "jenkins.fullname" $ }}-{{ $agent.cache.clearJob.componentName }}
   namespace: {{ template "jenkins.master.slaveKubernetesNamespace" $ }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" $ }}'
     "helm.sh/chart": "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
     "app.kubernetes.io/instance": "{{ $.Release.Name }}"
-    "app.kubernetes.io/component": "{{ $.Values.master.componentName }}"
+    "app.kubernetes.io/component": "{{ $.Values.agent.componentName }}-clear-cache"
 spec:
   concurrencyPolicy : "Forbid"
   failedJobsHistoryLimit : 5
   successfulJobsHistoryLimit: 5
-  schedule: "{{ $agent.cache.clearJob.schedule }}"
+  schedule: {{ $agent.cache.clearJob.schedule | quote }}
+  startingDeadlineSeconds: 120
   jobTemplate:
     spec:
       backoffLimit: 6
@@ -43,31 +37,29 @@ spec:
             "helm.sh/chart": "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
             "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
             "app.kubernetes.io/instance": "{{ $.Release.Name }}"
-            "app.kubernetes.io/component": "{{ $.Values.master.componentName }}"
+            "app.kubernetes.io/component": "{{ $.Values.agent.componentName }}-clear-cache"
         spec:
-          volumes:
-          - name: cache-volume
-            persistentVolumeClaim:
-              claimName: {{ tpl ($agent.cache.clearJob.claimName | required "cache clear.claimName is required") $ }}
-          containers:
-          - name: {{ tpl ($agent.cache.clearJob.componentName | required "cache clear componentName is required") $ }}
-            image: "{{ $agent.cache.clearJob.image }}:{{ $agent.cache.clearJob.tag }}"
-            volumeMounts:
-            - mountPath: {{ tpl ($agent.cache.clearJob.mountPath | required "cache mountPath is required") $ }}
-              name: cache-volume
-            resources:
-              limits:
-                cpu: 500m
-                memory: 512Mi
-              requests:
-                cpu: 500m
-                memory: 512Mi
-            command:
-            - /bin/sh
-            - -c
-            - |
-              cd {{ tpl ($agent.cache.clearJob.mountPath | required "cache mountPath is required") $ }}
-              {{- tpl $agent.cache.clearJob.command $ | nindent 14 }}
           restartPolicy: OnFailure
+          volumes:
+            - name: cache-volume
+              persistentVolumeClaim:
+                claimName: {{ include "jenkins.fullname" $ }}-{{ $agent.cache.volume.pvcComponentName }}
+          containers:
+            - name: clear-cache
+              image: "{{ $agent.cache.clearJob.image }}:{{ $agent.cache.clearJob.tag }}"
+              volumeMounts:
+                - name: cache-volume
+                  mountPath: {{ $agent.cache.volume.mountPath }}
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 500m
+                  memory: 512Mi
+              workingDir: {{ $agent.cache.volume.mountPath }}
+              command: {{ toYaml $agent.cache.clearJob.command | nindent 16 }}
+              args: {{ toYaml $agent.cache.clearJob.args | nindent 16 }}
 {{- end }}
-{{- $_ := unset .Values "agentList" }}
+{{- end }}
+{{- $_ := unset .Values "agentMap" }}

--- a/charts/jenkins/templates/cache-cronjobs.yaml
+++ b/charts/jenkins/templates/cache-cronjobs.yaml
@@ -1,0 +1,63 @@
+{{- /* create list of agents */}}
+{{- $_ := set .Values "agentList" (list .Values.agent) }}
+{{- range $name, $additionalAgent := .Values.additionalAgents }}
+    {{- /* merge .Values.agent into additional agent to ensure it at least has the default values */}}
+    {{- $_ := set $.Values "agentList" (append $.Values.agentList (merge $additionalAgent $.Values.agent)) }}
+{{- end }}
+{{- range $agent := .Values.agentList }}
+{{- if $agent.cache.clear.enabled }}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ tpl ($agent.cache.clear.componentName | required "cache clear componentName is required") $ }}
+  labels:
+    "app.kubernetes.io/name": '{{ template "jenkins.name" $ }}'
+    "helm.sh/chart": "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
+    "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+    "app.kubernetes.io/component": "{{ $.Values.master.componentName }}"
+spec:
+  concurrencyPolicy : "Forbid"
+  failedJobsHistoryLimit : 5
+  successfulJobsHistoryLimit: 5
+  schedule: "{{ $agent.cache.clear.schedule }}"
+  jobTemplate:
+    spec:
+      backoffLimit: 6
+      template:
+        metadata:
+          labels:
+            "app.kubernetes.io/name": '{{ template "jenkins.name" $ }}'
+            "helm.sh/chart": "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+            "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
+            "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+            "app.kubernetes.io/component": "{{ $.Values.master.componentName }}"
+        spec:
+          volumes:
+          - name: cache-volume
+            persistentVolumeClaim:
+              claimName: {{ tpl ($agent.cache.clear.claimName | required "cache clear.claimName is required") $ }}
+          containers:
+          - name: {{ tpl ($agent.cache.clear.componentName | required "cache clear componentName is required") $ }}
+            image: "docker-registry.default.svc:5000/{{ $agent.cache.clear.image }}:{{ $agent.cache.clear.tag }}"
+            volumeMounts:
+            - mountPath: {{ tpl ($agent.cache.clear.mountPath | required "cache mountPath is required") $ }}
+              name: cache-volume
+            resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 500m
+                memory: 512Mi
+            command:
+            - /bin/sh
+            - -c
+            - |
+              cd {{ tpl ($agent.cache.clear.mountPath | required "cache mountPath is required") $ }}
+              {{- tpl $agent.cache.clear.command $ | nindent 14 }}
+          restartPolicy: OnFailure
+{{- end }}
+{{- end }}
+{{- $_ := unset .Values "agentList" }}

--- a/charts/jenkins/templates/cache-pvcs.yaml
+++ b/charts/jenkins/templates/cache-pvcs.yaml
@@ -1,30 +1,33 @@
-{{- /* create list of agents */}}
-{{- $_ := set .Values "agentList" (list .Values.agent) }}
+{{- /* create agent map */}}
+{{- /* merge .Values.agent into additional agent(s) to propogate values except cache.pvc.create */}}
+{{- $_ := set .Values "agentMap" (dict "agent" .Values.agent) }}
+{{- $agentCopy := deepCopy .Values.agentMap.agent }}
+{{- $_ := set $agentCopy.cache.pvc "create" false }}
 {{- range $name, $additionalAgent := .Values.additionalAgents }}
-    {{- /* merge .Values.agent into additional agent to ensure it at least has the default values */}}
-    {{- $_ := set $.Values "agentList" (append $.Values.agentList (merge $additionalAgent $.Values.agent)) }}
+    {{- /* use mergeOverwrite - see helm issue 7313 */}}
+    {{- $_ := set $.Values.agentMap $name (mergeOverwrite (deepCopy $agentCopy) $additionalAgent) }}
 {{- end }}
-{{- range $agent := .Values.agentList }}
+{{- range $name, $agent := .Values.agentMap }}
 {{- if $agent.cache.pvc.create }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ tpl ($agent.cache.pvc.componentName | required "cache pvc componentName is required") $ }}
+  name: {{ include "jenkins.fullname" $ }}-{{ $agent.cache.pvc.componentName }}
   namespace: {{ template "jenkins.master.slaveKubernetesNamespace" $ }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" $ }}'
     "helm.sh/chart": "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
     "app.kubernetes.io/instance": "{{ $.Release.Name }}"
-    "app.kubernetes.io/component": "{{ $.Values.master.componentName }}"
+    "app.kubernetes.io/component": "{{ $.Values.agent.componentName }}-cache"
 spec:
   accessModes:
     - "ReadWriteMany"
   resources:
     requests:
-      storage: {{ $agent.cache.pvc.size | required "size is required" }}
+      storage: {{ $agent.cache.pvc.size }}
   storageClassName: {{ $agent.cache.pvc.storageClass | default "" }}
 {{- end }}
 {{- end }}
-{{- $_ := unset .Values "agentList" }}
+{{- $_ := unset .Values "agentMap" }}

--- a/charts/jenkins/templates/cache-pvcs.yaml
+++ b/charts/jenkins/templates/cache-pvcs.yaml
@@ -1,0 +1,29 @@
+{{- /* create list of agents */}}
+{{- $_ := set .Values "agentList" (list .Values.agent) }}
+{{- range $name, $additionalAgent := .Values.additionalAgents }}
+    {{- /* merge .Values.agent into additional agent to ensure it at least has the default values */}}
+    {{- $_ := set $.Values "agentList" (append $.Values.agentList (merge $additionalAgent $.Values.agent)) }}
+{{- end }}
+{{- range $agent := .Values.agentList }}
+{{- if $agent.cache.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ tpl ($agent.cache.persistence.componentName | required "cache persistence componentName is required") $ }}
+  labels:
+    "app.kubernetes.io/name": '{{ template "jenkins.name" $ }}'
+    "helm.sh/chart": "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
+    "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+    "app.kubernetes.io/component": "{{ $.Values.master.componentName }}"
+spec:
+  accessModes:
+    - "ReadWriteMany"
+  resources:
+    requests:
+      storage: {{ $agent.cache.persistence.size | required "size is required" }}
+  storageClassName: {{ $agent.cache.persistence.storageClass | default "" }}
+{{- end }}
+{{- end }}
+{{- $_ := unset .Values "agentList" }}

--- a/charts/jenkins/templates/cache-pvcs.yaml
+++ b/charts/jenkins/templates/cache-pvcs.yaml
@@ -5,12 +5,13 @@
     {{- $_ := set $.Values "agentList" (append $.Values.agentList (merge $additionalAgent $.Values.agent)) }}
 {{- end }}
 {{- range $agent := .Values.agentList }}
-{{- if $agent.cache.persistence.enabled }}
+{{- if $agent.cache.pvc.create }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ tpl ($agent.cache.persistence.componentName | required "cache persistence componentName is required") $ }}
+  name: {{ tpl ($agent.cache.pvc.componentName | required "cache pvc componentName is required") $ }}
+  namespace: {{ template "jenkins.master.slaveKubernetesNamespace" $ }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" $ }}'
     "helm.sh/chart": "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
@@ -22,8 +23,8 @@ spec:
     - "ReadWriteMany"
   resources:
     requests:
-      storage: {{ $agent.cache.persistence.size | required "size is required" }}
-  storageClassName: {{ $agent.cache.persistence.storageClass | default "" }}
+      storage: {{ $agent.cache.pvc.size | required "size is required" }}
+  storageClassName: {{ $agent.cache.pvc.storageClass | default "" }}
 {{- end }}
 {{- end }}
 {{- $_ := unset .Values "agentList" }}

--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -54,7 +54,7 @@ data:
     {{- $agent := .Values.agent }}
     {{- range $name, $additionalAgent := .Values.additionalAgents }}
       {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
-      {{- $additionalAgent := merge $additionalAgent $agent }}
+      {{- $additionalAgent := mergeOverwrite (deepCopy $agent) $additionalAgent }}
       {{- /* set .Values.agent to $additionalAgent */}}
       {{- $_ := set $.Values "agent" $additionalAgent }}
       {{- include "jenkins.xml.podTemplate" $ | nindent 12 }}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -480,6 +480,26 @@ agent:
   # Controls how agent pods are retained after the Jenkins build completes
   # Possible values: Always, Never, OnFailure
   podRetention: "Never"
+  # create a cache for this agent, the chart will create a PVC as per componentName
+  # and storageClass, if defined. This PVC can be mounted for use  in the volumes section.
+  cache:
+    # create PVC
+    persistence:
+      enabled: false
+      componentName: "{{ .Release.Name }}-cache"
+      storageClass:
+      size: "4Gi"
+    # storageClass:
+    # create CronJob (mounts an agent volume)
+    clear:
+      enabled: false
+      componentName: "{{ .Release.Name }}-clear-cache"
+      claimName: "{{ .Release.Name }}-cache"
+      mountPath: "/tmp/cache"
+      schedule: "0 0 * * SUN"
+      image: "maorfr/kube-tasks"
+      tag: "0.2.0"
+      command: "kube-tasks execute --command 'rm -rf'"
   # You can define the volumes that you want to mount for this container
   # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, PVC, Secret
   # Configure the attributes as they appear in the corresponding Java class for that type

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -483,23 +483,25 @@ agent:
   # create a cache for this agent, the chart will create a PVC as per componentName
   # and storageClass, if defined. This PVC can be mounted for use  in the volumes section.
   cache:
-    # create PVC
     pvc:
+      # create PVC to host the cache
       create: false
-      componentName: "{{ .Release.Name }}-cache"
+      componentName: "agent-cache"
       storageClass:
       size: "4Gi"
-    # storageClass:
-    # create CronJob (mounts an agent volume)
+    volume:
+      pvcComponentName: "agent-cache"
+      mountPath: "/var/cache"
     clearJob:
+      # create CronJob to clear the cache
       create: false
-      componentName: "{{ .Release.Name }}-clear-cache"
-      claimName: "{{ .Release.Name }}-cache"
-      mountPath: "/tmp/cache"
+      componentName: "clear-agent-cache"
       schedule: "0 0 * * SUN"
       image: "maorfr/kube-tasks"
       tag: "0.2.0"
-      command: "kube-tasks execute --command 'rm -rf'"
+      workingDir: "/var/cache"
+      command: ["kube-tasks"]
+      args: ["execute", "--command", "rm -rf *"]
   # You can define the volumes that you want to mount for this container
   # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, PVC, Secret
   # Configure the attributes as they appear in the corresponding Java class for that type

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -484,15 +484,15 @@ agent:
   # and storageClass, if defined. This PVC can be mounted for use  in the volumes section.
   cache:
     # create PVC
-    persistence:
-      enabled: false
+    pvc:
+      create: false
       componentName: "{{ .Release.Name }}-cache"
       storageClass:
       size: "4Gi"
     # storageClass:
     # create CronJob (mounts an agent volume)
-    clear:
-      enabled: false
+    clearJob:
+      create: false
       componentName: "{{ .Release.Name }}-clear-cache"
       claimName: "{{ .Release.Name }}-cache"
       mountPath: "/tmp/cache"


### PR DESCRIPTION
#### What this PR does / why we need it:

Note: this is the PR #22691 moved from combined helm-charts repo to jenkinsci repo.
REF: [stable/jenkins]: add cache section under persistence to define volumes #22691

Allows the chart to defined a set of volumes that can be mounted by agents for caching libraries and other build artifacts.
Volumes of type `PVC` are created by the chart and a corresponding `CronJob` is created to clear the cache on a periodic basis.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Added cache section under agent thats set to false by default.

| `agent.cache`              | Defining Cache volumes                          | enabled=false          |

These caches can be mounted under the agent using the existing approach to mount PVC volumes.

#### Defining Caches for your agent pods

Its possible to define a set of cache volumes that can be mounted by agent pods for storing libraries and other artifacts for build. The volume defined, under `persistence`, will be created as a new `PVC` by the chart. The volume has to be mounted under the `volumes` section. Along with the cache, a `CronJob` can be defined under the `clear` section to perform cache activies, including clearing old libraries, on a periodic basis. The `CronJob` is required both to prevent unused libraries from accumulating over time and to avoid security issues.

> **Tip**: Ensure a PVC and CronJob with a given `componentName` is defined only once

The cache is defined in the format below:

```
    cache:
      # create PVC
      persistence:
        enabled: true
        componentName: "{{ .Release.Name }}-maven-cache"
        storageClass:
        size: "8Gi"
      # create CronJob (which mounts all agent volumes)
      clear:
        enabled: true
        componentName: "{{ .Release.Name }}-clear-maven-cache"
        claimName: "{{ .Release.Name }}-maven-cache"
        mountPath: "/home/jenkins/agent/.m2/repository"
        schedule: "0 2 * * WED"
        image: "maven"
        tag: "3.6.3-openjdk-11"
        command: "mvn dependency:purge-local-repository -DsnapshotOnly=true"

```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `stable/jenkins`)

Signed-off-by: Krishnakumar Venkataraman <krishnakumar.venkataraman@ally.com>

