### PR TITLE
Do not render empty JCasC templates

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -10,6 +10,8 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
 
+## 2.6.1 Do not  render emty JCasC templates
+
 ## 2.6.0 First release in jenkinsci GitHub org
 
 Updated README for new location

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.6.0
+version: 2.6.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/ci/default-values.yaml
+++ b/charts/jenkins/ci/default-values.yaml
@@ -1,1 +1,5 @@
 # this file is empty to check if defaults within values.yaml work as expected
+master:
+  JCasC:
+    configScripts:
+      empty: ""

--- a/charts/jenkins/templates/jcasc-config.yaml
+++ b/charts/jenkins/templates/jcasc-config.yaml
@@ -1,6 +1,7 @@
 {{- $root := . }}
 {{- if and (.Values.master.JCasC.enabled) (.Values.master.sidecars.configAutoReload.enabled) }}
 {{- range $key, $val := .Values.master.JCasC.configScripts }}
+{{- if $val }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -17,6 +18,7 @@ metadata:
 data:
   {{ $key }}.yaml: |-
 {{ tpl $val $| indent 4 }}
+{{- end }}
 {{- end }}
 {{- if .Values.master.JCasC.defaultConfig }}
 ---


### PR DESCRIPTION
This avoids rendering empty config maps in case no values is provides.
With this one can simply disable rendering authorizationStrategy and
securityRealm if their configuration is provided outside of the chart.

```yaml
master
  JCasC:
    configScripts:
      authorizationStrategy: ""
      securityRealm: ""
```

Signed-off-by: Torsten Walter <mail@torstenwalter.de>