### PR TITLE
Migrate to Helm 3 - apiVersion is now v2

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,7 +12,8 @@ The change log until v1.5.7 was auto-generated based on git commits. Those entri
 
 ## 3.0.0
 
-Remove all XML configuration options
+- Remove all XML configuration options
+- This chart now requires Helm 3
 
 
 ## 2.6.3

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
 version: 3.0.0

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -20,9 +20,6 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 ```console
 # Helm 3
 $ helm install [RELEASE_NAME] jenkinsci/jenkins [flags]
-
-# Helm 2
-$ helm install --name [RELEASE_NAME] jenkinsci/jenkins [flags]
 ```
 
 _See [configuration](#configuration) below._
@@ -34,9 +31,6 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 ```console
 # Helm 3
 $ helm uninstall [RELEASE_NAME]
-
-# Helm 2
-# helm delete --purge [RELEASE_NAME]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -46,7 +40,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 ## Upgrade Chart
 
 ```console
-# Helm 3 or 2
+# Helm 3
 $ helm upgrade [RELEASE_NAME] jenkinsci/jenkins [flags]
 ```
 
@@ -325,6 +319,8 @@ Upgrade an existing release from `stable/jenkins` to `jenkinsci/jenkins` seamles
 Chart release versions follow [semver](../../CONTRIBUTING.md#versioning), where a MAJOR version change (example `1.0.0` -> `2.0.0`) indicates an incompatible breaking change needing manual actions.
 
 ### To 3.0.0
+
+Starting from this version we require Helm 3.
 
 All values which used XML to configure settings have been removed.
 You need to use JCasC to configure settings instead.


### PR DESCRIPTION
Update chart to apiiVersion v2, which means it no longer supports helm version 2, but only version 3.