### PR TITLE
Change Helm repo name from jenkinsci to jenkins

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -61,7 +61,7 @@ key: value
 ```
 
 ```
-helm install my-release jenkinsci/jenkins --version version --values values.yaml
+helm install my-release jenkins/jenkins --version version --values values.yaml
 ```
 
 -->

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 Once Helm is set up properly, add the repo as follows:
 
 ```console
-helm repo add jenkinsci https://charts.jenkins.io
+helm repo add jenkins https://charts.jenkins.io
 ```
 
-You can then run `helm search repo jenkinsci` to see the charts.
+You can then run `helm search repo jenkins` to see the charts.
 
 <!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->
 Chart documentation is available in [jenkins directory](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/README.md).

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.7.0
+version: 2.7.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -9,7 +9,7 @@ Inspired by the awesome work of [Carlos Sanchez](https://github.com/carlossg).
 ## Get Repo Info
 
 ```console
-helm repo add jenkinsci https://charts.jenkins.io
+helm repo add jenkins https://charts.jenkins.io
 helm repo update
 ```
 
@@ -19,10 +19,10 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 
 ```console
 # Helm 3
-$ helm install [RELEASE_NAME] jenkinsci/jenkins [flags]
+$ helm install [RELEASE_NAME] jenkins/jenkins [flags]
 
 # Helm 2
-$ helm install --name [RELEASE_NAME] jenkinsci/jenkins [flags]
+$ helm install --name [RELEASE_NAME] jenkins/jenkins [flags]
 ```
 
 _See [configuration](#configuration) below._
@@ -47,7 +47,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ```console
 # Helm 3 or 2
-$ helm upgrade [RELEASE_NAME] jenkinsci/jenkins [flags]
+$ helm upgrade [RELEASE_NAME] jenkins/jenkins [flags]
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
@@ -62,10 +62,10 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 
 ```console
 # Helm 3
-$ helm show values jenkinsci/jenkins
+$ helm show values jenkins/jenkins
 
 # Helm 2
-$ helm inspect values jenkinsci/jenkins
+$ helm inspect values jenkins/jenkins
 ```
 
 For a summary of all configurable options, see [VALUES_SUMMARY.md](./VALUES_SUMMARY.md)


### PR DESCRIPTION
This name is up to the final user after all, so better we use a more convenient suggestion. Jenkins Docker Hub repo was moved from `jenkinsci` to `jenkins` for example.