### PR TITLE
Bumped casc version to 1.43

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -13,7 +13,7 @@ The change log until v1.5.7 was auto-generated based on git commits. Those entri
 ## 2.8.2
 
 Bumped configuration-as-code plugin version from 1.41 to 1.43.
-See https://github.com/jenkinsci/configuration-as-code-plugin/issues/1478
+See [configuration-as-code plugin issue #1478](https://github.com/jenkinsci/configuration-as-code-plugin/issues/1478)
 
 ## 2.8.1
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -10,7 +10,7 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
 
-## Future version
+## 2.8.2
 
 Bumped configuration-as-code plugin version from 1.41 to 1.43.
 See https://github.com/jenkinsci/configuration-as-code-plugin/issues/1478

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -10,6 +10,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
 
+## Future version
+
+Bumped configuration-as-code plugin version from 1.41 to 1.43.
+See https://github.com/jenkinsci/configuration-as-code-plugin/issues/1478
+
 ## 2.8.1
 
 Fix indentation of JAVA_OPTS

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.8.1
+version: 2.8.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -230,7 +230,7 @@ master:
     - workflow-aggregator:2.6
     - credentials-binding:1.23
     - git:4.2.2
-    - configuration-as-code:1.41
+    - configuration-as-code:1.43
 
   # List of plugins to install in addition to those listed in master.installPlugins
   additionalPlugins: []


### PR DESCRIPTION
# What this PR does / why we need it
Bump configuration-as-code-plugin to 1.43

# Which issue this PR fixes
https://github.com/jenkinsci/configuration-as-code-plugin/issues/1478

# Special notes for your reviewer
Have a nice day 💯 

# Checklist

- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
