### PR TITLE
Pin super-linter to specific version

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,9 +13,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: docker://github/super-linter:v3.12.0
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
           VALIDATE_YAML: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What this PR does / why we need it

Linting is broken with latest version of super-linter. It will try to lint `Chart.yaml` as Kubernetes manifest.

https://github.com/github/super-linter/blob/master/action.yml

The GitHub action refers to the v3 tag of the docker image:

```yaml
name: 'Super-Linter'
author: 'GitHub'
description: 'It is a simple combination of various linters, written in bash, to help validate your source code.'
runs:
  using: 'docker'
  image: 'docker://ghcr.io/github/super-linter:v3'
branding:
  icon: 'check-square'
  color: 'white'
```

It's a floating tag as one can check in https://hub.docker.com/r/github/super-linter/tags

Kubeval was added in https://github.com/github/super-linter/releases/tag/v3.11.0



# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] CHANGELOG.md was updated
