### PR TITLE
* Add option to configure securityContext capabilities

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -10,6 +10,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
 
+## 2.8.3
+
+Add option to configure securityContext capabilities
+
 ## 2.8.2
 
 Bumped configuration-as-code plugin version from 1.41 to 1.43.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.8.2
+version: 2.8.3
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/charts/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -36,9 +36,13 @@ spec:
           securityContext:
             runAsUser: {{ default 0 .Values.backup.runAsUser }}
             {{- if and (.Values.backup.runAsUser) (.Values.backup.fsGroup) }}
-            {{- if not (eq (int .Values.backup.runAsUser) 0) }}
+              {{- if not (eq (int .Values.backup.runAsUser) 0) }}
             fsGroup: {{ .Values.backup.fsGroup }}
+              {{- end }}
             {{- end }}
+            {{- if .Values.backup.securityContextCapabilities }}
+          capabilities:
+            {{- toYaml .Values.backup.securityContextCapabilities | nindent 12 }}
             {{- end }}
           {{- end }}
           containers:

--- a/charts/jenkins/templates/jenkins-master-deployment.yaml
+++ b/charts/jenkins/templates/jenkins-master-deployment.yaml
@@ -72,15 +72,15 @@ spec:
 {{- if .Values.master.usePodSecurityContext }}
       securityContext:
         runAsUser: {{ default 0 .Values.master.runAsUser }}
-{{- if and (.Values.master.runAsUser) (.Values.master.fsGroup) }}
-{{- if not (eq (int .Values.master.runAsUser) 0) }}
+  {{- if and (.Values.master.runAsUser) (.Values.master.fsGroup) }}
+    {{- if not (eq (int .Values.master.runAsUser) 0) }}
         fsGroup: {{ .Values.master.fsGroup }}
-{{- end }}
-{{- if .Values.master.securityContextCapabilities }}
+    {{- end }}
+    {{- if .Values.master.securityContextCapabilities }}
         capabilities:
-{{ toYaml .Values.master.securityContextCapabilities | indent 10 }}
-{{- end }}
-{{- end }}
+          {{- toYaml .Values.master.securityContextCapabilities | nindent 10 }}
+    {{- end }}
+  {{- end }}
 {{- end }}
       serviceAccountName: "{{ template "jenkins.serviceAccountName" . }}"
 {{- if .Values.master.hostNetworking }}

--- a/charts/jenkins/templates/jenkins-master-deployment.yaml
+++ b/charts/jenkins/templates/jenkins-master-deployment.yaml
@@ -76,6 +76,10 @@ spec:
 {{- if not (eq (int .Values.master.runAsUser) 0) }}
         fsGroup: {{ .Values.master.fsGroup }}
 {{- end }}
+{{- if .Values.master.securityContextCapabilities }}
+        capabilities:
+{{ toYaml .Values.master.securityContextCapabilities | indent 10 }}
+{{- end }}
 {{- end }}
 {{- end }}
       serviceAccountName: "{{ template "jenkins.serviceAccountName" . }}"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -142,6 +142,10 @@ master:
   # When setting runAsUser to a different value than 0 also set fsGroup to the same value:
   runAsUser: 1000
   fsGroup: 1000
+  # If you have PodSecurityPolicies that require dropping of capabilities as suggested by CIS K8s benchmark, put them here
+  securityContextCapabilities: false
+  #  drop:
+  #    - NET_RAW
   servicePort: 8080
   targetPort: 8080
   # For minikube, set this to NodePort, elsewhere use LoadBalancer

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -740,4 +740,7 @@ backup:
   # When setting runAsUser to a different value than 0 also set fsGroup to the same value:
   runAsUser: 1000
   fsGroup: 1000
+  securityContextCapabilities: {}
+  #  drop:
+  #    - NET_RAW
 checkDeprecation: true

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -143,7 +143,7 @@ master:
   runAsUser: 1000
   fsGroup: 1000
   # If you have PodSecurityPolicies that require dropping of capabilities as suggested by CIS K8s benchmark, put them here
-  securityContextCapabilities: false
+  securityContextCapabilities: {}
   #  drop:
   #    - NET_RAW
   servicePort: 8080


### PR DESCRIPTION

# What this PR does / why we need it

To comply with CIS kubernetes benchmark, PodSecurityPolicies should require that at least NET_RAW, preferrably ALL 
capabilities be dropped. In order to run Jenkins under such a PodSecurityPolicy, it must be possible to configure the capabilities of the jenkins deployment.

Signed-off-by: Tor Ake Fransson <tor-ake.fransson@linefeed.se>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->


# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
