### PR TITLE
Feature to only overwrite jenkins init scripts

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.13.0
+version: 2.14.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -225,7 +225,7 @@ data:
 {{- if .Values.master.initScripts }}
     echo "copy init scripts"
     mkdir -p {{ .Values.master.jenkinsHome }}/init.groovy.d/;
-    {{- if .Values.master.overwriteConfig or .Values.master.overwriteInitScripts }}
+    {{- if or .Values.master.overwriteConfig .Values.master.overwriteInitScripts }}
     rm -f {{ .Values.master.jenkinsHome }}/init.groovy.d/*.groovy
     {{- end }}
     yes n | cp -i /var/jenkins_config/*.groovy {{ .Values.master.jenkinsHome }}/init.groovy.d/;

--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -225,7 +225,7 @@ data:
 {{- if .Values.master.initScripts }}
     echo "copy init scripts"
     mkdir -p {{ .Values.master.jenkinsHome }}/init.groovy.d/;
-    {{- if .Values.master.overwriteConfig }}
+    {{- if .Values.master.overwriteConfig or .Values.master.overwriteInitScripts }}
     rm -f {{ .Values.master.jenkinsHome }}/init.groovy.d/*.groovy
     {{- end }}
     yes n | cp -i /var/jenkins_config/*.groovy {{ .Values.master.jenkinsHome }}/init.groovy.d/;

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -379,6 +379,9 @@ master:
   # the jenkins config with the contents of the configMap every time the pod starts.
   # This will also overwrite all init scripts
   overwriteConfig: false
+  
+  # In some case it's necessary to overwrite only jenkins init scripts from configMap 
+  overwriteInitScripts: false
 
   # By default, the Jobs Map is only used to set the initial jobs the first time
   # that the chart is installed.  Setting `overwriteJobs` to `true` will overwrite


### PR DESCRIPTION
# What this PR does / why we need it

In some case i just want to change my init script, and if I update the values with my modified init script, then jenkins is redeployed but the script updates are not taking effect because of the `overwriteConfig` properties.

Then to achieve it i add a `overwriteInitScripts` boolean


