### PR TITLE
Use envFrom for mounting jenkins admin credentials in container

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -10,6 +10,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
 
+## 2.15.0
+
+Use envFrom for mounting jenkins admin credentials in container
+
 ## 2.14.0
 
 Added support for annotations in podTemplates

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -130,9 +130,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.deploymentAnnotations`           | Annotations for master deployment           | `{}`                                      |
 | `master.lifecycle`                | Lifecycle specification for master-container | Not set                           |
 | `master.priorityClassName`        | The name of a `priorityClass` to apply to the master pod | Not set               |
-| `master.admin.existingSecret`     | The name of an existing secret containing the admin credentials. | `""`|
-| `master.admin.userKey`            | The key in the existing admin secret containing the username. | `jenkins-admin-user` |
-| `master.admin.passwordKey`        | The key in the existing admin secret containing the password. | `jenkins-admin-password` |
+| `master.admin.existingSecret`     | The name of an existing secret containing the admin credentials. It should have keys ADMIN_PASSWORD & ADMIN_USER | `""`|
 | `master.customInitContainers`     | Custom init-container specification in raw-yaml format | Not set                 |
 | `master.sidecars.other`           | Configures additional sidecar container(s) for Jenkins master | `[]`             |
 

--- a/charts/jenkins/templates/NOTES.txt
+++ b/charts/jenkins/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Get your '{{ .Values.master.adminUser }}' user password by running:
-  printf $(kubectl get secret --namespace {{ template "jenkins.namespace" . }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo
+  printf $(kubectl get secret --namespace {{ template "jenkins.namespace" . }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.ADMIN_PASSWORD}" | base64 --decode);echo
 
 {{- if .Values.master.ingress.hostName }}
 

--- a/charts/jenkins/templates/jenkins-master-deployment.yaml
+++ b/charts/jenkins/templates/jenkins-master-deployment.yaml
@@ -102,20 +102,12 @@ spec:
 {{- end }}
           imagePullPolicy: "{{ .Values.master.imagePullPolicy }}"
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
-          env:
-          {{- if .Values.master.useSecurity }}
-            - name: ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.master.admin.existingSecret | default (include "jenkins.fullname" .) }}
-                  key: {{ .Values.master.admin.passwordKey | default "jenkins-admin-password" }}
-            - name: ADMIN_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.master.admin.existingSecret | default (include "jenkins.fullname" .) }}
-                  key: {{ .Values.master.admin.userKey | default "jenkins-admin-user" }}
-            {{- end }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.master.admin.existingSecret | default (include "jenkins.fullname" .) }}
+              optional: false
             {{- if .Values.master.initContainerEnv }}
+          env:
 {{ toYaml .Values.master.initContainerEnv | indent 12 }}
             {{- end }}
           resources:
@@ -181,6 +173,10 @@ spec:
           lifecycle:
 {{ toYaml .Values.master.lifecycle | indent 12 }}
           {{- end }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.master.admin.existingSecret | default (include "jenkins.fullname" .) }}
+              optional: false
           env:
             - name: POD_NAME
               valueFrom:
@@ -192,18 +188,6 @@ spec:
               value: "{{ if .Values.master.jenkinsUriPrefix }}--prefix={{ .Values.master.jenkinsUriPrefix }} {{ end }}{{ default "" .Values.master.jenkinsOpts}}"
             - name: JENKINS_SLAVE_AGENT_PORT
               value: "{{ .Values.master.slaveListenerPort }}"
-            {{- if .Values.master.useSecurity }}
-            - name: ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.master.admin.existingSecret | default (include "jenkins.fullname" .) }}
-                  key: {{ .Values.master.admin.password | default "jenkins-admin-password" }}
-            - name: ADMIN_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.master.admin.existingSecret | default (include "jenkins.fullname" .) }}
-                  key: {{ .Values.master.admin.user | default "jenkins-admin-user" }}
-            {{- end }}
             {{- if .Values.master.httpsKeyStore.enable }}
             - name: JENKINS_HTTPS_KEYSTORE_PASSWORD
               valueFrom:

--- a/charts/jenkins/templates/secret.yaml
+++ b/charts/jenkins/templates/secret.yaml
@@ -14,9 +14,9 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.master.adminPassword -}}
-  jenkins-admin-password: {{ .Values.master.adminPassword | b64enc | quote }}
+  ADMIN_PASSWORD: {{ .Values.master.adminPassword | b64enc | quote }}
   {{ else -}}
-  jenkins-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
+  ADMIN_PASSWORD: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end -}}
-  jenkins-admin-user: {{ .Values.master.adminUser | b64enc | quote }}
+  ADMIN_USER: {{ .Values.master.adminUser | b64enc | quote }}
 {{- end }}

--- a/charts/jenkins/tests/jenkins-master-deployment-test.yaml
+++ b/charts/jenkins/tests/jenkins-master-deployment-test.yaml
@@ -54,6 +54,10 @@ tests:
                   - --argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)
                   - --argumentsRealm.roles.$(ADMIN_USER)=admin
                   - --httpPort=8080
+                  envFrom:
+                  - secretRef:
+                      name: my-release-jenkins
+                      optional: false
                   env:
                   - name: POD_NAME
                     valueFrom:
@@ -65,16 +69,6 @@ tests:
                     value: ""
                   - name: JENKINS_SLAVE_AGENT_PORT
                     value: "50000"
-                  - name: ADMIN_PASSWORD
-                    valueFrom:
-                      secretKeyRef:
-                        key: jenkins-admin-password
-                        name: my-release-jenkins
-                  - name: ADMIN_USER
-                    valueFrom:
-                      secretKeyRef:
-                        key: jenkins-admin-user
-                        name: my-release-jenkins
                   - name: CASC_JENKINS_CONFIG
                     value: /var/jenkins_home/casc_configs
                   image: jenkins/jenkins:lts
@@ -152,17 +146,10 @@ tests:
                 - command:
                   - sh
                   - /var/jenkins_config/apply_config.sh
-                  env:
-                  - name: ADMIN_PASSWORD
-                    valueFrom:
-                      secretKeyRef:
-                        key: jenkins-admin-password
-                        name: my-release-jenkins
-                  - name: ADMIN_USER
-                    valueFrom:
-                      secretKeyRef:
-                        key: jenkins-admin-user
-                        name: my-release-jenkins
+                  envFrom:
+                  - secretRef:
+                      name: my-release-jenkins
+                      optional: false
                   image: jenkins/jenkins:lts
                   imagePullPolicy: Always
                   name: copy-default-config

--- a/charts/jenkins/tests/secret-test.yaml
+++ b/charts/jenkins/tests/secret-test.yaml
@@ -21,19 +21,19 @@ tests:
       - isNull:
           path: metadata.annotations
       - equal:
-          path: data.jenkins-admin-user
+          path: data.ADMIN_USER
           value: YWRtaW4=
       - isNotNull:
-          path: data.jenkins-admin-password
+          path: data.ADMIN_PASSWORD
   - it: set admin password
     set:
       master.adminPassword: secret
     asserts:
       - equal:
-          path: data.jenkins-admin-user
+          path: data.ADMIN_USER
           value: YWRtaW4=
       - equal:
-          path: data.jenkins-admin-password
+          path: data.ADMIN_PASSWORD
           value: c2VjcmV0
   - it: disable
     set:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -103,9 +103,8 @@ master:
   adminUser: "admin"
   # adminPassword: <defaults to random>
   admin:
+    # should have keys ADMIN_PASSWORD & ADMIN_USER
     existingSecret: ""
-    userKey: jenkins-admin-user
-    passwordKey: jenkins-admin-password
   # This values should not be changed unless you use your custom image of jenkins or any devired from. If you want to use
   # Cloudbees Jenkins Distribution docker, you should set jenkinsHome: "/var/cloudbees-jenkins-distribution"
   jenkinsHome: "/var/jenkins_home"


### PR DESCRIPTION
Signed-off-by: Prabhu Jayakumar <j.prabhu91@gmail.com>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it
Use envFrom instead of env to mount admin credentials in container

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #94 

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
