### PR TITLE
Fix error on missing `ingress.paths` value

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -9,6 +9,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 * Commit: `https://github.com/helm/charts/commit/[commit]/stable/jenkins`
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
+
+## 2.15.3
+Fix error on missing `ingress.paths` value
+
 ## 2.15.2
 
 Added documentation for ingress and jenkins url

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.15.2
+version: 2.15.3
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -491,7 +491,6 @@ master:
    ingress:
        enabled: true
        apiVersion: "extensions/v1beta1"
-       paths: []
        hostName: "jenkins.internal.example.com"
        annotations:
            kubernetes.io/ingress.class: "internal"

--- a/charts/jenkins/templates/jenkins-master-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-master-ingress.yaml
@@ -25,12 +25,12 @@ spec:
   rules:
   - http:
       paths:
-{{- if len (.Values.master.ingress.paths) }}
-{{ tpl (toYaml .Values.master.ingress.paths | indent 6) . }}
-{{- else }}
+{{- if empty (.Values.master.ingress.paths) }}
       - backend:
           serviceName: {{ template "jenkins.fullname" . }}
           servicePort: {{ .Values.master.servicePort }}
+{{- else }}
+{{ tpl (toYaml .Values.master.ingress.paths | indent 6) . }}
 {{- if .Values.master.ingress.path }}
         path: {{ .Values.master.ingress.path }}
 {{- end -}}

--- a/charts/jenkins/tests/jenkins-master-ingress-test.yaml
+++ b/charts/jenkins/tests/jenkins-master-ingress-test.yaml
@@ -1,4 +1,4 @@
-suite: Controller Secondary Ingress
+suite: Controller Primary Ingress
 release:
   name: my-release
   namespace: my-namespace

--- a/charts/jenkins/tests/jenkins-master-ingress-test.yaml
+++ b/charts/jenkins/tests/jenkins-master-ingress-test.yaml
@@ -105,3 +105,17 @@ tests:
             app.kubernetes.io/instance: my-release
             app.kubernetes.io/managed-by: Tiller
             app.kubernetes.io/name: jenkins
+  - it: empty paths
+    set:
+      master.ingress:
+        enabled: true
+        paths:
+    asserts:
+    - equal:
+        path: spec.rules
+        value:
+          - http:
+              paths:
+                - backend:
+                    serviceName: my-release-jenkins
+                    servicePort: 8080


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it
This PR fixes the need for specifying `master.ingress.paths` even if no paths need to be overwritten.
This is done by adding an additional check to see if  `master.ingress.paths` is even defined before taking the length

# Which issue this PR fixes

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
