### PR TITLE
Use plugin-installation-manager-tool

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -10,6 +10,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
 
+## 2.17.0
+
+Add support for plugin-installation-manager-tool
+
 ## 2.16.0
 
 Added Startup probe for Jenkins pod when Kubernetes cluster is 1.16 or newer

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.16.0
+version: 2.17.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -209,7 +209,14 @@ data:
     # Install missing plugins
     cp /var/jenkins_config/plugins.txt {{ .Values.master.jenkinsHome }};
     rm -rf {{ .Values.master.jenkinsRef }}/plugins/*.lock
-    /usr/local/bin/install-plugins.sh `echo $(cat {{ .Values.master.jenkinsHome }}/plugins.txt)`;
+    version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+    if [ -f "{{ .Values.master.jenkinsRef }}/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
+      jenkins-plugin-cli --war {{ .Values.master.jenkinsRef }}/jenkins.war --plugin-file {{ .Values.master.jenkinsHome }}/plugins.txt;
+    elif [ -f "{{ .Values.master.jenkinsHome }}/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
+      jenkins-plugin-cli --war {{ .Values.master.jenkinsHome }}/jenkins.war --plugin-file {{ .Values.master.jenkinsHome }}/plugins.txt;
+    else
+      /usr/local/bin/install-plugins.sh `echo $(cat {{ .Values.master.jenkinsHome }}/plugins.txt)`;
+    fi
     echo "copy plugins to shared volume"
     # Copy plugins to shared volume
     yes n | cp -i {{ .Values.master.jenkinsRef }}/plugins/* /var/jenkins_plugins/;

--- a/charts/jenkins/tests/config-test.yaml
+++ b/charts/jenkins/tests/config-test.yaml
@@ -27,7 +27,14 @@ tests:
             # Install missing plugins
             cp /var/jenkins_config/plugins.txt /var/jenkins_home;
             rm -rf /usr/share/jenkins/ref/plugins/*.lock
-            /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+            version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+            if [ -f "/usr/share/jenkins/ref/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
+              jenkins-plugin-cli --war /usr/share/jenkins/ref/jenkins.war --plugin-file /var/jenkins_home/plugins.txt;
+            elif [ -f "/var/jenkins_home/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
+              jenkins-plugin-cli --war /var/jenkins_home/jenkins.war --plugin-file /var/jenkins_home/plugins.txt;
+            else
+              /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+            fi
             echo "copy plugins to shared volume"
             # Copy plugins to shared volume
             yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
@@ -75,7 +82,14 @@ tests:
             # Install missing plugins
             cp /var/jenkins_config/plugins.txt /var/jenkins_home;
             rm -rf /usr/share/jenkins/ref/plugins/*.lock
-            /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+            version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+            if [ -f "/usr/share/jenkins/ref/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
+              jenkins-plugin-cli --war /usr/share/jenkins/ref/jenkins.war --plugin-file /var/jenkins_home/plugins.txt;
+            elif [ -f "/var/jenkins_home/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
+              jenkins-plugin-cli --war /var/jenkins_home/jenkins.war --plugin-file /var/jenkins_home/plugins.txt;
+            else
+              /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+            fi
             echo "copy plugins to shared volume"
             # Copy plugins to shared volume
             yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;

--- a/charts/jenkins/tests/jenkins-master-deployment-test.yaml
+++ b/charts/jenkins/tests/jenkins-master-deployment-test.yaml
@@ -45,7 +45,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: 3ba23f433d321215bc22cf8295c0a264594bc1675408af2f710e36b86c1c1f38
+                  checksum/config: a4e9178adb6ab11b7bdaaca51a566701e8f8f3a2f7a803c87721b1c403b03d04
                 labels:
                   app.kubernetes.io/component: jenkins-master
                   app.kubernetes.io/instance: my-release


### PR DESCRIPTION
# What this PR does / why we need it

Updates the helm chart to use the plugin-installation-manager-tool

# Special notes for your reviewer

I've created a PR to add the new version to the docker images, so it'll soon be working.
Note: before 2.1.1 it tries to delete the entire directory where plugins are installed into, which breaks in the helm chart because its a volume - Fixed in https://github.com/jenkinsci/plugin-installation-manager-tool/pull/215

Added a version check and added https://github.com/jenkinsci/docker/pull/1015 so it gets released in new docker images

I don't know how to run the tests though

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] CHANGELOG.md was updated
