### PR TITLE
Updated locations of stable and incubator Helm repositories

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,11 +27,6 @@ jobs:
           chmod 700 get_helm.sh
           ./get_helm.sh
 
-      - name: Add dependency chart repos
-        run: |
-          helm repo add stable https://charts.helm.sh/stable/
-          helm repo add incubator https://charts.helm.sh/incubator/
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-          helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+          helm repo add stable https://charts.helm.sh/stable/
+          helm repo add incubator https://charts.helm.sh/incubator/
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0


### PR DESCRIPTION
# What this PR does / why we need it

Locations of `stable` and `incubator` repositories in the release action are no longer valid and the step `Add dependency chart repos` fails when adding them

```
Error: repo "https://kubernetes-charts.storage.googleapis.com/" is no longer available; try "https://charts.helm.sh/stable" instead
```

For that reason there is *no* new release after each merge to the `main` branch

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
