### PR TITLE
Modified to work with skaffold.

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -9,6 +9,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 * Commit: `https://github.com/helm/charts/commit/[commit]/stable/jenkins`
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
+## 2.17.2
+
+Also support skaffold values for images
 
 ## 2.17.1
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.17.1
+version: 2.17.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -98,7 +98,9 @@ The following tables list the configurable parameters of the Jenkins chart and t
 #### Kubernetes Deployment & Service
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `master.image`                    | Master image name                    | `jenkins/jenkins`                         |
+| `master.registry`                 | Master image registry                |                                           |
+| `master.repository`               | Master image repository from registry |                                           |
+| `master.image`                    | Master image name (unless master.repository is set) | `jenkins/jenkins`          |
 | `master.tag`                      | Master image tag                     | `lts`                                     |
 | `master.imagePullPolicy`          | Master image pull policy             | `Always`                                  |
 | `master.imagePullSecretName`      | Master image pull secret             | Not set                                   |
@@ -273,8 +275,10 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | Parameter                  | Description                                     | Default                |
 | -------------------------- | ----------------------------------------------- | ---------------------- |
 | `agent.sideContainerName`  | Side container name in agent                    | jnlp                   |
-| `agent.image`              | Agent image name                                | `jenkins/inbound-agent`|
-| `agent.tag`                | Agent image tag                                 | `4.3-4`               |
+| `agent.registry`           | Agent image registry                            |                        |
+| `agent.repository`         | Agent image repository from registry            |                        |
+| `agent.image`              | Agent image name (if agent.repository not set)  | `jenkins/inbound-agent`|
+| `agent.tag`                | Agent image tag                                 | `4.3-4`                |
 | `agent.alwaysPullImage`    | Always pull agent container image before build  | `false`                |
 | `agent.privileged`         | Agent privileged container                      | `false`                |
 | `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 512m, memory: 512Mi}, limits: {cpu: 512m, memory: 512Mi}}` |

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -204,6 +204,10 @@ Returns kubernetes pod template configuration as code
           {{- end }}
     {{- if .Values.agent.imageTag }}
     image: "{{ .Values.agent.image }}:{{ .Values.agent.imageTag }}"
+    {{- else if and (.Values.agent.registry) (.Values.agent.repository) }}
+    image: "{{ .Values.agent.registry }}/{{ .Values.agent.repository }}:{{ .Values.agent.tag }}"
+    {{- else if .Values.agent.repository }}
+    image: "{{ .Values.agent.repository }}:{{ .Values.agent.tag }}"
     {{- else }}
     image: "{{ .Values.agent.image }}:{{ .Values.agent.tag }}"
     {{- end }}
@@ -313,6 +317,10 @@ Returns kubernetes pod template xml configuration
       <name>{{ .Values.agent.sideContainerName }}</name>
 {{- if .Values.agent.imageTag }}
       <image>{{ .Values.agent.image }}:{{ .Values.agent.imageTag }}</image>
+{{- else if and (.Values.agent.registry) (.Values.agent.repository) }}
+      <image>{{ .Values.agent.registry }}/{{ .Values.agent.repository }}:{{ .Values.agent.tag }}</image>
+{{- else if .Values.agent.repository }}
+      <image>{{ .Values.agent.repository }}:{{ .Values.agent.tag }}</image>
 {{- else }}
       <image>{{ .Values.agent.image }}:{{ .Values.agent.tag }}</image>
 {{- end }}

--- a/charts/jenkins/templates/jenkins-master-deployment.yaml
+++ b/charts/jenkins/templates/jenkins-master-deployment.yaml
@@ -97,6 +97,10 @@ spec:
         - name: "copy-default-config"
 {{- if .Values.master.imageTag }}
           image: "{{ .Values.master.image }}:{{ .Values.master.imageTag }}"
+{{- else if and (.Values.master.registry) (.Values.master.repository) }}
+          image: "{{ .Values.master.registry }}/{{ .Values.master.repository }}:{{ .Values.master.tag }}"
+{{- else if .Values.master.repository }}
+          image: "{{ .Values.master.repository }}:{{ .Values.master.tag }}"
 {{- else }}
           image: "{{ .Values.master.image }}:{{ .Values.master.tag }}"
 {{- end }}
@@ -163,6 +167,10 @@ spec:
         - name: jenkins
 {{- if .Values.master.imageTag }}
           image: "{{ .Values.master.image }}:{{ .Values.master.imageTag }}"
+{{- else if and (.Values.master.registry) (.Values.master.repository) }}
+          image: "{{ .Values.master.registry }}/{{ .Values.master.repository }}:{{ .Values.master.tag }}"
+{{- else if .Values.master.repository }}
+          image: "{{ .Values.master.repository }}:{{ .Values.master.tag }}"
 {{- else }}
           image: "{{ .Values.master.image }}:{{ .Values.master.tag }}"
 {{- end }}

--- a/charts/jenkins/templates/tests/jenkins-test.yaml
+++ b/charts/jenkins/templates/tests/jenkins-test.yaml
@@ -32,6 +32,10 @@ spec:
     - name: {{ .Release.Name }}-ui-test
 {{- if .Values.master.imageTag }}
       image: {{ .Values.master.image }}:{{ .Values.master.imageTag }}
+{{- else if and (.Values.master.registry) (.Values.master.repository) }}
+      image: {{ .Values.master.registry }}/{{ .Values.master.repository }}:{{ .Values.master.tag }}
+{{- else if .Values.master.repository }}
+      image: {{ .Values.master.repository }}:{{ .Values.master.tag }}
 {{- else }}
       image: {{ .Values.master.image }}:{{ .Values.master.tag }}
 {{- end }}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -67,6 +67,9 @@ master:
         hYAzODo1Jt59pcqqKJEas0C/lFJEB3frw4ImNx5fNlJYOpx+ijfQs9m39CevDq0=
   # Used for label app.kubernetes.io/component
   componentName: "jenkins-master"
+  # Set by skaffold if used.
+  registry:
+  repository:
   image: "jenkins/jenkins"
   tag: "lts"
   imagePullPolicy: "Always"
@@ -504,6 +507,8 @@ master:
 
 agent:
   enabled: true
+  registry:
+  repository:
   image: "jenkins/inbound-agent"
   tag: "4.3-4"
   workingDir: "/home/jenkins"


### PR DESCRIPTION
# What this PR does / why we need it

This chart does not quite work with skaffold and the automatically assigned image/tag values. Skaffold require images to be identified as <value>.repository, <value>.tag. This is also the image naming suggested in https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md#configuration

This PR adds master.repository and agent.repository as possible alternative names for images if set. If not set, it uses the master.image and agent.image as before.

# Which issue this PR fixes
- 
# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
