### PR TITLE
Dropping /tmp volume

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -9,6 +9,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 * Commit: `https://github.com/helm/charts/commit/[commit]/stable/jenkins`
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
+## 2.18.0
+
+Removed /tmp volume. Making /tmp a volume causes permission issues with jmap/jstack on certain Kubernetes clusters
 
 ## 2.17.1
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.17.1
+version: 2.18.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/templates/jenkins-master-deployment.yaml
+++ b/charts/jenkins/templates/jenkins-master-deployment.yaml
@@ -121,8 +121,6 @@ spec:
           resources:
 {{ toYaml .Values.master.resources | indent 12 }}
           volumeMounts:
-            - mountPath: /tmp
-              name: tmp
             - mountPath: {{ .Values.master.jenkinsHome }}
               name: jenkins-home
               {{- if .Values.persistence.subPath }}
@@ -273,8 +271,6 @@ spec:
             - mountPath: {{ .Values.master.httpsKeyStore.path }}
               name: jenkins-https-keystore
             {{- end }}
-            - mountPath: /tmp
-              name: tmp
             - mountPath: {{ .Values.master.jenkinsHome }}
               name: jenkins-home
               readOnly: false
@@ -362,8 +358,6 @@ spec:
 {{ tpl (toYaml .Values.persistence.volumes | indent 6) . }}
 {{- end }}
       - name: plugins
-        emptyDir: {}
-      - name: tmp
         emptyDir: {}
       - name: jenkins-config
         configMap:

--- a/charts/jenkins/tests/jenkins-master-deployment-test.yaml
+++ b/charts/jenkins/tests/jenkins-master-deployment-test.yaml
@@ -112,8 +112,6 @@ tests:
                       cpu: 50m
                       memory: 256Mi
                   volumeMounts:
-                  - mountPath: /tmp
-                    name: tmp
                   - mountPath: /var/jenkins_home
                     name: jenkins-home
                     readOnly: false
@@ -177,8 +175,6 @@ tests:
                       cpu: 50m
                       memory: 256Mi
                   volumeMounts:
-                  - mountPath: /tmp
-                    name: tmp
                   - mountPath: /var/jenkins_home
                     name: jenkins-home
                   - mountPath: /var/jenkins_config
@@ -194,8 +190,6 @@ tests:
                 volumes:
                 - emptyDir: {}
                   name: plugins
-                - emptyDir: {}
-                  name: tmp
                 - configMap:
                     name: my-release-jenkins
                   name: jenkins-config


### PR DESCRIPTION
Signed-off-by: janssk1 <janssk1@hotmail.com>

# What this PR does / why we need it

Don't use a volume for /tmp. It causes issues on certain KS environments

# Which issue this PR fixes

- fixes #135 

# Special notes for your reviewer
Was able to install jenkins and run jmap. Not sure if any other feature requires all containers in the pod to point to the same /tmp folder. 

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ x] Chart Version bumped
- [ x] CHANGELOG.md was updated
