### PR TITLE
fix: java_ops issue with quoted values

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 2.18.2
+
+Fix: `master.javaOpts` issue with quoted values
+
 ## 2.18.1
 
 Recommend installing plugins in custom image

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.18.1
+version: 2.18.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/templates/jenkins-master-deployment.yaml
+++ b/charts/jenkins/templates/jenkins-master-deployment.yaml
@@ -185,9 +185,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: JAVA_OPTS
-              value: {{- if .Values.master.sidecars.configAutoReload.enabled }} -Dcasc.reload.token=$(POD_NAME) {{- end }} {{ default "" .Values.master.javaOpts }}
+              value: >-
+                {{ if .Values.master.sidecars.configAutoReload.enabled }} -Dcasc.reload.token=$(POD_NAME) {{ end }}{{ default "" .Values.master.javaOpts }}
             - name: JENKINS_OPTS
-              value: "{{ if .Values.master.jenkinsUriPrefix }}--prefix={{ .Values.master.jenkinsUriPrefix }} {{ end }}{{ default "" .Values.master.jenkinsOpts}}"
+              value: >-
+                {{ if .Values.master.jenkinsUriPrefix }}--prefix={{ .Values.master.jenkinsUriPrefix }} {{ end }}{{ default "" .Values.master.jenkinsOpts }}
             - name: JENKINS_SLAVE_AGENT_PORT
               value: "{{ .Values.master.slaveListenerPort }}"
             {{- if .Values.master.useSecurity }}

--- a/charts/jenkins/tests/jenkins-master-deployment-test.yaml
+++ b/charts/jenkins/tests/jenkins-master-deployment-test.yaml
@@ -63,7 +63,7 @@ tests:
                       fieldRef:
                         fieldPath: metadata.name
                   - name: JAVA_OPTS
-                    value: -Dcasc.reload.token=$(POD_NAME)
+                    value: "-Dcasc.reload.token=$(POD_NAME) "
                   - name: JENKINS_OPTS
                     value: ""
                   - name: JENKINS_SLAVE_AGENT_PORT
@@ -319,7 +319,8 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: JAVA_OPTS
-            value: "-Dcasc.reload.token=$(POD_NAME) -Dio.jenkins.plugins.kubernetes.disableNoDelayProvisioning=true"
+            value: >-
+              -Dcasc.reload.token=$(POD_NAME) -Dio.jenkins.plugins.kubernetes.disableNoDelayProvisioning=true
   - it: disable helm.sh label
     set:
       renderHelmLabels: false
@@ -331,3 +332,23 @@ tests:
             app.kubernetes.io/instance: my-release
             app.kubernetes.io/managed-by: Tiller
             app.kubernetes.io/name: jenkins
+  - it: java & jenkins opts with quotes
+    set:
+      master:
+        javaOpts: >-
+          -Dhudson.model.DirectoryBrowserSupport.CSP="default-src 'self';"
+        jenkinsOpts: >-
+          -Dtest="custom: 'true'"
+    asserts:
+      - contains:
+         path: spec.template.spec.containers[0].env
+         content:
+           name: JAVA_OPTS
+           value: >-
+             -Dcasc.reload.token=$(POD_NAME) -Dhudson.model.DirectoryBrowserSupport.CSP="default-src 'self';"
+      - contains:
+         path: spec.template.spec.containers[0].env
+         content:
+           name: JENKINS_OPTS
+           value: >-
+             -Dtest="custom: 'true'"


### PR DESCRIPTION

# What this PR does / why we need it

Fix issues with quoted values like : `-Dhudson.model.DirectoryBrowserSupport.CSP="default-src 'self';"`


# Special notes for your reviewer

# Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
