### PR TITLE
feat: allow to store JCASC config as Secret

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -9,6 +9,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 * Commit: `https://github.com/helm/charts/commit/[commit]/stable/jenkins`
 
 The change log until v1.5.7 was auto-generated based on git commits. Those entries include a reference to the git commit to be able to get more details.
+
+## 2.19.0
+
+Allow to store JCASC Config in Secrets instead of ConfigMap since they may contains some sensitive data.
+
 ## 2.18.0
 
 Removed /tmp volume. Making /tmp a volume causes permission issues with jmap/jstack on certain Kubernetes clusters

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.18.0
+version: 2.19.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -22,6 +22,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `master.JCasC.enabled`            | Whether Jenkins Configuration as Code is enabled or not | `true`                  |
 | `master.JCasC.defaultConfig`      | Enables default Jenkins configuration via configuration as code plugin | `true`  |
+| `master.JCasC.useSecrets`         |  When true use Secret resources to store JCasC configurations else use ConfigMap | `false`  |
 | `master.JCasC.configScripts`      | List of Jenkins Config as Code scripts | `{}`                                    |
 | `master.JCasC.securityRealm`      | Jenkins Config as Code for Security Realm | `legacy`                             |
 | `master.JCasC.authorizationStrategy` | Jenkins Config as Code for Authorization Strategy | `loggedInUsersCanDoAnything` |

--- a/charts/jenkins/ci/jscasc-secrets-config.yaml
+++ b/charts/jenkins/ci/jscasc-secrets-config.yaml
@@ -1,0 +1,5 @@
+master:
+  JCasC:
+    useScrets: true
+    configScripts:
+      empty: ""

--- a/charts/jenkins/templates/jcasc-config.yaml
+++ b/charts/jenkins/templates/jcasc-config.yaml
@@ -4,7 +4,7 @@
 {{- if $val }}
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: {{ if $root.Values.master.JCasC.useSecrets }}"Secret"{{ else }}"ConfigMap"{{ end }}
 metadata:
   name: {{ template "jenkins.fullname" $root }}-jenkins-config-{{ $key }}
   namespace: {{ template "jenkins.namespace" $root }}
@@ -16,8 +16,12 @@ metadata:
     "app.kubernetes.io/component": "{{ $.Values.master.componentName }}"
     {{ template "jenkins.fullname" $root }}-jenkins-config: "true"
 data:
+  {{- if $root.Values.master.JCasC.useSecrets }}
+  {{ $key }}.yaml: {{ tpl $val $ | b64enc | quote }}
+  {{- else }}
   {{ $key }}.yaml: |-
-{{ tpl $val $| indent 4 }}
+    {{- tpl $val $ | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.master.JCasC.defaultConfig }}
@@ -36,6 +40,6 @@ metadata:
     {{ template "jenkins.fullname" $root }}-jenkins-config: "true"
 data:
   jcasc-default-config.yaml: |-
-    {{- include "jenkins.casc.defaults" . |nindent 4 }}
-{{- end}}
+    {{- include "jenkins.casc.defaults" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/jenkins/templates/jenkins-master-deployment.yaml
+++ b/charts/jenkins/templates/jenkins-master-deployment.yaml
@@ -325,6 +325,8 @@ spec:
               value: "{{ template "jenkins.fullname" . }}-jenkins-config"
             - name: FOLDER
               value: "{{ .Values.master.sidecars.configAutoReload.folder }}"
+            - name: RESOURCE
+              value: "both"
             - name: NAMESPACE
               value: "{{ .Values.master.sidecars.configAutoReload.searchNamespace | default .Release.Namespace }}"
             - name: REQ_URL

--- a/charts/jenkins/tests/jcasc-config-test.yaml
+++ b/charts/jenkins/tests/jcasc-config-test.yaml
@@ -597,3 +597,28 @@ tests:
     asserts:
       - hasDocuments:
          count: 0
+  - it: use secrets to store config
+    set:
+      master:
+        JCasC:
+          useSecrets: true
+          configScripts:
+            welcome-message: |
+              jenkins:
+                systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Secret
+      - documentIndex: 0
+        isNotEmpty:
+          path: data.welcome-message\.yaml
+      - documentIndex: 0
+        equal:
+          path: data.welcome-message\.yaml
+          value: "amVua2luczoKICBzeXN0ZW1NZXNzYWdlOiBXZWxjb21lIHRvIG91ciBDSVxDRCBzZXJ2ZXIuICBUaGlzIEplbmtpbnMgaXMgY29uZmlndXJlZCBhbmQgbWFuYWdlZCAnYXMgY29kZScuCg=="
+      - documentIndex: 1
+        isKind:
+          of: ConfigMap

--- a/charts/jenkins/tests/jenkins-master-deployment-test.yaml
+++ b/charts/jenkins/tests/jenkins-master-deployment-test.yaml
@@ -132,6 +132,8 @@ tests:
                     value: my-release-jenkins-jenkins-config
                   - name: FOLDER
                     value: /var/jenkins_home/casc_configs
+                  - name: RESOURCE
+                    value: both
                   - name: NAMESPACE
                     value: my-namespace
                   - name: REQ_URL

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -295,6 +295,8 @@ master:
   JCasC:
     enabled: true
     defaultConfig: true
+    # When true use Secret resources to store JCasC configurations
+    useSecrets: false
     configScripts: {}
     #  welcome-message: |
     #    jenkins:


### PR DESCRIPTION
# What this PR does / why we need it

Since JCASC may contains some sensitive data, let to users the availability to define how to store theses configs.

# Which issue this PR fixes

N/A

# Special notes for your reviewer

It could be nice to be able to choose for each `configScripts` but it's a Breaking change.
Maybe this could be relevant to take care about this in your next major release, or not. I dunno

# Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
