### PR TITLE
Update configured plugins

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,12 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 2.19.0
+
+* Use lts version 2.249.3
+* Update kubernetes, workflow-aggregator, git and configuration-as-code plugins.
+* Fail apply_config.sh script if an error occurs.
+
 ## 2.18.2
 
 Fix: `master.javaOpts` issue with quoted values

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,14 +1,12 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.18.2
-appVersion: lts
-description: Open source continuous integration server. It supports multiple SCM tools
-  including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
-  projects as well as arbitrary scripts.
+version: 2.19.0
+appVersion: 2.249.3
+description: The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
 - https://github.com/jenkinsci/jenkins
-- https://github.com/jenkinsci/docker-jnlp-slave
+- https://github.com/jenkinsci/docker-inbound-agent
 - https://github.com/maorfr/kube-tasks
 - https://github.com/jenkinsci/configuration-as-code-plugin
 maintainers:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -3,7 +3,7 @@ name: jenkins
 home: https://jenkins.io/
 version: 2.19.0
 appVersion: 2.249.3
-description: The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
+description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
 - https://github.com/jenkinsci/jenkins
 - https://github.com/jenkinsci/docker-inbound-agent

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -81,7 +81,7 @@ Here is an example how that can be done:
 
 ```Dockerfile
 FROM jenkins/jenkins:lts
-RUN jenkins-plugin-cli --plugins kubernetes workflow-job workflow-aggregator credentials-binding git configuration-as-code
+RUN jenkins-plugin-cli --plugins kubernetes workflow-aggregator git configuration-as-code
 ```
 
 NOTE: If you want a reproducible build then you should specify a non floating tag for the image `jenkins/jenkins:2.249.3` and specify plugin versions.

--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -158,6 +158,7 @@ data:
     </jenkins.CLI>
 {{- end }}
   apply_config.sh: |-
+    set -e
 {{- if .Values.master.initializeOnce }}
     if [ -f {{ .Values.master.jenkinsHome }}/initialization-completed ]; then
       echo "master was previously initialized, refusing to re-initialize"
@@ -219,7 +220,7 @@ data:
     # Copy plugins to shared volume
     yes n | cp -i {{ .Values.master.jenkinsRef }}/plugins/* /var/jenkins_plugins/;
 {{- end }}
-{{- if .Values.master.scriptApproval }}
+{{- if and .Values.master.enableXmlConfig .Values.master.scriptApproval }}
     echo "configure script approval"
   {{- if .Values.master.overwriteConfig }}
     cp /var/jenkins_config/scriptapproval.xml {{ .Values.master.jenkinsHome }}/scriptApproval.xml;

--- a/charts/jenkins/tests/config-test.yaml
+++ b/charts/jenkins/tests/config-test.yaml
@@ -18,6 +18,7 @@ tests:
       - equal:
           path: data.apply_config\.sh
           value: |-
+            set -e
             echo "applying Jenkins configuration"
             echo "disable Setup Wizard"
             # Prevent Setup Wizard when JCasC is enabled
@@ -40,12 +41,10 @@ tests:
       - equal:
           path: data.plugins\.txt
           value: |-
-            kubernetes:1.25.7
-            workflow-job:2.39
+            kubernetes:1.27.6
             workflow-aggregator:2.6
-            credentials-binding:1.23
-            git:4.2.2
-            configuration-as-code:1.43
+            git:4.4.5
+            configuration-as-code:1.46
   - it: no plugins
     set:
       master.installPlugins: []
@@ -53,6 +52,7 @@ tests:
       - equal:
           path: data.apply_config\.sh
           value: |-
+            set -e
             echo "applying Jenkins configuration"
             echo "disable Setup Wizard"
             # Prevent Setup Wizard when JCasC is enabled
@@ -71,6 +71,7 @@ tests:
       - equal:
           path: data.apply_config\.sh
           value: |-
+            set -e
             echo "applying Jenkins configuration"
             echo "disable Setup Wizard"
             # Prevent Setup Wizard when JCasC is enabled
@@ -93,10 +94,8 @@ tests:
       - equal:
           path: data.plugins\.txt
           value: |-
-            kubernetes:1.25.7
-            workflow-job:2.39
+            kubernetes:1.27.6
             workflow-aggregator:2.6
-            credentials-binding:1.23
-            git:4.2.2
-            configuration-as-code:1.43
+            git:4.4.5
+            configuration-as-code:1.46
             kubernetes-credentials-provider

--- a/charts/jenkins/tests/jcasc-config-test.yaml
+++ b/charts/jenkins/tests/jcasc-config-test.yaml
@@ -58,7 +58,7 @@ tests:
                           - envVar:
                               key: "JENKINS_URL"
                               value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
-                        image: "jenkins/inbound-agent:4.3-4"
+                        image: "jenkins/inbound-agent:4.6-1"
                         privileged: "false"
                         resourceLimitCpu: 512m
                         resourceLimitMemory: 512Mi
@@ -171,7 +171,7 @@ tests:
                           - envVar:
                               key: "JENKINS_URL"
                               value: "http://RELEASE-NAME-jenkins.controller-namespace.svc.cluster.local:8080/"
-                        image: "jenkins/inbound-agent:4.3-4"
+                        image: "jenkins/inbound-agent:4.6-1"
                         privileged: "false"
                         resourceLimitCpu: 512m
                         resourceLimitMemory: 512Mi

--- a/charts/jenkins/tests/jenkins-master-deployment-test.yaml
+++ b/charts/jenkins/tests/jenkins-master-deployment-test.yaml
@@ -45,7 +45,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: dca52edd4e45bf3ea5de7a168d17c5bd2b7010dd376344760cee9d683b0c3d66
+                  checksum/config: b658db5fded177557794338be19575f0d99995b5156fddbaae6cd78b7dfcedb2
                 labels:
                   app.kubernetes.io/component: jenkins-master
                   app.kubernetes.io/instance: my-release
@@ -140,7 +140,7 @@ tests:
                     value: POST
                   - name: REQ_RETRY_CONNECT
                     value: "10"
-                  image: kiwigrid/k8s-sidecar:0.1.193
+                  image: kiwigrid/k8s-sidecar:0.1.275
                   imagePullPolicy: IfNotPresent
                   name: jenkins-sc-config
                   resources: {}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -193,12 +193,10 @@ master:
 
   # List of plugins to be install during Jenkins master start
   installPlugins:
-    - kubernetes:1.25.7
-    - workflow-job:2.39
+    - kubernetes:1.27.6
     - workflow-aggregator:2.6
-    - credentials-binding:1.23
-    - git:4.2.2
-    - configuration-as-code:1.43
+    - git:4.4.5
+    - configuration-as-code:1.46
 
   # List of plugins to install in addition to those listed in master.installPlugins
   additionalPlugins: []
@@ -272,7 +270,7 @@ master:
       # jcasc changes will cause a reboot and will only be applied at the subsequent start-up.  Auto-reload uses the
       # http://<jenkins_url>/reload-configuration-as-code endpoint to reapply config when changes to the configScripts are detected.
       enabled: true
-      image: kiwigrid/k8s-sidecar:0.1.193
+      image: kiwigrid/k8s-sidecar:0.1.275
       imagePullPolicy: IfNotPresent
       resources: {}
         #   limits:
@@ -506,7 +504,7 @@ master:
 agent:
   enabled: true
   image: "jenkins/inbound-agent"
-  tag: "4.3-4"
+  tag: "4.6-1"
   workingDir: "/home/jenkins"
   customJenkinsLabels: []
   # name of the secret to be used for image pulling


### PR DESCRIPTION
# What this PR does / why we need it

- Use lts version 2.249.3
- Update kubernetes, workflow-aggregator, git and configuration-as-code plugins.
- remove plugins which are provided as dependency
- Fail apply_config.sh script if an error occurs.

# Which issue this PR fixes

- fixes #140

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
