### PR TITLE
Add support to override default Kubernetes ServerUrl

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 2.19.1
+
+* Added support to override default Kubernetes ServerUrl
+
 ## 2.19.0
 
 * Use lts version 2.249.3

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.19.0
+version: 2.19.1
 appVersion: 2.249.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -126,7 +126,7 @@ jenkins:
       maxRequestsPerHostStr: "32"
       name: "kubernetes"
       namespace: "{{ template "jenkins.master.slaveKubernetesNamespace" . }}"
-      serverUrl: "https://kubernetes.default"
+      serverUrl: "{{- default "https://kubernetes.default" .Values.master.slaveKubernetesServerUrl }}"
       {{- if .Values.agent.enabled }}
       podLabels:
       - key: "jenkins/{{ .Release.Name }}-{{ .Values.agent.componentName }}"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -163,6 +163,7 @@ master:
   slaveDefaultsProviderTemplate: ""
   slaveConnectTimeout: 5
   slaveReadTimeout: 15
+  slaveKubernetesServerUrl: 
   slaveKubernetesNamespace:
   slaveJenkinsUrl:
   slaveJenkinsTunnel:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -163,7 +163,7 @@ master:
   slaveDefaultsProviderTemplate: ""
   slaveConnectTimeout: 5
   slaveReadTimeout: 15
-  slaveKubernetesServerUrl: 
+  slaveKubernetesServerUrl:
   slaveKubernetesNamespace:
   slaveJenkinsUrl:
   slaveJenkinsTunnel:


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

Previously, there was no value exposed to set the Kubernetes serverUrl and instead it was Hardcoded in the `_helpers.tpl` file. This PR will add the support the override the default Kubernetes serverUrl.

There was some issue in the kubernetes plugin which requires the the Kubernetes plugin to be in the format `<protocol>://<kubernetes_url>:<port>`. If we want to change the url in this format then there was no ability to do this change. Please refer [this post](https://support.cloudbees.com/hc/en-us/articles/360036006032-Kubernetes-Plugin-KubernetesClientException-provisioning-error) for more info.

# Which issue this PR fixes

- N/A

# Special notes for your reviewer

- N/A

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
