### PR TITLE
Updated UI tests to use official BATS image

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -18,6 +18,13 @@ Those entries include a reference to the git commit to be able to get more detai
 * This chart now requires Helm 3
 * componentName for the controller is now `jenkins-controller`
 * componentName for the agent is now `jenkins-agent`
+* container names are now
+  * `init` for the init container which downloads Jenkins plugins
+  * `jenkins` for the Jenkins controller
+  * `config-reload` for the sidecar container which automatically reloads JCasC
+* Updated UI tests to use official `bats/bats` image instead of `dduportal/bats`
+
+For migration instructions from previous versions and additional information check README.md.
 
 ## 2.19.0
 

--- a/charts/jenkins/templates/tests/jenkins-test.yaml
+++ b/charts/jenkins/templates/tests/jenkins-test.yaml
@@ -17,21 +17,22 @@ spec:
   {{- end }}
   initContainers:
     - name: "test-framework"
-      image: "dduportal/bats:0.4.0"
+      image: "bats/bats:1.2.1"
       command:
-      - "bash"
-      - "-c"
-      - |
-        set -ex
-        # copy bats to tools dir
-        cp -R /usr/local/libexec/ /tools/bats/
+        - "bash"
+        - "-c"
+      args:
+        - |
+          # copy bats to tools dir
+          set -ex
+          cp -R /opt/bats /tools/bats/
       volumeMounts:
       - mountPath: /tools
         name: tools
   containers:
     - name: {{ .Release.Name }}-ui-test
       image: {{ .Values.controller.image }}:{{ .Values.controller.tag }}
-      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      command: ["/tools/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:
       - mountPath: /tests
         name: tests


### PR DESCRIPTION
# What this PR does / why we need it

The referenced image `dduportal/bats:0.4.0` has been updated 4 years ago and is still using [docker image manifest v1](https://github.com/moby/moby/blob/master/image/spec/v1.md) which has [been deprecated](https://docs.docker.com/registry/spec/deprecated-schema-v1/).

Current versions [1.1.0](https://github.com/dduportal-dockerfiles/bats/releases/tag/1.1.0) do not have any shell installed and thus can not be used to copy `bats` into the test image.

This is why I have updated the image from `dduportal/bats:0.4.0` to the official `bats/bats:1.2.1` image from [https://hub.docker.com/r/bats/bats](https://hub.docker.com/r/bats/bats).

More information on the v1 deprecation which affected us after implementing our own Docker image cache:

* https://github.com/docker/distribution/releases/tag/v2.7.0
* https://github.com/docker/distribution/issues/2827

# Test Output

```
» helm test jenkins
NAME: jenkins
LAST DEPLOYED: Tue Nov 24 13:38:48 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE:     jenkins-ui-test-d7lgz
Last Started:   Tue Nov 24 14:08:55 2020
Last Completed: Tue Nov 24 14:08:58 2020
Phase:          Succeeded
NOTES:
[...]
NOTE: Consider using a custom image with pre-installed plugins
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
» kubectl get pods
NAME                       READY   STATUS      RESTARTS   AGE   IP            NODE                               NOMINATED NODE   READINESS GATES
jenkins-84555f5675-fm45l   2/2     Running     0          30m   10.244.0.8    jenkins-helm-chart-control-plane   <none>           <none>
jenkins-ui-test-d7lgz      0/1     Completed   0          7s    10.244.0.14   jenkins-helm-chart-control-plane   <none>           <none>
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
» kubectl logs jenkins-ui-test-d7lgz 
1..1
ok 1 Testing Jenkins UI is accessible
```

# Special notes for your reviewer

Since I can not know which release this change gets pulled into, I did not update the Changelog.md or the Chart.yaml. Hope this is OK.

# Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x]  CHANGELOG.md was updated