### PR TITLE
Configure admin user via configuration as code

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -23,6 +23,8 @@ Those entries include a reference to the git commit to be able to get more detai
   * `jenkins` for the Jenkins controller
   * `config-reload` for the sidecar container which automatically reloads JCasC
 
+For migration instructions from previous versions and additional information check README.md.
+
 ## 2.19.0
 
 * Use lts version 2.249.3

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -501,6 +501,7 @@ Chart release versions follow [semver](../../CONTRIBUTING.md#versioning), where 
   The following values from `values.yaml` have been renamed:
 
   * `master` => `controller`
+  * `master.useSecurity` => `controller.adminSecret`
   * `master.slaveListenerPort` => `controller.agentListenerPort`
   * `master.slaveHostPort` => `controller.agentListenerHostPort`
   * `master.slaveKubernetesNamespace` => `agent.namespace`

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -57,12 +57,35 @@ To see all configurable options with detailed comments, visit the chart's [value
 ```console
 # Helm 3
 $ helm show values jenkins/jenkins
-
-# Helm 2
-$ helm inspect values jenkins/jenkins
 ```
 
 For a summary of all configurable options, see [VALUES_SUMMARY.md](./VALUES_SUMMARY.md)
+
+### Configure Security Realm and Authorization Strategy
+
+This chart configured a `securityRealm` and `authorizationStrategy` as shown below:
+
+```yaml
+controller:
+  JCasC:
+    securityRealm: |-
+      local:
+        allowsSignup: false
+        enableCaptcha: false
+        users:
+        - id: "${chart-admin-username}"
+          name: "Jenkins Admin"
+          password: "${chart-admin-password}"
+    authorizationStrategy: |-
+      loggedInUsersCanDoAnything:
+        allowAnonymousRead: false
+```
+
+With the configuration above there is only a single user.
+This is ok for getting started quickly, but it needs to be adjusted for any serious environment.
+
+So you should adjust this to suite your needs.
+That could be using LDAP / OIDC / .. as authorization strategy and use globalMatrix as authorization strategy to configure more fine grained permissions.
 
 ### Consider using a custom image
 
@@ -467,6 +490,8 @@ Chart release versions follow [semver](../../CONTRIBUTING.md#versioning), where 
 
 ### To 3.0.0
 
+* Check `securityRealm` and `authorizationStrategy` and adjust it.
+  Otherwise your configured users and permissions will be overridden.
 * You need to use helm version 3 as the `Chart.yaml` uses `apiVersion: v2`.
 * All XML configuration options have been removed.
   In case those are still in use you need to migrate to configuration as code.

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -35,13 +35,13 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.initScripts`              | List of Jenkins init scripts         | `[]`                                      |
+| `controller.initScripts`          | List of Jenkins init scripts         | `[]`                                      |
 
 #### Jenkins Global Security
 
-| Parameter                         | Description                          | Default                                   |
-| --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.useSecurity`              | Use basic security                   | `true`                                    |
+| Parameter                         | Description                              | Default                                   |
+| --------------------------------- | ---------------------------------------- | ----------------------------------------- |
+| `controller.adminSecret`              | Create secret for admin user         | `true`                                    |
 | `controller.disableRememberMe`        | Disable use of remember me           | `false`                                   |
 | `controller.enableRawHtmlMarkupFormatter` | Enable HTML parsing using        | false                                     |
 | `controller.markupFormatter`          | Yaml of the markup formatter to use  | `plainText`                               |
@@ -53,49 +53,49 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.numExecutors`             | Set Number of executors              | 0                                         |
-| `controller.executorMode`             | Set executor mode of the Jenkins node. Possible values are: NORMAL or EXCLUSIVE | NORMAL |
-| `controller.customJenkinsLabels`      | Append Jenkins labels to the controller  | `{}`                                      |
-| `controller.jenkinsHome`              | Custom Jenkins home path             | `/var/jenkins_home`                       |
-| `controller.jenkinsRef`               | Custom Jenkins reference path        | `/usr/share/jenkins/ref`                  |
-| `controller.jenkinsAdminEmail`        | Email address for the administrator of the Jenkins instance | Not set            |
-| `controller.jenkinsUrlProtocol`       | Set protocol for Jenkins URL | Set to `https` if `controller.ingress.tls`, `http` otherwise |
-| `controller.jenkinsUriPrefix`         | Root Uri Jenkins will be served on   | Not set                                   |
+| `controller.numExecutors`         | Set Number of executors              | 0                                         |
+| `controller.executorMode`         | Set executor mode of the Jenkins node. Possible values are: NORMAL or EXCLUSIVE | NORMAL |
+| `controller.customJenkinsLabels`  | Append Jenkins labels to the controller  | `{}`                                      |
+| `controller.jenkinsHome`          | Custom Jenkins home path             | `/var/jenkins_home`                       |
+| `controller.jenkinsRef`           | Custom Jenkins reference path        | `/usr/share/jenkins/ref`                  |
+| `controller.jenkinsAdminEmail`    | Email address for the administrator of the Jenkins instance | Not set            |
+| `controller.jenkinsUrlProtocol`   | Set protocol for Jenkins URL | Set to `https` if `controller.ingress.tls`, `http` otherwise |
+| `controller.jenkinsUriPrefix`     | Root Uri Jenkins will be served on   | Not set                                   |
 
 #### Jenkins In-Process Script Approval
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.scriptApproval`           | List of groovy functions to approve  | `[]`                                      |
+| `controller.scriptApproval`       | List of groovy functions to approve  | `[]`                                      |
 
 #### Jenkins Plugins
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.installPlugins`           | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.18.2 workflow-aggregator:2.6 credentials-binding:1.19 git:3.11.0 workflow-job:2.33` |
-| `controller.additionalPlugins`        | List of Jenkins plugins to install in addition to those listed in controller.installPlugins | `[]` |
-| `controller.initializeOnce`           | Initialize only on first install. Ensures plugins do not get updated inadvertently. Requires `persistence.enabled` to be set to `true`. | `false` |
-| `controller.overwritePlugins`         | Overwrite installed plugins on start.| `false`                                   |
+| `controller.installPlugins`       | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.18.2 workflow-aggregator:2.6 credentials-binding:1.19 git:3.11.0 workflow-job:2.33` |
+| `controller.additionalPlugins`    | List of Jenkins plugins to install in addition to those listed in controller.installPlugins | `[]` |
+| `controller.initializeOnce`       | Initialize only on first install. Ensures plugins do not get updated inadvertently. Requires `persistence.enabled` to be set to `true`. | `false` |
+| `controller.overwritePlugins`     | Overwrite installed plugins on start.| `false`                                   |
 | `controller.overwritePluginsFromImage` | Keep plugins that are already installed in the controller image.| `true`            |
 
 #### Jenkins Agent Listener
 
-| Parameter                         | Description                          | Default                                   |
-| --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.agentListenerPort`        | Listening port for agents            | `50000`                                   |
-| `controller.agentListenerHostPort`            | Host port to listen for agents            | Not set                              |
-| `controller.agentListenerServiceType` | Defines how to expose the agentListener service | `ClusterIP`                    |
-| `controller.agentListenerServiceAnnotations` | Annotations for the agentListener service | `{}`                         |
-| `controller.agentListenerLoadBalancerIP` | Static IP for the agentListener LoadBalancer | Not set                       |
+| Parameter                                    | Description                                     | Default      |
+| -------------------------------------------- | ----------------------------------------------- | ------------ |
+| `controller.agentListenerPort`               | Listening port for agents                       | `50000`      |
+| `controller.agentListenerHostPort`           | Host port to listen for agents                  | Not set      |
+| `controller.agentListenerServiceType`        | Defines how to expose the agentListener service | `ClusterIP`  |
+| `controller.agentListenerServiceAnnotations` | Annotations for the agentListener service       | `{}`         |
+| `controller.agentListenerLoadBalancerIP`     | Static IP for the agentListener LoadBalancer    | Not set      |
 
 #### Kubernetes StatefulSet & Service
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.image`                    | Controller image name                    | `jenkins/jenkins`                         |
-| `controller.tag`                      | Controller image tag                     | `lts`                                     |
-| `controller.imagePullPolicy`          | Controller image pull policy             | `Always`                                  |
-| `controller.imagePullSecretName`      | Controller image pull secret             | Not set                                   |
+| `controller.image`                    | Controller image name                     | `jenkins/jenkins`                         |
+| `controller.tag`                      | Controller image tag                      | `lts`                                     |
+| `controller.imagePullPolicy`          | Controller image pull policy              | `Always`                                  |
+| `controller.imagePullSecretName`      | Controller image pull secret              | Not set                                   |
 | `controller.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 4096Mi}}`|
 | `controller.initContainerEnv`         | Environment variables for Init Container                                 | Not set |
 | `controller.containerEnv`             | Environment variables for Jenkins Container                              | Not set |
@@ -208,8 +208,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.adminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin` |
-| `controller.adminPassword`            | Admin password (and user) created as a secret if useSecurity is true | Random value |
+| `controller.adminUser`                | Admin username (and password) created as a secret if adminSecret is true | `admin` |
+| `controller.adminPassword`            | Admin password (and user) created as a secret if adminSecret is true | Random value |
 
 #### Kubernetes NetworkPolicy
 

--- a/charts/jenkins/templates/NOTES.txt
+++ b/charts/jenkins/templates/NOTES.txt
@@ -1,6 +1,5 @@
 1. Get your '{{ .Values.controller.adminUser }}' user password by running:
-  printf $(kubectl get secret --namespace {{ template "jenkins.namespace" . }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo
-
+  kubectl exec --namespace {{ template "jenkins.namespace" . }} -it svc/{{ template "jenkins.fullname" . }} -c jenkins -- /bin/cat /run/secrets/chart-admin-password && echo
 {{- if .Values.controller.ingress.hostName }}
 
 2. Visit http://{{ .Values.controller.ingress.hostName }}
@@ -22,15 +21,14 @@
 {{- end }}
 
 {{- else if contains "ClusterIP"  .Values.controller.serviceType }}
-  export POD_NAME=$(kubectl get pods --namespace {{ template "jenkins.namespace" . }} -l "app.kubernetes.io/component={{ .Values.controller.componentName }}" -l "app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:{{ .Values.controller.servicePort }}
-  kubectl --namespace {{ template "jenkins.namespace" . }} port-forward $POD_NAME {{ .Values.controller.servicePort }}:{{ .Values.controller.servicePort }}
-
+  kubectl --namespace {{ template "jenkins.namespace" . }} port-forward svc/{{template "jenkins.fullname" . }} {{ .Values.controller.servicePort }}:{{ .Values.controller.servicePort }}
 {{- end }}
 {{- end }}
 
 3. Login with the password from step 1 and the username: {{ .Values.controller.adminUser }}
-4. Use Jenkins Configuration as Code by specifying configScripts in your values.yaml file, see documentation: http://{{ .Values.controller.ingress.hostName }}/configuration-as-code and examples: https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos
+4. Configure security realm and authorization strategy
+5. Use Jenkins Configuration as Code by specifying configScripts in your values.yaml file, see documentation: http://{{ .Values.controller.ingress.hostName }}/configuration-as-code and examples: https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos
 
 For more information on running Jenkins on Kubernetes, visit:
 https://cloud.google.com/solutions/jenkins-on-container-engine

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -49,6 +49,29 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Returns the admin password
+https://github.com/helm/charts/issues/5167#issuecomment-619137759
+*/}}
+{{- define "jenkins.password" -}}
+  {{ if .Values.controller.adminPassword -}}
+    {{- .Values.controller.adminPassword | b64enc | quote }}
+  {{- else -}}
+    {{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "jenkins.fullname" .)).data -}}
+    {{- if $secret -}}
+      {{/*
+        Reusing current password since secret exists
+      */}}
+      {{- index $secret ( .Values.controller.admin.passwordKey | default "jenkins-admin-password" ) -}}
+    {{- else -}}
+      {{/*
+          Generate new password
+      */}}
+      {{- randAlphaNum 22 | b64enc | quote }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Returns the Jenkins URL
 */}}
 {{- define "jenkins.url" -}}

--- a/charts/jenkins/templates/deprecation.yaml
+++ b/charts/jenkins/templates/deprecation.yaml
@@ -19,6 +19,10 @@
       {{ fail "`controller.slaveDefaultsProviderTemplate` does no longer exist. It has been renamed to `agent.defaultsProviderTemplate`" }}
    {{- end }}
 
+   {{- if .Values.controller.useSecurity }}
+      {{ fail "`controller.useSecurity` does no longer exist. It has been renamed to `controller.adminSecret`" }}
+   {{- end }}
+
    {{- if .Values.controller.slaveJenkinsUrl }}
       {{ fail "`controller.slaveJenkinsUrl` does no longer exist. It has been renamed to `agent.jenkinsUrl`" }}
    {{- end }}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -94,8 +94,8 @@ spec:
           image: "{{ .Values.controller.image }}:{{ .Values.controller.tag }}"
           imagePullPolicy: "{{ .Values.controller.imagePullPolicy }}"
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
-          env:
             {{- if .Values.controller.initContainerEnv }}
+          env:
 {{ toYaml .Values.controller.initContainerEnv | indent 12 }}
             {{- end }}
           resources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -95,18 +95,6 @@ spec:
           imagePullPolicy: "{{ .Values.controller.imagePullPolicy }}"
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
           env:
-          {{- if .Values.controller.useSecurity }}
-            - name: ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.controller.admin.existingSecret | default (include "jenkins.fullname" .) }}
-                  key: {{ .Values.controller.admin.passwordKey | default "jenkins-admin-password" }}
-            - name: ADMIN_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.controller.admin.existingSecret | default (include "jenkins.fullname" .) }}
-                  key: {{ .Values.controller.admin.userKey | default "jenkins-admin-user" }}
-            {{- end }}
             {{- if .Values.controller.initContainerEnv }}
 {{ toYaml .Values.controller.initContainerEnv | indent 12 }}
             {{- end }}
@@ -134,13 +122,9 @@ spec:
           imagePullPolicy: "{{ .Values.controller.imagePullPolicy }}"
           {{- if .Values.controller.httpsKeyStore.enable }}
           {{- $httpsJKSFilePath :=  printf "%s/%s" .Values.controller.httpsKeyStore.path .Values.controller.httpsKeyStore.fileName -}}
-              {{- if .Values.controller.useSecurity }}
-          args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin", "--httpPort={{.Values.controller.httpsKeyStore.httpPort}}", "--httpsPort={{.Values.controller.targetPort}}", '--httpsKeyStore={{ $httpsJKSFilePath }}', "--httpsKeyStorePassword=$(JENKINS_HTTPS_KEYSTORE_PASSWORD)" ]
-              {{- else }}
           args: [ "--httpPort={{.Values.controller.httpsKeyStore.httpPort}}", "--httpsPort={{.Values.controller.targetPort}}", '--httpsKeyStore={{ $httpsJKSFilePath | quote }}', "--httpsKeyStorePassword=$(JENKINS_HTTPS_KEYSTORE_PASSWORD)" ]
-              {{- end }}
-          {{- else if .Values.controller.useSecurity }}
-          args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin", "--httpPort={{.Values.controller.targetPort}}"]
+          {{- else }}
+          args: [ "--httpPort={{.Values.controller.targetPort}}"]
           {{- end }}
           {{- if .Values.controller.lifecycle }}
           lifecycle:
@@ -159,18 +143,6 @@ spec:
                 {{ if .Values.controller.jenkinsUriPrefix }}--prefix={{ .Values.controller.jenkinsUriPrefix }} {{ end }}{{ default "" .Values.controller.jenkinsOpts}}
             - name: JENKINS_SLAVE_AGENT_PORT
               value: "{{ .Values.controller.agentListenerPort }}"
-            {{- if .Values.controller.useSecurity }}
-            - name: ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.controller.admin.existingSecret | default (include "jenkins.fullname" .) }}
-                  key: {{ .Values.controller.admin.password | default "jenkins-admin-password" }}
-            - name: ADMIN_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.controller.admin.existingSecret | default (include "jenkins.fullname" .) }}
-                  key: {{ .Values.controller.admin.user | default "jenkins-admin-user" }}
-            {{- end }}
             {{- if .Values.controller.httpsKeyStore.enable }}
             - name: JENKINS_HTTPS_KEYSTORE_PASSWORD
               valueFrom:
@@ -234,6 +206,16 @@ spec:
             {{- if .Values.controller.sidecars.configAutoReload.enabled }}
             - name: sc-config-volume
               mountPath: {{ .Values.controller.sidecars.configAutoReload.folder | default (printf "%s/casc_configs" (.Values.controller.jenkinsRef)) }}
+            {{- end }}
+            {{- if .Values.controller.useSecurity }}
+            - name: admin-secret
+              mountPath: /run/secrets/chart-admin-username
+              subPath: {{ .Values.controller.admin.userKey | default "jenkins-admin-user" }}
+              readOnly: true
+            - name: admin-secret
+              mountPath: /run/secrets/chart-admin-password
+              subPath: {{ .Values.controller.admin.passwordKey | default "jenkins-admin-password" }}
+              readOnly: true
             {{- end }}
 
 {{- if .Values.controller.sidecars.configAutoReload.enabled }}
@@ -309,6 +291,11 @@ spec:
           items:
           - key: jenkins-jks-file
             path: {{ .Values.controller.httpsKeyStore.fileName }}
+      {{- end }}
+      {{- if .Values.controller.useSecurity }}
+      - name: admin-secret
+        secret:
+          secretName: {{ .Values.controller.admin.existingSecret | default (include "jenkins.fullname" .) }}
       {{- end }}
 
 {{- if .Values.controller.imagePullSecretName }}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -207,7 +207,7 @@ spec:
             - name: sc-config-volume
               mountPath: {{ .Values.controller.sidecars.configAutoReload.folder | default (printf "%s/casc_configs" (.Values.controller.jenkinsRef)) }}
             {{- end }}
-            {{- if .Values.controller.useSecurity }}
+            {{- if .Values.controller.adminSecret }}
             - name: admin-secret
               mountPath: /run/secrets/chart-admin-username
               subPath: {{ .Values.controller.admin.userKey | default "jenkins-admin-user" }}
@@ -292,7 +292,7 @@ spec:
           - key: jenkins-jks-file
             path: {{ .Values.controller.httpsKeyStore.fileName }}
       {{- end }}
-      {{- if .Values.controller.useSecurity }}
+      {{- if .Values.controller.adminSecret }}
       - name: admin-secret
         secret:
           secretName: {{ .Values.controller.admin.existingSecret | default (include "jenkins.fullname" .) }}

--- a/charts/jenkins/templates/secret.yaml
+++ b/charts/jenkins/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.controller.admin.existingSecret) (.Values.controller.useSecurity) -}}
+{{- if and (not .Values.controller.admin.existingSecret) (.Values.controller.adminSecret) -}}
 
 apiVersion: v1
 kind: Secret

--- a/charts/jenkins/templates/secret.yaml
+++ b/charts/jenkins/templates/secret.yaml
@@ -13,10 +13,6 @@ metadata:
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
 type: Opaque
 data:
-  {{ if .Values.controller.adminPassword -}}
-  jenkins-admin-password: {{ .Values.controller.adminPassword | b64enc | quote }}
-  {{ else -}}
-  jenkins-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end -}}
+  jenkins-admin-password: {{ template "jenkins.password" . }}
   jenkins-admin-user: {{ .Values.controller.adminUser | b64enc | quote }}
 {{- end }}

--- a/charts/jenkins/tests/jcasc-config-test.yaml
+++ b/charts/jenkins/tests/jcasc-config-test.yaml
@@ -23,7 +23,13 @@ tests:
                 loggedInUsersCanDoAnything:
                   allowAnonymousRead: false
               securityRealm:
-                legacy
+                local:
+                  allowsSignup: false
+                  enableCaptcha: false
+                  users:
+                  - id: "${chart-admin-username}"
+                    name: "Jenkins Admin"
+                    password: "${chart-admin-password}"
               disableRememberMe: false
               remotingSecurity:
                 enabled: true
@@ -134,7 +140,13 @@ tests:
                 loggedInUsersCanDoAnything:
                   allowAnonymousRead: false
               securityRealm:
-                legacy
+                local:
+                  allowsSignup: false
+                  enableCaptcha: false
+                  users:
+                  - id: "${chart-admin-username}"
+                    name: "Jenkins Admin"
+                    password: "${chart-admin-password}"
               disableRememberMe: false
               remotingSecurity:
                 enabled: true
@@ -557,7 +569,13 @@ tests:
                 loggedInUsersCanDoAnything:
                   allowAnonymousRead: false
               securityRealm:
-                legacy
+                local:
+                  allowsSignup: false
+                  enableCaptcha: false
+                  users:
+                  - id: "${chart-admin-username}"
+                    name: "Jenkins Admin"
+                    password: "${chart-admin-password}"
               disableRememberMe: false
               remotingSecurity:
                 enabled: true

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -53,8 +53,6 @@ tests:
               spec:
                 containers:
                 - args:
-                  - --argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)
-                  - --argumentsRealm.roles.$(ADMIN_USER)=admin
                   - --httpPort=8080
                   env:
                   - name: POD_NAME
@@ -67,16 +65,6 @@ tests:
                     value: ""
                   - name: JENKINS_SLAVE_AGENT_PORT
                     value: "50000"
-                  - name: ADMIN_PASSWORD
-                    valueFrom:
-                      secretKeyRef:
-                        key: jenkins-admin-password
-                        name: my-release-jenkins
-                  - name: ADMIN_USER
-                    valueFrom:
-                      secretKeyRef:
-                        key: jenkins-admin-user
-                        name: my-release-jenkins
                   - name: CASC_JENKINS_CONFIG
                     value: /var/jenkins_home/casc_configs
                   image: jenkins/jenkins:lts
@@ -127,6 +115,14 @@ tests:
                     readOnly: false
                   - mountPath: /var/jenkins_home/casc_configs
                     name: sc-config-volume
+                  - mountPath: /run/secrets/chart-admin-username
+                    name: admin-secret
+                    readOnly: true
+                    subPath: jenkins-admin-user
+                  - mountPath: /run/secrets/chart-admin-password
+                    name: admin-secret
+                    readOnly: true
+                    subPath: jenkins-admin-password
                 - env:
                   - name: POD_NAME
                     valueFrom:
@@ -157,17 +153,6 @@ tests:
                 - command:
                   - sh
                   - /var/jenkins_config/apply_config.sh
-                  env:
-                  - name: ADMIN_PASSWORD
-                    valueFrom:
-                      secretKeyRef:
-                        key: jenkins-admin-password
-                        name: my-release-jenkins
-                  - name: ADMIN_USER
-                    valueFrom:
-                      secretKeyRef:
-                        key: jenkins-admin-user
-                        name: my-release-jenkins
                   image: jenkins/jenkins:lts
                   imagePullPolicy: Always
                   name: init
@@ -204,6 +189,9 @@ tests:
                     claimName: my-release-jenkins
                 - emptyDir: {}
                   name: sc-config-volume
+                - name: admin-secret
+                  secret:
+                    secretName: my-release-jenkins
   - it: test different values
     capabilities:
       apiVersions:

--- a/charts/jenkins/tests/secret-test.yaml
+++ b/charts/jenkins/tests/secret-test.yaml
@@ -52,7 +52,7 @@ tests:
   - it: disable
     set:
       controller:
-        useSecurity: false
+        adminSecret: false
     asserts:
     - hasDocuments:
         count: 0

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -225,7 +225,13 @@ controller:
     # Ignored if securityRealm is defined in controller.JCasC.configScripts and
     # ignored if controller.enableXmlConfig=true as controller.securityRealm takes precedence
     securityRealm: |-
-      legacy
+      local:
+        allowsSignup: false
+        enableCaptcha: false
+        users:
+        - id: "${chart-admin-username}"
+          name: "Jenkins Admin"
+          password: "${chart-admin-password}"
     # Ignored if authorizationStrategy is defined in controller.JCasC.configScripts
     authorizationStrategy: |-
       loggedInUsersCanDoAnything:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -36,8 +36,9 @@ controller:
   # This is ignored if enableRawHtmlMarkupFormatter is true
   markupFormatter: plainText
   customJenkinsLabels: []
-  # configAutoReload requires UseSecurity is set to true:
-  useSecurity: true
+  # The default configuration uses this secret to configure an admin user
+  # If you don't need that user or use a different security realm then you can disable it
+  adminSecret: true
 
   hostNetworking: false
   # When enabling LDAP or another non-Jenkins identity source, the built-in admin account will no longer exist.


### PR DESCRIPTION
# What this PR does / why we need it

    configure admin user via JCasC
    
    - admin username and password are no longer exposed as environment
      variables
    - admin password is not modified on helm updates instead the values from
      the existing secret is re-used
    - default legth of admin password was increased
    - renamed useSecurity to adminSecret

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #20
- fixes #94

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
