### PR TITLE
Remove whitespace when not rendering helm.sh/chart label

### DIFF
--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -318,9 +318,3 @@ Create the name of the service account for Jenkins agents to use
     {{ default "default" .Values.serviceAccountAgent.name }}
 {{- end -}}
 {{- end -}}
-
-{{- define "helm-chart-label" -}}
-  {{- if .Values.renderHelmLabels -}}
-"helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
-  {{- end -}}
-{{- end -}}

--- a/charts/jenkins/templates/home-pvc.yaml
+++ b/charts/jenkins/templates/home-pvc.yaml
@@ -11,7 +11,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jcasc-config.yaml
+++ b/charts/jenkins/templates/jcasc-config.yaml
@@ -10,7 +10,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" $root }}
   labels:
     "app.kubernetes.io/name": {{ template "jenkins.name" $root}}
-    {{ include "helm-chart-label" $root}}
+    {{- if $root.Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
     "app.kubernetes.io/instance": "{{ $.Release.Name }}"
     "app.kubernetes.io/component": "{{ $.Values.controller.componentName }}"
@@ -29,7 +31,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" $root }}
   labels:
     "app.kubernetes.io/name": {{ template "jenkins.name" $root}}
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
     "app.kubernetes.io/instance": "{{ $.Release.Name }}"
     "app.kubernetes.io/component": "{{ $.Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-agent-svc.yaml
+++ b/charts/jenkins/templates/jenkins-agent-svc.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/charts/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.backup.componentName }}"

--- a/charts/jenkins/templates/jenkins-backup-rbac.yaml
+++ b/charts/jenkins/templates/jenkins-backup-rbac.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
@@ -22,7 +24,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
@@ -41,7 +45,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-controller-alerting-rules.yaml
+++ b/charts/jenkins/templates/jenkins-controller-alerting-rules.yaml
@@ -11,7 +11,9 @@ metadata:
 {{- end }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-controller-backendconfig.yaml
+++ b/charts/jenkins/templates/jenkins-controller-backendconfig.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-controller-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-ingress.yaml
@@ -9,7 +9,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-controller-networkpolicy.yaml
+++ b/charts/jenkins/templates/jenkins-controller-networkpolicy.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
@@ -57,7 +59,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-controller-route.yaml
+++ b/charts/jenkins/templates/jenkins-controller-route.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     app: {{ template "jenkins.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     component: "{{ .Release.Name }}-{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-controller-secondary-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-secondary-ingress.yaml
@@ -11,7 +11,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-controller-servicemonitor.yaml
+++ b/charts/jenkins/templates/jenkins-controller-servicemonitor.yaml
@@ -11,7 +11,9 @@ metadata:
 {{- end }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -9,7 +9,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/jenkins-controller-svc.yaml
+++ b/charts/jenkins/templates/jenkins-controller-svc.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/rbac.yaml
+++ b/charts/jenkins/templates/rbac.yaml
@@ -9,7 +9,9 @@ metadata:
   namespace: {{ template "jenkins.agent.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
@@ -32,7 +34,9 @@ metadata:
   namespace: {{ template "jenkins.agent.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
@@ -57,7 +61,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
@@ -75,7 +81,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
@@ -101,7 +109,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
@@ -119,7 +129,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/secret-https-jks.yaml
+++ b/charts/jenkins/templates/secret-https-jks.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/secret.yaml
+++ b/charts/jenkins/templates/secret.yaml
@@ -7,7 +7,9 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/service-account-agent.yaml
+++ b/charts/jenkins/templates/service-account-agent.yaml
@@ -10,7 +10,9 @@ metadata:
 {{- end }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/templates/service-account.yaml
+++ b/charts/jenkins/templates/service-account.yaml
@@ -10,7 +10,9 @@ metadata:
 {{- end }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
-    {{ include "helm-chart-label" .}}
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- end }}
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"


### PR DESCRIPTION
# What this PR does / why we need it

Before:

```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: RELEASE-NAME-jenkins
  namespace: cockpit
  labels:
    "app.kubernetes.io/name": 'jenkins'

    "app.kubernetes.io/managed-by": "Helm"
    "app.kubernetes.io/instance": "RELEASE-NAME"
    "app.kubernetes.io/component": "jenkins-controller"
```

After:

```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: RELEASE-NAME-jenkins
  namespace: cockpit
  labels:
    "app.kubernetes.io/name": 'jenkins'
    "app.kubernetes.io/managed-by": "Helm"
    "app.kubernetes.io/instance": "RELEASE-NAME"
    "app.kubernetes.io/component": "jenkins-controller"
```


# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer

I played quite a bit with include, but getting white spaces right was a nightmare so I just includes that snippet in the manifests.

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed

