### PR TITLE
Check usage of deprecated imageTag

### DIFF
--- a/charts/jenkins/templates/deprecation.yaml
+++ b/charts/jenkins/templates/deprecation.yaml
@@ -3,6 +3,10 @@
       {{ fail "`master` does no longer exist. It has been renamed to `controller`" }}
    {{- end }}
 
+   {{- if .Values.controller.imageTag }}
+      {{ fail "`controller.imageTag` does no longer exist. Please use `controller.tag` instead" }}
+   {{- end }}
+
    {{- if .Values.controller.slaveListenerPort }}
       {{ fail "`controller.slaveListenerPort` does no longer exist. It has been renamed to `controller.agentListenerPort`" }}
    {{- end }}


### PR DESCRIPTION
# What this PR does / why we need it

Users would want a hint if they are using a value, which is no longer supported.

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
