### PR TITLE
fix error in additional secrets documentation

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.0.4
+* Fix documentation for additional secret mounts
+
 ## 3.0.3
 * Update `README.md` with explanation on how to mount additional secrets
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.0.3
+* Update `README.md` with explanation on how to mount additional secrets
+
 ## 3.0.2
 
 * Fix `.Values.controller.tolerations` and `.Values.controller.nodeSelector` variable names in templates\jenkins-backup-cronjob.yaml

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.0.3
+version: 3.0.4
 appVersion: 2.249.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.0.2
+version: 3.0.3
 appVersion: 2.249.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -317,8 +317,13 @@ persistence:
         secretName: idp-config
   mounts:
     - name: idp-config
-      secret:
-        secretName: idp-config
+      mountPath: /run/secrets/client_id
+      subpath: client_id
+      readOnly: true
+    - name: idp-config
+      mountPath: /run/secrets/client_secret
+      subPath: client_secret
+      readOnly: true
 ```
 
 `values.yaml` controller section, referencing mounted secrets:


### PR DESCRIPTION
Realized I had an error in #180, specifically regarding the format of `persistence.mounts` for mounting additional secrets to the controller. This is how it should look instead.
@torstenwalter apologies for the mix-up.