### PR TITLE
Update appVersion to match current LTS version of Jenkins

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.0.5
+* Update appVersion to reflect new jenkins lts release version 2.263.1
+
 ## 3.0.4
 * Fix documentation for additional secret mounts
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.0.4
-appVersion: 2.249.3
+version: 3.0.5
+appVersion: 2.263.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
 - https://github.com/jenkinsci/jenkins


### PR DESCRIPTION
# What this PR does / why we need it
Update appVersion since current LTS version of Jenkins is v2.263.1
# Which issue this PR fixes
Mismatch between appVersion and the actual version used.
# Special notes for your reviewer
I hope you are all doing relatively well during this challenging year.
