### PR TITLE
Fix conflicting explicit plugin and transitive plugin dependencies issue

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.0.8
+
+* Fix conflicting explicit and transitive plugin dependencies issue for plugins download
+
 ## 3.0.7
 
 * Add support for setting default agent workspaceVolume

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.0.7
+version: 3.0.8
 appVersion: 2.263.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -35,7 +35,7 @@ data:
     rm -rf {{ .Values.controller.jenkinsRef }}/plugins/*.lock
     version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
     if [ -f "{{ .Values.controller.jenkinsWar }}" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-      jenkins-plugin-cli --war "{{ .Values.controller.jenkinsWar }}" --plugin-file "{{ .Values.controller.jenkinsHome }}/plugins.txt";
+      jenkins-plugin-cli --war "{{ .Values.controller.jenkinsWar }}" --plugin-file "{{ .Values.controller.jenkinsHome }}/plugins.txt" --latest-specified;
     else
       /usr/local/bin/install-plugins.sh `echo $(cat {{ .Values.controller.jenkinsHome }}/plugins.txt)`;
     fi

--- a/charts/jenkins/tests/config-test.yaml
+++ b/charts/jenkins/tests/config-test.yaml
@@ -29,7 +29,7 @@ tests:
             rm -rf /usr/share/jenkins/ref/plugins/*.lock
             version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
             if [ -f "/usr/share/jenkins/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt";
+              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest-specified;
             else
               /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
             fi
@@ -80,7 +80,7 @@ tests:
             rm -rf /usr/share/jenkins/ref/plugins/*.lock
             version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
             if [ -f "/usr/share/jenkins/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt";
+              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest-specified;
             else
               /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
             fi

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -44,7 +44,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: c1970219d6ed4463c3aeb25c5a1acd68574d1ec9a847361e630893f69cc49dc0
+                  checksum/config: 62f26c612b84f5ae5eae9f3872c3c1b5634a89e97ebb06920ce47d8945f1c774
                 labels:
                   app.kubernetes.io/component: jenkins-controller
                   app.kubernetes.io/instance: my-release


### PR DESCRIPTION
# What this PR does / why we need it
This PR solves the issue with explicitly defined plugins and transitive plugins conflict.

# Which issue this PR fixes
https://github.com/jenkinsci/helm-charts/issues/186

# Special notes for your reviewer
By default `plugin-installation-manager-tool` downloads the latest version of transitive dependency if it is defined like `some_plugin≥minimal_version` and fails if an oldest version of `some_plugin` is defined one level above.

For example, `git-parameter:0.9.13` depends on `git≥3.10.0` plugin but `git:4.4.5` is defined before in command line and the latest version of git plugin is 4.5.0.
It fails with the current solution:
```
$ java -jar jenkins-plugin-manager-2.1.1.jar -p git:4.4.5 -p git-parameter:0.9.13 --no-download
Unable to open C:\ProgramData\Jenkins\jenkins.war
Unable to get version from war file
War not found, installing all plugins: C:\ProgramData\Jenkins\jenkins.war
Plugin git-parameter:0.9.13 depends on git:4.5.0, but there is an older version defined on the top level - git:4.4.5
```

But works as expected with `--latest-specified` flag:
```
$ java -jar jenkins-plugin-manager-2.1.1.jar -p git:4.4.5 -p git-parameter:0.9.13 --no-download --latest-specified
Unable to open C:\ProgramData\Jenkins\jenkins.war
Unable to get version from war file
War not found, installing all plugins: C:\ProgramData\Jenkins\jenkins.war
Done
```

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
