### PR TITLE
stale bot: increase time before acting on issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
+daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+daysUntilClose: 21
 # Issues with these labels will never be considered stale
 exemptLabels:
   - lifecycle/frozen


### PR DESCRIPTION
# What this PR does / why we need it

Let's wait for 60 days before issues are marked as stale and another 21 days before issues are closed.

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed

