### PR TITLE
Adding podSecurityContextOverride

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,12 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+
+## 3.1.0
+
+* Added `.Values.controller.podSecurityContextOverride` and `.Values.backup.podSecurityContextOverride`.
+* Added simple default values tests for `jenkins-backup-cronjob.yaml`.
+
 ## 3.0.14
 
 Enable to only backup job folder instead of whole jenkins

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.0.14
+version: 3.1.0
 appVersion: 2.263.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -302,7 +302,7 @@ attach/mount times, [10 or more minutes][K8S_VOLUME_TIMEOUT], when using
 `fsGroup`.  This issue may result in the following entries in the pod's event
 history:
 
-```
+```console
 Warning  FailedMount  38m                kubelet, aks-default-41587790-2 Unable to attach or mount volumes: unmounted volumes=[jenkins-home], unattached volumes=[plugins plugin-dir jenkins-token-rmq2g sc-config-volume tmp jenkins-home jenkins-config secrets-dir]: timed out waiting for the condition
 ```
 

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -292,8 +292,38 @@ See additional `persistence` values using [configuration commands](#configuratio
 #### Existing PersistentVolumeClaim
 
 1. Create the PersistentVolume
-1. Create the PersistentVolumeClaim
-1. [Install](#install-chart) the chart, setting `persistence.existingClaim` to `PVC_NAME`
+2. Create the PersistentVolumeClaim
+3. [Install](#install-chart) the chart, setting `persistence.existingClaim` to `PVC_NAME`
+
+#### Long Volume Attach/Mount Times
+
+Certain volume type and filesystem format combinations may experience long
+attach/mount times, [10 or more minutes][K8S_VOLUME_TIMEOUT], when using
+`fsGroup`.  This issue may result in the following entries in the pod's event
+history:
+
+```
+Warning  FailedMount  38m                kubelet, aks-default-41587790-2 Unable to attach or mount volumes: unmounted volumes=[jenkins-home], unattached volumes=[plugins plugin-dir jenkins-token-rmq2g sc-config-volume tmp jenkins-home jenkins-config secrets-dir]: timed out waiting for the condition
+```
+
+In these cases, experiment with replacing `fsGroup` with
+`supplementalGroups` in the pod's `securityContext`.  This can be achieved by
+setting the `controller.podSecurityContextOverride` Helm chart value to
+something like:
+
+```yaml
+controller:
+  podSecurityContextOverride:
+    runAsNonRoot: true
+    runAsUser: 1000
+    supplementalGroups: [1000]
+```
+
+This issue has been reported on [azureDisk with ext4][K8S_VOLUME_TIMEOUT] and
+on [Alibaba cloud][K8S_VOLUME_TIMEOUT_ALIBABA].
+
+[K8S_VOLUME_TIMEOUT]: https://github.com/kubernetes/kubernetes/issues/67014
+[K8S_VOLUME_TIMEOUT_ALIBABA]: https://github.com/kubernetes/kubernetes/issues/67014#issuecomment-698770511
 
 #### Storage Class
 

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -99,9 +99,10 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 4096Mi}}`|
 | `controller.initContainerEnv`         | Environment variables for Init Container                                 | Not set |
 | `controller.containerEnv`             | Environment variables for Jenkins Container                              | Not set |
-| `controller.usePodSecurityContext`    | Enable pod security context (must be `true` if `runAsUser` or `fsGroup` are set) | `true` |
+| `controller.usePodSecurityContext`    | Enable pod security context (must be `true` if `runAsUser`, `fsGroup`, or `podSecurityContextOverride` are set) | `true` |
 | `controller.runAsUser`                | uid that jenkins runs with           | `1000`                                    |
 | `controller.fsGroup`                  | uid that will be used for persistent volume | `1000`                             |
+| `controller.podSecurityContextOverride` | Completely overwrites the contents of the pod security context, ignoring the values provided for `runAsUser`, and `fsGroup`. | Not set |
 | `controller.hostAliases`              | Aliases for IPs in `/etc/hosts`      | `[]`                                      |
 | `controller.serviceAnnotations`       | Service annotations                  | `{}`                                      |
 | `controller.serviceType`              | k8s service type                     | `ClusterIP`                               |
@@ -337,3 +338,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `backup.resources`                       | Backup CPU/Memory resource requests/limits                        | Memory: `1Gi`, CPU: `1`           |
 | `backup.destination`                     | Destination to store backup artifacts                             | `s3://jenkins-data/backup`        |
 | `backup.onlyJobs`                        | Only backup the job folder                                        | `false`                           |
+| `backup.usePodSecurityContext`           | Enable backup pod's security context (must be `true` if `runAsUser`, `fsGroup`, or `podSecurityContextOverride` are set) | `true` |
+| `backup.runAsUser`                       | uid that jenkins runs with           | `1000`                                    |
+| `backup.fsGroup`                         | uid that will be used for persistent volume | `1000`                             |
+| `backup.podSecurityContextOverride`      | Completely overwrites the contents of the backup pod's security context, ignoring the values provided for `runAsUser`, and `fsGroup`. | Not set |

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -100,8 +100,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.initContainerEnv`         | Environment variables for Init Container                                 | Not set |
 | `controller.containerEnv`             | Environment variables for Jenkins Container                              | Not set |
 | `controller.usePodSecurityContext`    | Enable pod security context (must be `true` if `runAsUser`, `fsGroup`, or `podSecurityContextOverride` are set) | `true` |
-| `controller.runAsUser`                | uid that jenkins runs with           | `1000`                                    |
-| `controller.fsGroup`                  | uid that will be used for persistent volume | `1000`                             |
+| `controller.runAsUser`                | Deprecated in favor of `controller.podSecurityContextOverride`.  uid that jenkins runs with. | `1000`                                    |
+| `controller.fsGroup`                  | Deprecated in favor of `controller.podSecurityContextOverride`.  uid that will be used for persistent volume. | `1000`                             |
 | `controller.podSecurityContextOverride` | Completely overwrites the contents of the pod security context, ignoring the values provided for `runAsUser`, and `fsGroup`. | Not set |
 | `controller.hostAliases`              | Aliases for IPs in `/etc/hosts`      | `[]`                                      |
 | `controller.serviceAnnotations`       | Service annotations                  | `{}`                                      |
@@ -339,6 +339,6 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `backup.destination`                     | Destination to store backup artifacts                             | `s3://jenkins-data/backup`        |
 | `backup.onlyJobs`                        | Only backup the job folder                                        | `false`                           |
 | `backup.usePodSecurityContext`           | Enable backup pod's security context (must be `true` if `runAsUser`, `fsGroup`, or `podSecurityContextOverride` are set) | `true` |
-| `backup.runAsUser`                       | uid that jenkins runs with           | `1000`                                    |
-| `backup.fsGroup`                         | uid that will be used for persistent volume | `1000`                             |
+| `backup.runAsUser`                       | Deprecated in favor of `backup.podSecurityContextOverride`.  uid that jenkins runs with. | `1000`                                    |
+| `backup.fsGroup`                         | Deprecated in favor of `backup.podSecurityContextOverride`.  uid that will be used for persistent volume. | `1000`                             |
 | `backup.podSecurityContextOverride`      | Completely overwrites the contents of the backup pod's security context, ignoring the values provided for `runAsUser`, and `fsGroup`. | Not set |

--- a/charts/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/charts/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -36,15 +36,19 @@ spec:
           serviceAccountName: {{ template "jenkins.fullname" . }}-backup
           {{- if .Values.backup.usePodSecurityContext }}
           securityContext:
+            {{- if hasKey .Values.backup "podSecurityContextOverride" }}
+              {{- tpl (toYaml .Values.backup.podSecurityContextOverride | nindent 12) . }}
+            {{- else }}
             runAsUser: {{ default 0 .Values.backup.runAsUser }}
-            {{- if and (.Values.backup.runAsUser) (.Values.backup.fsGroup) }}
-              {{- if not (eq (int .Values.backup.runAsUser) 0) }}
+              {{- if and (.Values.backup.runAsUser) (.Values.backup.fsGroup) }}
+                {{- if not (eq (int .Values.backup.runAsUser) 0) }}
             fsGroup: {{ .Values.backup.fsGroup }}
+                {{- end }}
               {{- end }}
-            {{- end }}
-            {{- if .Values.backup.securityContextCapabilities }}
+              {{- if .Values.backup.securityContextCapabilities }}
           capabilities:
-            {{- toYaml .Values.backup.securityContextCapabilities | nindent 12 }}
+              {{- toYaml .Values.backup.securityContextCapabilities | nindent 12 }}
+              {{- end }}
             {{- end }}
           {{- end }}
           containers:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -71,6 +71,11 @@ spec:
   {{- if hasKey .Values.controller "podSecurityContextOverride" }}
     {{- tpl (toYaml .Values.controller.podSecurityContextOverride | nindent 8) . -}}
   {{- else }}
+    {{/* The rest of this section should be replaced with the contents of this comment one the runAsUser, fsGroup, and securityContextCapabilities Helm chart values have been removed:
+        runAsUser: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+    */}}
         runAsUser: {{ default 0 .Values.controller.runAsUser }}
     {{- if and (.Values.controller.runAsUser) (.Values.controller.fsGroup) }}
       {{- if not (eq (int .Values.controller.runAsUser) 0) }}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -68,15 +68,19 @@ spec:
       {{- end }}
 {{- if .Values.controller.usePodSecurityContext }}
       securityContext:
+  {{- if hasKey .Values.controller "podSecurityContextOverride" }}
+    {{- tpl (toYaml .Values.controller.podSecurityContextOverride | nindent 8) . -}}
+  {{- else }}
         runAsUser: {{ default 0 .Values.controller.runAsUser }}
-  {{- if and (.Values.controller.runAsUser) (.Values.controller.fsGroup) }}
-    {{- if not (eq (int .Values.controller.runAsUser) 0) }}
+    {{- if and (.Values.controller.runAsUser) (.Values.controller.fsGroup) }}
+      {{- if not (eq (int .Values.controller.runAsUser) 0) }}
         fsGroup: {{ .Values.controller.fsGroup }}
         runAsNonRoot: true
-    {{- end }}
-    {{- if .Values.controller.securityContextCapabilities }}
+      {{- end }}
+      {{- if .Values.controller.securityContextCapabilities }}
         capabilities:
           {{- toYaml .Values.controller.securityContextCapabilities | nindent 10 }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/jenkins/tests/jenkins-backup-cronjob-test.yaml
+++ b/charts/jenkins/tests/jenkins-backup-cronjob-test.yaml
@@ -1,0 +1,44 @@
+suite: Jenkins Backup Cronjob
+release:
+  name: my-release
+  namespace: my-namespace
+templates:
+  - jenkins-backup-cronjob.yaml
+tests:
+  - it: test default values
+    set:
+      backup:
+        enabled: true
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext
+          value:
+            fsGroup: 1000
+            runAsUser: 1000
+  - it: test empty backup.podSecurityContextOverride
+    set:
+      backup:
+        enabled: true
+        podSecurityContextOverride: {}
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext
+          value: {}
+  - it: test backup.podSecurityContextOverride
+    set:
+      backup:
+        enabled: true
+        podSecurityContextOverride:
+          runAsNonRoot: true
+          runAsUser: 4444
+          supplementalGroups: [5555]
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext
+          value:
+            runAsNonRoot: true
+            runAsUser: 4444
+            supplementalGroups:
+              - 5555

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -349,3 +349,26 @@ tests:
            name: JENKINS_OPTS
            value: >-
              -Dtest="custom: 'true'"
+  - it: test empty controller.podSecurityContextOverride
+    set:
+      controller:
+        podSecurityContextOverride: {}
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value: {}
+  - it: test controller.podSecurityContextOverride
+    set:
+      controller:
+        podSecurityContextOverride:
+          runAsNonRoot: true
+          runAsUser: 4444
+          supplementalGroups: [5555]
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsNonRoot: true
+            runAsUser: 4444
+            supplementalGroups:
+              - 5555

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -78,7 +78,7 @@ controller:
   # jenkinsUrl: ""
   # If you set this prefix and use ingress controller then you might want to set the ingress path below
   # jenkinsUriPrefix: "/jenkins"
-  # Enable pod security context (must be `true` if runAsUser or fsGroup are set)
+  # Enable pod security context (must be `true` if podSecurityContextOverride, runAsUser or fsGroup are set)
   usePodSecurityContext: true
   # Set runAsUser to 1000 to let Jenkins run as non-root user 'jenkins' which exists in 'jenkins/jenkins' docker image.
   # When setting runAsUser to a different value than 0 also set fsGroup to the same value:
@@ -88,6 +88,12 @@ controller:
   securityContextCapabilities: {}
   #  drop:
   #    - NET_RAW
+  # Completely overwrites the contents of the `securityContext`, ignoring the values provided for `runAsUser`, `fsGroup`, and `securityContextCapabilities`.
+  # podSecurityContextOverride:
+  #   runAsUser: 1000
+  #   runAsNonRoot: true
+  #   supplementalGroups: [1000]
+  #   # capabilities: {}
   servicePort: 8080
   targetPort: 8080
   # For minikube, set this to NodePort, elsewhere use LoadBalancer

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -80,6 +80,8 @@ controller:
   # jenkinsUriPrefix: "/jenkins"
   # Enable pod security context (must be `true` if podSecurityContextOverride, runAsUser or fsGroup are set)
   usePodSecurityContext: true
+  # Note that `runAsUser`, `fsGroup`, and `securityContextCapabilities` are
+  # being deprecated and replaced by `podSecurityContextOverride`.
   # Set runAsUser to 1000 to let Jenkins run as non-root user 'jenkins' which exists in 'jenkins/jenkins' docker image.
   # When setting runAsUser to a different value than 0 also set fsGroup to the same value:
   runAsUser: 1000
@@ -88,7 +90,11 @@ controller:
   securityContextCapabilities: {}
   #  drop:
   #    - NET_RAW
-  # Completely overwrites the contents of the `securityContext`, ignoring the values provided for `runAsUser`, `fsGroup`, and `securityContextCapabilities`.
+  # Completely overwrites the contents of the `securityContext`, ignoring the
+  # values provided for the deprecated fields: `runAsUser`, `fsGroup`, and
+  # `securityContextCapabilities`.  In the case of mounting an ext4 filesystem,
+  # it might be desirable to use `supplementalGroups` instead of `fsGroup` in
+  # the `securityContext` block: https://github.com/kubernetes/kubernetes/issues/67014#issuecomment-589915496
   # podSecurityContextOverride:
   #   runAsUser: 1000
   #   runAsNonRoot: true


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

This PR introduces the `podSecurityContextOverride` value that completely overwrites `securityContext` in both the controller `StatefulSet` and backup `CronJob`.  It gives greater flexability in what can be put in the pod `securityContext` block, not limited to just `runAsUse`, `fsGroup`, and `securityContextCapabilities`.

In our particular case, we need to be able to unset `fsGroup` and set `supplementalGroups` instead.  Using an override as implemented, would allow use of other `securityContext` values without further complicating the existing Helm Chart.

This is related to the solution in [ kubernetes/kubernetes - Timeout expired waiting for volumes to attach #67014](https://github.com/kubernetes/kubernetes/issues/67014).


# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #203
- fixes #110

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
