### PR TITLE
Improve Documentation around JCasc and Custom Image

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.0.13
+
+Improve Documentation around JCasc and Custom Image
+
 ## 3.0.12
 
 Added GitHub Action testing on Kind 1.16, 1.17, 1.18, 1.19 & 1.20

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.0.12
+version: 3.0.13
 appVersion: 2.263.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -112,7 +112,7 @@ controller:
   installPlugins: []
 ```
 
-Notice: `installPlugins` is set to an empty list to disable plugin download.
+Notice: `installPlugins` is set to an empty list to disable plugin download. In this case, the image `registry/my-jenkins:v1.2.3` must have the plugins specified as default value for [the `controller.installPlugins` directive](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES_SUMMARY.md#jenkins-plugins) to ensure that the configuration side-car system works as expected.
 
 In case you are using a private registry you can use 'imagePullSecretName' to specify the name of the secret to use when pulling the image:
 
@@ -133,14 +133,23 @@ If you are not using the provided ingress you can specify `controller.jenkinsUrl
 
 ### Configuration as Code
 
-Jenkins Configuration as Code is now a standard component in the Jenkins project.
-Add a key under configScripts for each configuration area, where each corresponds to a plugin or section of the UI.
-The keys (prior to `|` character) are just labels, and can be any value.
-They are only used to give the section a meaningful name.
+Jenkins Configuration as Code (JCasC) is now a standard component in the Jenkins project.
+To allow JCasC's configuration from the helm values, the plugin [`configuration-as-code`](https://plugins.jenkins.io/configuration-as-code/) must be installed in the Jenkins Controller's Docker image (which is the case by default as specified by the [default value of the directive `controller.installPlugins`](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES_SUMMARY.md#jenkins-plugins)).
+
+JCasc configuration is passed through Helm values under the key `controller.JCasC`.
+The section ["Jenkins Configuration as Code (JCasC)" of the page "VALUES_SUMMARY.md"](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES_SUMMARY.md#jenkins-configuration-as-code-jcasc) lists all the possible directives.
+
+In particular, you may specify custom JCasC scripts by adding sub-key under the `controller.JCasC.configScripts` for each configuration area where each corresponds to a plugin or section of the UI.
+
+The sub-keys (prior to `|` character) are only labels used to give the section a meaningful name.
 The only restriction is they must conform to RFC 1123 definition of a DNS label, so they may only contain lowercase letters, numbers, and hyphens.
+
 Each key will become the name of a configuration yaml file on the controller in `/var/jenkins_home/casc_configs` (by default) and will be processed by the Configuration as Code Plugin during Jenkins startup.
+
 The lines after each `|` become the content of the configuration yaml file.
+
 The first line after this is a JCasC root element, e.g. jenkins, credentials, etc.
+
 Best reference is the Documentation link here: `https://<jenkins_url>/configuration-as-code`.
 
 The example below sets custom systemMessage:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -72,7 +72,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.installPlugins`       | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.18.2 workflow-aggregator:2.6 credentials-binding:1.19 git:3.11.0 workflow-job:2.33` |
+| `controller.installPlugins`       | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.27.6 workflow-aggregator:2.6 git:4.4.5 configuration-as-code:1.46` |
 | `controller.additionalPlugins`    | List of Jenkins plugins to install in addition to those listed in controller.installPlugins | `[]` |
 | `controller.initializeOnce`       | Initialize only on first install. Ensures plugins do not get updated inadvertently. Requires `persistence.enabled` to be set to `true`. | `false` |
 | `controller.overwritePlugins`     | Overwrite installed plugins on start.| `false`                                   |


### PR DESCRIPTION
# What this PR does / why we need it

This PR fix some parts of the chart documentation to help newcomers around JCasC configuration:

- Add an explicit requirement about the mandatory plugins required by the chart
- Improve the JCasC configuration explanation for newcomers
- Fix the documented default value for the directive `controller.installPlugins`

# Which issue this PR fixes

- N/A.

# Special notes for your reviewer

🎅 Merry Christmas and Happy New Year!

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
