### PR TITLE
Enable to only backup job folder

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.0.14
+
+Enable to only backup job folder instead of whole jenkins
+
 ## 3.0.13
 
 Improve Documentation around JCasc and Custom Image

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.0.13
+version: 3.0.14
 appVersion: 2.263.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -336,3 +336,4 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `backup.env`                             | Backup environment variables                                      | `[]`                              |
 | `backup.resources`                       | Backup CPU/Memory resource requests/limits                        | Memory: `1Gi`, CPU: `1`           |
 | `backup.destination`                     | Destination to store backup artifacts                             | `s3://jenkins-data/backup`        |
+| `backup.onlyJobs`                     | Only backup the job folder                                           | `false`        |

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -336,4 +336,4 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `backup.env`                             | Backup environment variables                                      | `[]`                              |
 | `backup.resources`                       | Backup CPU/Memory resource requests/limits                        | Memory: `1Gi`, CPU: `1`           |
 | `backup.destination`                     | Destination to store backup artifacts                             | `s3://jenkins-data/backup`        |
-| `backup.onlyJobs`                     | Only backup the job folder                                           | `false`        |
+| `backup.onlyJobs`                        | Only backup the job folder                                        | `false`                           |

--- a/charts/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/charts/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -60,7 +60,11 @@ spec:
             - --container
             - jenkins
             - --path
+            {{- if .Values.backup.onlyJobs }}
+            - {{ .Values.controller.jenkinsHome }}/jobs
+            {{- else}}
             - {{ .Values.controller.jenkinsHome }}
+            {{- end}}
             - --dst
             - {{ .Values.backup.destination }}
             {{- with .Values.backup.extraArgs }}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -746,6 +746,8 @@ backup:
   # Additional support can added. Visit this repository for details
   # Ref: https://github.com/maorfr/skbn
   destination: "s3://jenkins-data/backup"
+  # By enabling only the jenkins_home/jobs folder gets backed up, not the whole jenkins instance
+  onlyJobs: false
   # Enable backup pod security context (must be `true` if runAsUser or fsGroup are set)
   usePodSecurityContext: true
   # When setting runAsUser to a different value than 0 also set fsGroup to the same value:


### PR DESCRIPTION
# What this PR does / why we need it
With full usage of JCasC, there is often no need to backup the full Jenkins instance. The only thing needing backup are the job logs and artifacts (so the /job folder). 
This enables much faster backups, since the backup is a lot smaller. In my testing I was able to cut down the backup time from 3-4 hours to only a few minutes.

With this pull request the user can select "onlyJobs=true" and have only the jenkins_home/jobs folder backed up.

If you have better idea how to implement this, please let me know. :)

# Checklist
- [X] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] CHANGELOG.md was updated
