### PR TITLE
Adding controller.updateStrategy (#191)

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -11,6 +11,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
+
+## 3.1.11
+
+Enable setting controller.updateStrategy to change the update strategy for StatefulSet
+
 ## 3.1.10
 
 Fixed issue for the AgentListener where it was not possible to attribute a NodePort

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.1.10
+version: 3.1.11
 appVersion: 2.263.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -125,6 +125,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.tolerations`              | Toleration labels for pod assignment | `[]`                                      |
 | `controller.podAnnotations`           | Annotations for controller pod           | `{}`                                      |
 | `controller.statefulSetAnnotations`   | Annotations for controller StatefulSet   | `{}`                                      |
+| `controller.updateStrategy`           | Update strategy for StatefulSet      | `{}`                                      |
 | `controller.lifecycle`                | Lifecycle specification for controller-container | Not set                           |
 | `controller.priorityClassName`        | The name of a `priorityClass` to apply to the controller pod | Not set               |
 | `controller.admin.existingSecret`     | The name of an existing secret containing the admin credentials. | `""`|

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -29,6 +29,10 @@ spec:
     matchLabels:
       "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
       "app.kubernetes.io/instance": "{{ .Release.Name }}"
+  {{- if .Values.controller.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.controller.updateStrategy | indent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -230,6 +230,8 @@ tests:
           - ip: 192.168.50.50
             hostnames:
               - something.local
+        updateStrategy:
+          type: OnDelete
       serviceAccount.name: my-serviceaccount
     asserts:
     - equal:
@@ -291,6 +293,9 @@ tests:
           - ip: 192.168.50.50
             hostnames:
               - something.local
+    - equal:
+        path: spec.updateStrategy.type
+        value: OnDelete
   - it: configure image tag
     set:
       controller.tag: 2.249.1-slim

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -327,6 +327,10 @@ controller:
   # Add StatefulSet annotations
   statefulSetAnnotations: {}
 
+  # StatefulSet updateStrategy
+  # ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  updateStrategy: {}
+
   ingress:
     enabled: false
     # Override for the default paths that map requests to the backend


### PR DESCRIPTION
# What this PR does / why we need it

Add an option controller.updateStrategy to set the spec.updateStrategy for StatefulSet.

# Which issue this PR fixes

- fixes #191

# Special notes for your reviewer

# Checklist
- [ x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ x] Chart Version bumped
- [ x] CHANGELOG.md was updated
