### PR TITLE
Fix documentation for the kubernetes probes

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.1.3
+
+* 🐛 📝  Fix documentation for the kubernetes probes
+
 ## 3.1.2
 
 Enable setting maxRequestsPerHostStr to change the max concurrent connections to Kubernetes API

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.1.2
+version: 3.1.3
 appVersion: 2.263.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -136,15 +136,25 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.healthProbes`             | Enable k8s liveness and readiness probes    | `true`                             |
-| `controller.healthProbesLivenessTimeout`  | Set the timeout for the liveness probe  | `5`                              |
-| `controller.healthProbesReadinessTimeout` | Set the timeout for the readiness probe | `5`                               |
-| `controller.healthProbeLivenessPeriodSeconds` | Set how often (in seconds) to perform the liveness probe | `10`         |
-| `controller.healthProbeReadinessPeriodSeconds` | Set how often (in seconds) to perform the readiness probe | `10`         |
-| `controller.healthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `5`               |
-| `controller.healthProbeReadinessFailureThreshold` | Set the failure threshold for the readiness probe | `3`               |
-| `controller.healthProbeLivenessInitialDelay` | Set the initial delay for the liveness probe | `90`               |
-| `controller.healthProbeReadinessInitialDelay` | Set the initial delay for the readiness probe | `60`               |
+| `controller.healthProbes`             | Enable [Kubernetes Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes) configuration from `controller.probes` (see below) | `true` |
+| `controller.probes.livenessProbe.timeoutSeconds` | Set the timeout for the liveness probe in seconds  | `5` |
+| `controller.probes.livenessProbe.periodSeconds` | Set the time interval (in seconds) between two liveness probes executions | `10` |
+| `controller.probes.livenessProbe.failureThreshold` | Set the failure threshold for the liveness probe | `5` |
+| `controller.probes.livenessProbe.initialDelaySeconds` | Set the initial delay for the liveness probe | Not set |
+| `controller.probes.livenessProbe.httpGet.port` | Set the Pod's HTTP port to use for the liveness probe | `http` |
+| `controller.probes.livenessProbe.httpGet.path` | Set the HTTP's path for the liveness probe | `/login'` (or `${controller.jenkinsUriPrefix}/login` if `controller.jenkinsUriPrefix` is defined) |
+| `controller.probes.readinessProbe.timeoutSeconds` | Set the timeout for the readiness probe in seconds  | `5` |
+| `controller.probes.readinessProbe.periodSeconds` | Set the time interval (in seconds) between two readiness probes executions | `10` |
+| `controller.probes.readinessProbe.failureThreshold` | Set the failure threshold for the readiness probe | `3` |
+| `controller.probes.readinessProbe.initialDelaySeconds` | Set the initial delay for the readiness probe | Not set |
+| `controller.probes.readinessProbe.httpGet.port` | Set the Pod's HTTP port to use for the readiness probe | `http` |
+| `controller.probes.readinessProbe.httpGet.path` | Set the HTTP's path for the readiness probe | `/login'` (or `${controller.jenkinsUriPrefix}/login` if `controller.jenkinsUriPrefix` is defined) |
+| `controller.probes.startupProbe.timeoutSeconds` | Set the timeout for the startup probe in seconds  | `5` |
+| `controller.probes.startupProbe.periodSeconds` | Set the time interval (in seconds) between two startup probes executions | `10` |
+| `controller.probes.startupProbe.failureThreshold` | Set the failure threshold for the startup probe | `12` |
+| `controller.probes.startupProbe.initialDelaySeconds` | Set the initial delay for the startup probe | Not set |
+| `controller.probes.startupProbe.httpGet.port` | Set the Pod's HTTP port to use for the startup probe | `http` |
+| `controller.probes.startupProbe.httpGet.path` | Set the HTTP's path for the startup probe | `/login'` (or `${controller.jenkinsUriPrefix}/login` if `controller.jenkinsUriPrefix` is defined) |
 
 #### Kubernetes Ingress
 

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -137,6 +137,9 @@ controller:
         port: http
       periodSeconds: 10
       timeoutSeconds: 5
+      # If Startup Probe is not supported on your Kubernetes cluster, you might want to use "initialDelaySeconds" instead.
+      # It delays the initial liveness probe while Jenkins is starting
+      # initialDelaySeconds: 60
     readinessProbe:
       failureThreshold: 3
       httpGet:
@@ -144,6 +147,9 @@ controller:
         port: http
       periodSeconds: 10
       timeoutSeconds: 5
+      # If Startup Probe is not supported on your Kubernetes cluster, you might want to use "initialDelaySeconds" instead.
+      # It delays the initial readyness probe while Jenkins is starting
+      # initialDelaySeconds: 60
   agentListenerPort: 50000
   agentListenerHostPort:
   disabledAgentProtocols:


### PR DESCRIPTION
# What this PR does / why we need it

- The current documentation is not describing the correct values for the Kubernetes probes (wrong keys, missing keys, and false default values)
- If a user is running on a Kubernetes cluster <= 1.18, then startup probes might not be available and the initialDelay should be documented to holds off the liveness probe, to avoid a premature restart of Jenkins triggered by the local Kubelet.

# Which issue this PR fixes

N.A.

# Special notes for your reviewer

# Checklist

- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
