### PR TITLE
chore(deps): bump jenkins version from 2.263.2 to 2.263.3

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,14 +12,17 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.1.3
+
+Update Jenkins image and appVersion to jenkins lts release version 2.263.3
+
 ## 3.1.2
 
 Enable setting maxRequestsPerHostStr to change the max concurrent connections to Kubernetes API
 
 ## 3.1.1
 
-* Update Jenkins image and appVersion to jenkins lts release version 2.263.2
-
+Update Jenkins image and appVersion to jenkins lts release version 2.263.2
 
 ## 3.1.0
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.1.2
-appVersion: 2.263.2
+version: 3.1.3
+appVersion: 2.263.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
 - https://github.com/jenkinsci/jenkins

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -67,7 +67,7 @@ tests:
                     value: "50000"
                   - name: CASC_JENKINS_CONFIG
                     value: /var/jenkins_home/casc_configs
-                  image: jenkins/jenkins:2.263.2
+                  image: jenkins/jenkins:2.263.3
                   imagePullPolicy: Always
                   livenessProbe:
                     failureThreshold: 5
@@ -153,7 +153,7 @@ tests:
                 - command:
                   - sh
                   - /var/jenkins_config/apply_config.sh
-                  image: jenkins/jenkins:2.263.2
+                  image: jenkins/jenkins:2.263.3
                   imagePullPolicy: Always
                   name: init
                   resources:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -19,7 +19,7 @@ controller:
   # Used for label app.kubernetes.io/component
   componentName: "jenkins-controller"
   image: "jenkins/jenkins"
-  tag: "2.263.2"
+  tag: "2.263.3"
   imagePullPolicy: "Always"
   imagePullSecretName:
   # Optionally configure lifetime for controller-container


### PR DESCRIPTION
Signed-off-by: Gareth Evans <gareth@bryncynfelin.co.uk>

# What this PR does / why we need it

2.263.3 is a security release.

# Which issue this PR fixes

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
