### PR TITLE
Updating git plugin version

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.1.4
+
+Update Git plugin version to v4.5.2
+
 ## 3.1.3
 
 Update Jenkins image and appVersion to jenkins lts release version 2.263.3

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.1.3
+version: 3.1.4
 appVersion: 2.263.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -72,7 +72,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.installPlugins`       | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.27.6 workflow-aggregator:2.6 git:4.4.5 configuration-as-code:1.46` |
+| `controller.installPlugins`       | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.27.6 workflow-aggregator:2.6 git:4.5.2 configuration-as-code:1.46` |
 | `controller.additionalPlugins`    | List of Jenkins plugins to install in addition to those listed in controller.installPlugins | `[]` |
 | `controller.initializeOnce`       | Initialize only on first install. Ensures plugins do not get updated inadvertently. Requires `persistence.enabled` to be set to `true`. | `false` |
 | `controller.overwritePlugins`     | Overwrite installed plugins on start.| `false`                                   |

--- a/charts/jenkins/tests/config-test.yaml
+++ b/charts/jenkins/tests/config-test.yaml
@@ -42,7 +42,7 @@ tests:
           value: |-
             kubernetes:1.27.6
             workflow-aggregator:2.6
-            git:4.4.5
+            git:4.5.2
             configuration-as-code:1.46
   - it: no plugins
     set:
@@ -93,6 +93,6 @@ tests:
           value: |-
             kubernetes:1.27.6
             workflow-aggregator:2.6
-            git:4.4.5
+            git:4.5.2
             configuration-as-code:1.46
             kubernetes-credentials-provider

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -44,7 +44,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: c1970219d6ed4463c3aeb25c5a1acd68574d1ec9a847361e630893f69cc49dc0
+                  checksum/config: df3de6275280d65eb256e11acbd827e974a683764acc280359fd6bee9d7363d5
                 labels:
                   app.kubernetes.io/component: jenkins-controller
                   app.kubernetes.io/instance: my-release

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -193,7 +193,7 @@ controller:
   installPlugins:
     - kubernetes:1.27.6
     - workflow-aggregator:2.6
-    - git:4.4.5
+    - git:4.5.2
     - configuration-as-code:1.46
 
   # List of plugins to install in addition to those listed in controller.installPlugins


### PR DESCRIPTION
# What this PR does / why we need it

This PR is upgrading the Git plugin from v4.4.5 to v4.5.2. Without this change, the BlueOcean plugin in the latest version fails to install and requires to override all plugins in `controller.installPlugins`.

# Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
