### PR TITLE
Apply namespaceOverride when loading JCasC

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.1.5
+
+Fix `namespaceOverride` not applied when loading JCasC
+
 ## 3.1.4
 
 Update Git plugin version to v4.5.2

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.1.4
+version: 3.1.5
 appVersion: 2.263.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -244,7 +244,7 @@ spec:
             - name: FOLDER
               value: "{{ .Values.controller.sidecars.configAutoReload.folder }}"
             - name: NAMESPACE
-              value: "{{ .Values.controller.sidecars.configAutoReload.searchNamespace | default .Release.Namespace }}"
+              value: '{{ .Values.controller.sidecars.configAutoReload.searchNamespace | default (include "jenkins.namespace" .) }}'
             - name: REQ_URL
               value: "http://localhost:{{- .Values.controller.targetPort -}}{{- .Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
             - name: REQ_METHOD


### PR DESCRIPTION
Signed-off-by: James Fogarty <jayfo@users.noreply.github.com>

# What this PR does / why we need it

Applies `namespaceOverride` to sidecar that loads JCasC.

# Which issue this PR fixes

Fixes #237 

# Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
