### PR TITLE
Fixing bug when setting agentListenerServiceType to NodePort

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -11,6 +11,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
+## 3.1.10
+
+Fixed issue for the AgentListener where it was not possible to attribute a NodePort
+
 ## 3.1.9
 
 Upgrade kubernetes plugin t0 1.29.0 and CasC plugin to 1.47

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.1.9
+version: 3.1.10
 appVersion: 2.263.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -84,6 +84,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | -------------------------------------------- | ----------------------------------------------- | ------------ |
 | `controller.agentListenerPort`               | Listening port for agents                       | `50000`      |
 | `controller.agentListenerHostPort`           | Host port to listen for agents                  | Not set      |
+| `controller.agentListenerNodePort`           | Node port to listen for agents                  | Not set      |
 | `controller.agentListenerServiceType`        | Defines how to expose the agentListener service | `ClusterIP`  |
 | `controller.agentListenerServiceAnnotations` | Annotations for the agentListener service       | `{}`         |
 | `controller.agentListenerLoadBalancerIP`     | Static IP for the agentListener LoadBalancer    | Not set      |

--- a/charts/jenkins/templates/jenkins-agent-svc.yaml
+++ b/charts/jenkins/templates/jenkins-agent-svc.yaml
@@ -19,8 +19,8 @@ spec:
   ports:
     - port: {{ .Values.controller.agentListenerPort }}
       targetPort: {{ .Values.controller.agentListenerPort }}
-      {{- if (and (eq .Values.controller.agentListenerServiceType "NodePort") (not (empty .Values.controller.agentListenerPort))) }}
-      nodePort: {{ .Values.controller.agentListenerPort }}
+      {{- if (and (eq .Values.controller.agentListenerServiceType "NodePort") (not (empty .Values.controller.agentListenerNodePort))) }}
+      nodePort: {{ .Values.controller.agentListenerNodePort }}
       {{- end }}
       name: agent-listener
   selector:

--- a/charts/jenkins/tests/jenkins-agent-svc-test.yaml
+++ b/charts/jenkins/tests/jenkins-agent-svc-test.yaml
@@ -56,7 +56,7 @@ tests:
               app.kubernetes.io/component: jenkins-controller
               app.kubernetes.io/instance: my-release
             type: ClusterIP
-  - it: node port
+  - it: node port random
     set:
       controller:
         agentListenerServiceType: NodePort
@@ -66,9 +66,26 @@ tests:
           value:
             ports:
             - name: agent-listener
-              nodePort: 50000
               port: 50000
               targetPort: 50000
+            selector:
+              app.kubernetes.io/component: jenkins-controller
+              app.kubernetes.io/instance: my-release
+            type: NodePort
+  - it: node port defined
+    set:
+      controller:
+        agentListenerServiceType: NodePort
+        agentListenerNodePort: 32123
+    asserts:
+      - equal:
+          path: spec
+          value:
+            ports:
+            - name: agent-listener
+              port: 50000
+              targetPort: 50000
+              nodePort: 32123
             selector:
               app.kubernetes.io/component: jenkins-controller
               app.kubernetes.io/instance: my-release

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -146,6 +146,7 @@ controller:
       timeoutSeconds: 5
   agentListenerPort: 50000
   agentListenerHostPort:
+  agentListenerNodePort:
   disabledAgentProtocols:
     - JNLP-connect
     - JNLP2-connect


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

Need to expose the agent listener port to add external agents via JNLP (e.g.: using the swarm plugin).
There is a bug now, when specifying the agentListenerServiceType to NodePort, is will automatically assign the agentListenerPort to the nodePort value of the service. This results in a kubernetes exception as the default port 50000 from agentListenerPort is out of range of the default NodePort range of kubernetes (30000-32767).
I added an optional value controller.agentListenerNodePort that allows to set a node port of generate a random one by Kubernetes if not specified.

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
