### PR TITLE
Fix rendering of controller.ingress.path

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.2.3
+
+Fix rendering `controller.ingress.path`
+
 ## 3.2.2
 
 Added description for `controller.jenkinsUrl` value

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.2.2
+version: 3.2.3
 appVersion: 2.263.4
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-ingress.yaml
@@ -42,11 +42,11 @@ spec:
           serviceName: {{ template "jenkins.fullname" . }}
           servicePort: {{ .Values.controller.servicePort }}
 {{ end }}
-{{- else }}
-{{ tpl (toYaml .Values.controller.ingress.paths | indent 6) . }}
 {{- if .Values.controller.ingress.path }}
         path: {{ .Values.controller.ingress.path }}
 {{- end -}}
+{{- else }}
+{{ tpl (toYaml .Values.controller.ingress.paths | indent 6) . }}
 {{- end -}}
 {{- if .Values.controller.ingress.hostName }}
     host: {{ .Values.controller.ingress.hostName | quote }}

--- a/charts/jenkins/tests/jenkins-controller-ingress-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-ingress-test.yaml
@@ -123,3 +123,18 @@ tests:
                 - backend:
                     serviceName: my-release-jenkins
                     servicePort: 8080
+  - it: single path
+    set:
+      controller.ingress:
+        enabled: true
+        path: /jenkins/
+    asserts:
+    - equal:
+        path: spec.rules
+        value:
+          - http:
+              paths:
+                - path: /jenkins/
+                  backend:
+                    serviceName: my-release-jenkins
+                    servicePort: 8080


### PR DESCRIPTION
# What this PR does / why we need it

Fixes rendering `controller.ingress.path` options. It does not make sense to put it under the branch of when `paths` are explicitly defined, it should be in the block where `paths` are empty.

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
