### PR TITLE
Add images metadata for artifacthub

### DIFF
--- a/.github/workflows/sync-lts.yaml
+++ b/.github/workflows/sync-lts.yaml
@@ -53,6 +53,11 @@ jobs:
         run: |
           sed -i -e '1h;2,$H;$!d;g' -re 's|(jenkins/jenkins"\n  tag: ")[0-9]+\.[0-9]+\.[0-9]+(")|\1${{ steps.lts.outputs.jenkins_version }}\2|' charts/jenkins/values.yaml
 
+      - name: Update artifacthub.images in Chart.yaml
+        if: ${{ steps.update.outputs.available == 'true' }}
+        run: |
+          sed -i 's|jenkins/jenkins.*|jenkins/jenkins:${{ steps.lts.outputs.jenkins_version }}|' charts/jenkins/Chart.yaml
+
       - name: Changelog
         if: ${{ steps.update.outputs.available == 'true' }}
         run: |

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.2.5
+
+Add additional metadata `artifacthub.io/images` for artifacthub
+
 ## 3.2.4
 Update Jenkins image and appVersion to jenkins lts release version 2.277.1
 Update Git plugin version to v4.6.0

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.2.4
+version: 3.2.5
 appVersion: 2.277.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
@@ -22,8 +22,17 @@ maintainers:
     email: timjacomb1@gmail.com
 icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png
 annotations:
-  "artifacthub.io/links": |
+  artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/jenkinsci/helm-charts/tree/main/charts/jenkins
     - name: Jenkins
       url: https://www.jenkins.io/
+  artifacthub.io/images: |
+    - name: jenkins
+      image: jenkins/jenkins:2.277.1
+    - name: k8s-sidecar
+      image: kiwigrid/k8s-sidecar:0.1.275
+    - name: inbound-agent
+      image: jenkins/inbound-agent:4.6-1
+    - name: backup
+      image: maorfr/kube-tasks:0.2.0


### PR DESCRIPTION
Was mentioned on IRC:

<halkeye[m]> dev.g4v:halkeye 
timja: btw, we should claim artifacthub repo ownership, and adding the artifacthub annotations - https://artifacthub.io/packages/helm/halkeye/wallabag  - changelog and docker image security scans
11:38 PM 
(i'll do it eventually, just super distracted right now)