### PR TITLE
Add missing controller.jenkinsUrlProtocol useful when not using ingre…

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.2.6
+
+Add missing `controller.jenkinsUrlProtocol` property
+
 ## 3.2.5
 
 Add additional metadata `artifacthub.io/images` for artifacthub

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.2.5
+version: 3.2.6
 appVersion: 2.277.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -75,6 +75,10 @@ controller:
   # Set min/max heap here if needed with:
   # javaOpts: "-Xms512m -Xmx512m"
   # jenkinsOpts: ""
+  # If you are using the ingress definitions provided by this chart via the `controller.ingress` block the configured hostname will be the ingress hostname starting with `https://` or `http://` depending on the `tls` configuration.
+  # The Protocol can be overwritten by specifying `controller.jenkinsUrlProtocol`.
+  # jenkinsUrlProtocol: "https"
+  # If you are not using the provided ingress you can specify `controller.jenkinsUrl` to change the url definition.
   # jenkinsUrl: ""
   # If you set this prefix and use ingress controller then you might want to set the ingress path below
   # jenkinsUriPrefix: "/jenkins"


### PR DESCRIPTION
Add missing `controller.jenkinsUrlProtocol` property in `values` as referenced in the [README](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/README.md#external-url-configuration)

It is required to specify `https` when using `googleOAuth2` with an external `ingress`. Otherwise, the internal redirect uses `http` and it is not allowed in google console.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

@timja 
@mogaal 
@maorfr 
@torstenwalter
@wmcdona89