### PR TITLE
Change default image to jdk11 variant

### DIFF
--- a/.github/workflows/sync-lts.yaml
+++ b/.github/workflows/sync-lts.yaml
@@ -33,6 +33,7 @@ jobs:
             echo "::set-output name=available::false"
           else
             echo "::set-output name=available::true"
+            echo "::set-output name=current-version::$CURRENT_VERSION"
           fi
 
       - name: Update appVersion in Chart.yaml
@@ -57,6 +58,11 @@ jobs:
         if: ${{ steps.update.outputs.available == 'true' }}
         run: |
           sed -i 's|jenkins/jenkins.*|jenkins/jenkins:${{ steps.lts.outputs.jenkins_version }}|' charts/jenkins/Chart.yaml
+
+      - name: Update controller.tag in VALUES_SUMMARY.md
+        if: ${{ steps.update.outputs.available == 'true' }}
+        run: |
+          sed -i 's|${{ steps.update.outputs.current-version }}|${{ steps.lts.outputs.jenkins_version }}|' charts/jenkins/VALUES_SUMMARY.md
 
       - name: Changelog
         if: ${{ steps.update.outputs.available == 'true' }}

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.0
+
+Change default Jenkins image to `jdk11` variant
+
 ## 3.2.6
 
 Add missing `controller.jenkinsUrlProtocol` property

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.2.6
+version: 3.3.0
 appVersion: 2.277.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
@@ -29,7 +29,7 @@ annotations:
       url: https://www.jenkins.io/
   artifacthub.io/images: |
     - name: jenkins
-      image: jenkins/jenkins:2.277.1
+      image: jenkins/jenkins:2.277.1-jdk11
     - name: k8s-sidecar
       image: kiwigrid/k8s-sidecar:0.1.275
     - name: inbound-agent

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -95,7 +95,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `controller.image`                    | Controller image name                     | `jenkins/jenkins`                         |
-| `controller.tag`                      | Controller image tag                      | `lts`                                     |
+| `controller.tag`                      | Controller image tag                      | `2.277.1-jdk11`                           |
 | `controller.imagePullPolicy`          | Controller image pull policy              | `Always`                                  |
 | `controller.imagePullSecretName`      | Controller image pull secret              | Not set                                   |
 | `controller.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 4096Mi}}`|

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -67,7 +67,7 @@ tests:
                     value: "50000"
                   - name: CASC_JENKINS_CONFIG
                     value: /var/jenkins_home/casc_configs
-                  image: jenkins/jenkins:2.277.1
+                  image: jenkins/jenkins:2.277.1-jdk11
                   imagePullPolicy: Always
                   livenessProbe:
                     failureThreshold: 5
@@ -153,7 +153,7 @@ tests:
                 - command:
                   - sh
                   - /var/jenkins_config/apply_config.sh
-                  image: jenkins/jenkins:2.277.1
+                  image: jenkins/jenkins:2.277.1-jdk11
                   imagePullPolicy: Always
                   name: init
                   resources:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -19,7 +19,7 @@ controller:
   # Used for label app.kubernetes.io/component
   componentName: "jenkins-controller"
   image: "jenkins/jenkins"
-  tag: "2.277.1"
+  tag: "2.277.1-jdk11"
   imagePullPolicy: "Always"
   imagePullSecretName:
   # Optionally configure lifetime for controller-container


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

Changes the default image to jdk11, this follows on from changing the official docs to use jdk11 images everywhere and is a gradual move away from Java 8.

I'm not sure if this fits into a semver minor, happy to move it to a major just let me know

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
