### PR TITLE
Add Ingress example for Kubernetes 1.19+ and apiVersion: "networking.k8s.io/v1"

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.1
+
+Add ingress configuration example for Kubernetes v1.19+ if apiVersion: "networking.k8s.io/v1" is used
+
 ## 3.3.0
 
 Change default Jenkins image to `jdk11` variant

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,9 +12,13 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
-## 3.3.1
+## 3.3.2
 
 Add ingress configuration example for Kubernetes v1.19+ if apiVersion: "networking.k8s.io/v1" is used
+
+## 3.3.1
+
+Allow specifying additional Secrets for controller
 
 ## 3.3.0
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.0
+version: 3.3.1
 appVersion: 2.277.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.1
+version: 3.3.2
 appVersion: 2.277.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-ingress.yaml
@@ -1,12 +1,6 @@
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if .Values.controller.ingress.enabled }}
-{{- if semverCompare ">=1.19-0" $kubeTargetVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" $kubeTargetVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
 apiVersion: {{ .Values.controller.ingress.apiVersion }}
-{{- end }}
 kind: Ingress
 metadata:
   namespace: {{ template "jenkins.namespace" . }}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -343,8 +343,14 @@ controller:
 
   ingress:
     enabled: false
+    # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
+    apiVersion: "extensions/v1beta1"
+    # For Kubernetes v1.19+, use 'networking.k8s.io/v1'
+    # apiVersion: "networking.k8s.io/v1"
+
     # Override for the default paths that map requests to the backend
     paths: []
+    # For Kubernetes v1.14+, if apiVersion: "extensions/v1beta1"
     # - backend:
     #     serviceName: ssl-redirect
     #     servicePort: use-annotation
@@ -353,9 +359,20 @@ controller:
     #       {{ template "jenkins.fullname" . }}
     #     # Don't use string here, use only integer value!
     #     servicePort: 8080
-    # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
-    # For Kubernetes v1.19+, use 'networking.k8s.io/v1'
-    apiVersion: "extensions/v1beta1"
+    # For Kubernetes v1.19+, if apiVersion: "networking.k8s.io/v1"
+    #  - backend:
+    #      service:
+    #        name: ssl-redirect
+    #        port:
+    #          name: use-annotation
+    #    pathType: ImplementationSpecific
+    #  - backend:
+    #      service:
+    #        name: >-
+    #          {{ template "jenkins.fullname" . }}
+    #        port:
+    #          number: 8080
+    #    pathType: ImplementationSpecific
     labels: {}
     annotations: {}
     # kubernetes.io/ingress.class: nginx

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -514,7 +514,7 @@ controller:
 agent:
   enabled: true
   defaultsProviderTemplate: ""
-  # URL for connecting to the Jenkins contoller
+  # URL for connecting to the Jenkins controller
   jenkinsUrl:
   # connect to the specified host and port, instead of connecting directly to the Jenkins controller
   jenkinsTunnel:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -343,14 +343,14 @@ controller:
 
   ingress:
     enabled: false
-    # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
+    # For Kubernetes >=v1.14 and <v1.19, use 'networking.k8s.io/v1beta1'
     apiVersion: "extensions/v1beta1"
     # For Kubernetes v1.19+, use 'networking.k8s.io/v1'
     # apiVersion: "networking.k8s.io/v1"
 
     # Override for the default paths that map requests to the backend
     paths: []
-    # For Kubernetes v1.14+, if apiVersion: "extensions/v1beta1"
+    # For Kubernetes >=v1.14 and <v1.19, if apiVersion: "extensions/v1beta1"
     # - backend:
     #     serviceName: ssl-redirect
     #     servicePort: use-annotation
@@ -395,7 +395,7 @@ controller:
     # paths you want forwarded to the backend
     # ex /github-webhook
     paths: []
-    # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
+    # For Kubernetes >=v1.14 and <v1.19, use 'networking.k8s.io/v1beta1'
     # For Kubernetes v1.19+, use 'networking.k8s.io/v1'
     apiVersion: "extensions/v1beta1"
     labels: {}


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it
This PR adds example how to configure paths in Ingress object with `apiVersion: "networking.k8s.io/v1"` that used in Kubernetes 1.19+
Ingress 

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
