### PR TITLE
Enable --latest flag for the jenkins-plugin-cli in the init container

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.3
+
+Enable setting `controller.installLatestPlugins` to set whether to download the minimum required version of all dependencies.
+
 ## 3.3.2
 
 Add `controller.additionalSecrets` documentation

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -79,7 +79,7 @@ Fixed issue for the AgentListener where it was not possible to attribute a NodeP
 
 ## 3.1.9
 
-Upgrade kubernetes plugin t0 1.29.0 and CasC plugin to 1.47
+Upgrade kubernetes plugin to 1.29.0 and CasC plugin to 1.47
 
 ## 3.1.8
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.2
+version: 3.3.3
 appVersion: 2.277.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -78,6 +78,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.initializeOnce`       | Initialize only on first install. Ensures plugins do not get updated inadvertently. Requires `persistence.enabled` to be set to `true`. | `false` |
 | `controller.overwritePlugins`     | Overwrite installed plugins on start.| `false`                                   |
 | `controller.overwritePluginsFromImage` | Keep plugins that are already installed in the controller image.| `true`            |
+| `controller.installLatestPlugins`      | Set to false to download the minimum required version of all dependencies. | `false` |
 
 #### Jenkins Agent Listener
 

--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -35,7 +35,7 @@ data:
     rm -rf {{ .Values.controller.jenkinsRef }}/plugins/*.lock
     version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
     if [ -f "{{ .Values.controller.jenkinsWar }}" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-      jenkins-plugin-cli --war "{{ .Values.controller.jenkinsWar }}" --plugin-file "{{ .Values.controller.jenkinsHome }}/plugins.txt";
+      jenkins-plugin-cli --war "{{ .Values.controller.jenkinsWar }}" --plugin-file "{{ .Values.controller.jenkinsHome }}/plugins.txt" --latest {{ .Values.controller.installLatestPlugins }};
     else
       /usr/local/bin/install-plugins.sh `echo $(cat {{ .Values.controller.jenkinsHome }}/plugins.txt)`;
     fi

--- a/charts/jenkins/tests/config-test.yaml
+++ b/charts/jenkins/tests/config-test.yaml
@@ -29,7 +29,7 @@ tests:
             rm -rf /usr/share/jenkins/ref/plugins/*.lock
             version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
             if [ -f "/usr/share/jenkins/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt";
+              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest false;
             else
               /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
             fi
@@ -80,7 +80,7 @@ tests:
             rm -rf /usr/share/jenkins/ref/plugins/*.lock
             version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
             if [ -f "/usr/share/jenkins/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt";
+              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest false;
             else
               /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
             fi
@@ -96,3 +96,36 @@ tests:
             git:4.6.0
             configuration-as-code:1.47
             kubernetes-credentials-provider
+  - it: install latest plugins
+    set:
+      controller.installLatestPlugins: true
+    asserts:
+      - equal:
+          path: data.apply_config\.sh
+          value: |-
+            set -e
+            echo "disable Setup Wizard"
+            # Prevent Setup Wizard when JCasC is enabled
+            echo $JENKINS_VERSION > /var/jenkins_home/jenkins.install.UpgradeWizard.state
+            echo $JENKINS_VERSION > /var/jenkins_home/jenkins.install.InstallUtil.lastExecVersion
+            echo "download plugins"
+            # Install missing plugins
+            cp /var/jenkins_config/plugins.txt /var/jenkins_home;
+            rm -rf /usr/share/jenkins/ref/plugins/*.lock
+            version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+            if [ -f "/usr/share/jenkins/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
+              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest true;
+            else
+              /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+            fi
+            echo "copy plugins to shared volume"
+            # Copy plugins to shared volume
+            yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
+            echo "finished initialization"
+      - equal:
+          path: data.plugins\.txt
+          value: |-
+            kubernetes:1.29.2
+            workflow-aggregator:2.6
+            git:4.6.0
+            configuration-as-code:1.47

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -44,7 +44,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: 8ce33705643160d06b4062deacb00ee60e290dc4bd9069053b81dcac91279785
+                  checksum/config: 89183888d634af5f963ae86d045f36b06026324e3540e15c8cc8e292045a7ce3
                 labels:
                   app.kubernetes.io/component: jenkins-controller
                   app.kubernetes.io/instance: my-release

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -207,6 +207,9 @@ controller:
     - git:4.6.0
     - configuration-as-code:1.47
 
+  # Set to false to download the minimum required version of all dependencies.
+  installLatestPlugins: false
+
   # List of plugins to install in addition to those listed in controller.installPlugins
   additionalPlugins: []
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

Configure the plugin-installation-manager-tool to skip latest when the whole list of plugins have been defined with the installPlugins.

This should help to bump the version of all the plugins when upgrading the helm.

For instance, if bumping a version of an explicit plugin, then `helm upgrade`, if any of the other explicit plugins have been released with a new version, the init container will fail if all plugins were not bumped. 

It adds the latest flag -> https://github.com/jenkinsci/plugin-installation-manager-tool#cli-options

# Which issue this PR fixes

- https://github.com/jenkinsci/plugin-installation-manager-tool/issues/318

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
