### PR TITLE
[jcasc-config] add option to use secrets instead of configmaps

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,10 +12,13 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.4.0
+
+Add option to use Secrets instead of ConfigMaps for storing JCasC
+
 ## 3.3.4
 
 Update Jenkins image and appVersion to jenkins lts release version 2.277.2
-
 
 ## 3.3.3
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.5
+version: 3.4.0
 appVersion: 2.277.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -21,9 +21,10 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.JCasC.defaultConfig`      | Enables default Jenkins configuration via configuration as code plugin | `true`  |
-| `controller.JCasC.configScripts`      | List of Jenkins Config as Code scripts | `{}`                                    |
-| `controller.JCasC.securityRealm`      | Jenkins Config as Code for Security Realm | `legacy`                             |
+| `controller.JCasC.secret`         | Create JCasC as Secrets rather than ConfigMaps | `false`  |
+| `controller.JCasC.defaultConfig`  | Enables default Jenkins configuration via configuration as code plugin | `true`  |
+| `controller.JCasC.configScripts`  | List of Jenkins Config as Code scripts | `{}`                                    |
+| `controller.JCasC.securityRealm`  | Jenkins Config as Code for Security Realm | `legacy`                             |
 | `controller.JCasC.authorizationStrategy` | Jenkins Config as Code for Authorization Strategy | `loggedInUsersCanDoAnything` |
 | `controller.sidecars.configAutoReload` | Jenkins Config as Code auto-reload settings |                                   |
 | `controller.sidecars.configAutoReload.enabled` | Jenkins Config as Code auto-reload settings (Attention: rbac needs to be enabled otherwise the sidecar can't read the config map) | `true`                                                      |

--- a/charts/jenkins/ci/other-values.yaml
+++ b/charts/jenkins/ci/other-values.yaml
@@ -4,6 +4,7 @@ controller:
   runAsUser: 0
   fsGroup: 1000
   JCasC:
+    secret: true
     authorizationStrategy: |-
       loggedInUsersCanDoAnything:
         allowAnonymousRead: true

--- a/charts/jenkins/templates/jcasc-config.yaml
+++ b/charts/jenkins/templates/jcasc-config.yaml
@@ -4,7 +4,7 @@
 {{- if $val }}
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: {{ if $root.Values.controller.JCasC.secret }}Secret{{ else }}ConfigMap{{ end }}
 metadata:
   name: {{ template "jenkins.fullname" $root }}-jenkins-config-{{ $key }}
   namespace: {{ template "jenkins.namespace" $root }}
@@ -19,13 +19,17 @@ metadata:
     {{ template "jenkins.fullname" $root }}-jenkins-config: "true"
 data:
   {{ $key }}.yaml: |-
-{{ tpl $val $| indent 4 }}
+    {{- if $root.Values.controller.JCasC.secret }}
+    {{- tpl $val $ | b64enc | nindent 4 }}
+    {{- else }}
+    {{- tpl $val $ | nindent 4 }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.controller.JCasC.defaultConfig }}
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: {{ if .Values.controller.JCasC.secret }}Secret{{ else }}ConfigMap{{ end }}
 metadata:
   name: {{ template "jenkins.fullname" $root }}-jenkins-jcasc-config
   namespace: {{ template "jenkins.namespace" $root }}
@@ -40,6 +44,10 @@ metadata:
     {{ template "jenkins.fullname" $root }}-jenkins-config: "true"
 data:
   jcasc-default-config.yaml: |-
-    {{- include "jenkins.casc.defaults" . |nindent 4 }}
+    {{- if $root.Values.controller.JCasC.secret }}
+    {{- include "jenkins.casc.defaults" . | b64enc | nindent 4 }}
+    {{- else }}
+    {{- include "jenkins.casc.defaults" . | nindent 4 }}
+    {{- end }}
 {{- end}}
 {{- end }}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -257,6 +257,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- if $root.Values.controller.JCasC.secret }}
+            - name: RESOURCE
+              value: secret
+            {{- end }}
             - name: LABEL
               value: "{{ template "jenkins.fullname" . }}-jenkins-config"
             - name: FOLDER
@@ -301,13 +305,8 @@ spec:
           name: {{ template "jenkins.fullname" . }}-init-scripts
       {{- end }}
       - name: jenkins-config
-        {{- if .Values.controller.JCasC.secret }}
-        secret:
-          secretName: {{ template "jenkins.fullname" . }}
-        {{- else }}
         configMap:
           name: {{ template "jenkins.fullname" . }}
-        {{- end }}
       {{- if .Values.controller.installPlugins }}
       - name: plugin-dir
         emptyDir: {}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -301,8 +301,13 @@ spec:
           name: {{ template "jenkins.fullname" . }}-init-scripts
       {{- end }}
       - name: jenkins-config
+        {{- if $root.Values.controller.JCasC.secret }}
+        secret:
+          secretName: {{ template "jenkins.fullname" . }}
+        {{- else }}
         configMap:
           name: {{ template "jenkins.fullname" . }}
+        {{- end }}
       {{- if .Values.controller.installPlugins }}
       - name: plugin-dir
         emptyDir: {}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -257,7 +257,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            {{- if $root.Values.controller.JCasC.secret }}
+            {{- if .Values.controller.JCasC.secret }}
             - name: RESOURCE
               value: secret
             {{- end }}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -301,7 +301,7 @@ spec:
           name: {{ template "jenkins.fullname" . }}-init-scripts
       {{- end }}
       - name: jenkins-config
-        {{- if $root.Values.controller.JCasC.secret }}
+        {{- if .Values.controller.JCasC.secret }}
         secret:
           secretName: {{ template "jenkins.fullname" . }}
         {{- else }}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -248,6 +248,7 @@ controller:
   # become the content of the configuration yaml file.  The first line after this is a JCasC root element, eg jenkins, credentials,
   # etc.  Best reference is https://<jenkins_url>/configuration-as-code/reference.  The example below creates a welcome message:
   JCasC:
+    secret: false
     defaultConfig: true
     configScripts: {}
     #  welcome-message: |

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -248,6 +248,8 @@ controller:
   # become the content of the configuration yaml file.  The first line after this is a JCasC root element, eg jenkins, credentials,
   # etc.  Best reference is https://<jenkins_url>/configuration-as-code/reference.  The example below creates a welcome message:
   JCasC:
+    # If set, store JCasC as Secrets instead of ConfigMaps.
+    # Note: if you're setting this to protect credentials, the better way to do this is to set the credentials in .additionalSecrets and use the Kubernetes Credentials Provider (see https://plugins.jenkins.io/kubernetes-credentials-provider/)
     secret: false
     defaultConfig: true
     configScripts: {}


### PR DESCRIPTION
Signed-off-by: Alice Sawatzky <alice.sawatzky@farmersedge.ca>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

Adds an option to have JCasC stored as a Secret. Important when Credentials are set via JCasC.

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
