### PR TITLE
feat(jcasc): add additionalExistingSecrets capability

### DIFF
--- a/.github/workflows/sync-lts.yaml
+++ b/.github/workflows/sync-lts.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: next release version
         id: nextversion
-        uses: jenkins-x-plugins/jx-release-version@v2.4.2
+        uses: jenkins-x-plugins/jx-release-version@v2.4.4
         with:
           previous-version: from-file:charts/jenkins/Chart.yaml
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.10
+
+Add `controller.additionalExternalSecrets` property
+
 ## 3.3.9
 * Change helper template so user defined `agent.jenkinsUrl` value will always be used, if set
 * Simplify logic for `jenkinsUrl` and `jenkinsTunnel` generation: always use fully qualified address

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 3.3.10
 
-Add `controller.additionalExternalSecrets` property
+Add `controller.additionalExistingSecrets` property
 
 ## 3.3.9
 * Change helper template so user defined `agent.jenkinsUrl` value will always be used, if set

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.9
+version: 3.3.10
 appVersion: 2.277.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -342,7 +342,7 @@ If the storage class is set to null or left undefined (`""`), the default provis
 #### Additional Secrets
 
 Additional secrets and Additional External Secrets, 
-can be mounted into the Jenkins controller through the chart or created using `controller.additionalSecrets` or `controller.additionalExternalSecrets`. 
+can be mounted into the Jenkins controller through the chart or created using `controller.additionalSecrets` or `controller.additionalExistingSecrets`. 
 A common use case might be identity provider credentials if using an external LDAP or OIDC-based identity provider.
 The secret may then be referenced in JCasC configuration (see [JCasC configuration](#configuration-as-code)).
 
@@ -351,7 +351,7 @@ The secret may then be referenced in JCasC configuration (see [JCasC configurati
 controller:
   # 'name' and 'keyName' must be lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
   # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
-  additionalExternalSecrets:
+  additionalExistingSecrets:
     - name: secret-credentials
       keyName: github-username
     - name: secret-credentials

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -341,12 +341,24 @@ If the storage class is set to null or left undefined (`""`), the default provis
 
 #### Additional Secrets
 
-Additional secrets can be mounted into the Jenkins controller through the chart or created using `controller.additionalSecrets`. A common use case might be identity provider credentials if using an external LDAP or OIDC-based identity provider.
+Additional secrets and Additional External Secrets, 
+can be mounted into the Jenkins controller through the chart or created using `controller.additionalSecrets` or `controller.additionalExternalSecrets`. 
+A common use case might be identity provider credentials if using an external LDAP or OIDC-based identity provider.
 The secret may then be referenced in JCasC configuration (see [JCasC configuration](#configuration-as-code)).
 
 `values.yaml` controller section, referencing mounted secrets:
 ```yaml
 controller:
+  # 'name' and 'keyName' must be lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
+  # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
+  additionalExternalSecrets:
+    - name: secret-credentials
+      keyName: github-username
+    - name: secret-credentials
+      keyName: github-password
+   - name: secret-credentials
+      keyName: token
+  
   additionalSecrets:
     - name: client_id
       value: abc123
@@ -358,6 +370,23 @@ controller:
         clientId: ${client_id}
         clientSecret: ${client_secret}
         ...
+    configScripts:
+      jenkins-casc-configs: |
+        credentials:
+          system:
+            domainCredentials:
+            - credentials:
+              - string:
+                  description: "github access token"
+                  id: "github_app_token"
+                  scope: GLOBAL
+                  secret: ${secret-credentials-token}
+              - usernamePassword:
+                  description: "github access username password"
+                  id: "github_username_pass"
+                  password: ${secret-credentials-github-password}
+                  scope: GLOBAL
+                  username: ${secret-credentials-github-username}
 ```
 
 For more information, see [JCasC documentation](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets).

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -341,8 +341,8 @@ If the storage class is set to null or left undefined (`""`), the default provis
 
 #### Additional Secrets
 
-Additional secrets and Additional External Secrets, 
-can be mounted into the Jenkins controller through the chart or created using `controller.additionalSecrets` or `controller.additionalExistingSecrets`. 
+Additional secrets and Additional External Secrets,
+can be mounted into the Jenkins controller through the chart or created using `controller.additionalSecrets` or `controller.additionalExistingSecrets`.  
 A common use case might be identity provider credentials if using an external LDAP or OIDC-based identity provider.
 The secret may then be referenced in JCasC configuration (see [JCasC configuration](#configuration-as-code)).
 

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -341,7 +341,7 @@ If the storage class is set to null or left undefined (`""`), the default provis
 
 #### Additional Secrets
 
-Additional secrets and Additional External Secrets,
+Additional secrets and Additional Existing Secrets,
 can be mounted into the Jenkins controller through the chart or created using `controller.additionalSecrets` or `controller.additionalExistingSecrets`.  
 A common use case might be identity provider credentials if using an external LDAP or OIDC-based identity provider.
 The secret may then be referenced in JCasC configuration (see [JCasC configuration](#configuration-as-code)).
@@ -349,6 +349,8 @@ The secret may then be referenced in JCasC configuration (see [JCasC configurati
 `values.yaml` controller section, referencing mounted secrets:
 ```yaml
 controller:
+  # the 'name' and 'keyName' are concatenated with a '-' in between, so for example:
+  # an existing secret "secret-credentials" and a key inside it named "github-password" should be used in Jcasc as ${secret-credentials-github-password}
   # 'name' and 'keyName' must be lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
   # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
   additionalExistingSecrets:
@@ -356,7 +358,7 @@ controller:
       keyName: github-username
     - name: secret-credentials
       keyName: github-password
-   - name: secret-credentials
+    - name: secret-credentials
       keyName: token
   
   additionalSecrets:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -226,7 +226,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.adminUser`                | Admin username (and password) created as a secret if adminSecret is true | `admin` |
 | `controller.adminPassword`            | Admin password (and user) created as a secret if adminSecret is true | Random value |
 | `controller.additionalSecrets`        | List of additional secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
-| `controller.additionalExternalSecrets`| List of additional external secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
+| `controller.additionalExistingSecrets`| List of additional existing secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
 
 #### Kubernetes NetworkPolicy
 

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -226,7 +226,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.adminUser`                | Admin username (and password) created as a secret if adminSecret is true | `admin` |
 | `controller.adminPassword`            | Admin password (and user) created as a secret if adminSecret is true | Random value |
 | `controller.additionalSecrets`        | List of additional secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
-| `controller.additionalExistingSecrets`| List of additional existing secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
+| `controller.additionalExistingSecrets`| List of additional existing secrets to mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
 
 #### Kubernetes NetworkPolicy
 

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -226,6 +226,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.adminUser`                | Admin username (and password) created as a secret if adminSecret is true | `admin` |
 | `controller.adminPassword`            | Admin password (and user) created as a secret if adminSecret is true | Random value |
 | `controller.additionalSecrets`        | List of additional secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
+| `controller.additionalExternalSecrets`| List of additional external secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
 
 #### Kubernetes NetworkPolicy
 

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -247,7 +247,7 @@ spec:
               subPath: {{ .name }}
               readOnly: true
             {{- end }}
-            {{- range $key, $value := .Values.controller.additionalExternalSecrets }}
+            {{- range $key, $value := .Values.controller.additionalExistingSecrets }}
             - name: {{ $value.name }}-{{ $value.keyName }}
               mountPath: /run/secrets/{{ $value.name }}-{{ $value.keyName }}
               subPath: {{ $value.keyName }}
@@ -318,8 +318,8 @@ spec:
         secret:
           secretName: {{ template "jenkins.fullname" . }}-additional-secrets
       {{- end }}
-      {{- if .Values.controller.additionalExternalSecrets }}
-      {{- range $key, $value := .Values.controller.additionalExternalSecrets }}
+      {{- if .Values.controller.additionalExistingSecrets }}
+      {{- range $key, $value := .Values.controller.additionalExistingSecrets }}
       - name: {{ $value.name }}-{{ $value.keyName }}
         secret:
           secretName: {{ $value.name }}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -247,6 +247,12 @@ spec:
               subPath: {{ .name }}
               readOnly: true
             {{- end }}
+            {{- range $key, $value := .Values.controller.additionalExternalSecrets }}
+            - name: {{ $value.name }}-{{ $value.keyName }}
+              mountPath: /run/secrets/{{ $value.name }}-{{ $value.keyName }}
+              subPath: {{ $value.keyName }}
+              readOnly: true
+            {{- end }}
 
 {{- if .Values.controller.sidecars.configAutoReload.enabled }}
         - name: config-reload
@@ -311,6 +317,13 @@ spec:
       - name: jenkins-additional-secrets
         secret:
           secretName: {{ template "jenkins.fullname" . }}-additional-secrets
+      {{- end }}
+      {{- if .Values.controller.additionalExternalSecrets }}
+      {{- range $key, $value := .Values.controller.additionalExternalSecrets }}
+      - name: {{ $value.name }}-{{ $value.keyName }}
+        secret:
+          secretName: {{ $value.name }}
+      {{- end }}
       {{- end }}
       {{- if not (contains "jenkins-home" (quote .Values.persistence.volumes)) }}
       - name: jenkins-home

--- a/charts/jenkins/tests/secret-existing-test.yaml
+++ b/charts/jenkins/tests/secret-existing-test.yaml
@@ -1,0 +1,43 @@
+suite: Controller Additional Existing Secrets
+release:
+  name: my-release
+  namespace: my-namespace
+templates:
+  - jenkins-controller-statefulset.yaml
+tests:
+  - it: test additional existing secrets StatefulSet
+    set:
+      controller.additionalExistingSecrets:
+        - name: secret-name-1
+          keyName: username
+        - name: secret-name-1
+          keyName: password
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[6]
+          value:
+            mountPath: /run/secrets/secret-name-1-username
+            name: secret-name-1-username
+            readOnly: true
+            subPath: username
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[7]
+          value:
+            mountPath: /run/secrets/secret-name-1-password
+            name: secret-name-1-password
+            readOnly: true
+            subPath: password
+      - equal:
+          path: spec.template.spec.volumes[3]
+          value:
+            name: secret-name-1-username
+            secret:
+              secretName: secret-name-1
+      - equal:
+          path: spec.template.spec.volumes[4]
+          value:
+            name: secret-name-1-password
+            secret:
+              secretName: secret-name-1

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -236,6 +236,16 @@ controller:
   #  - |
   #    print 'adding global pipeline libraries, register properties, bootstrap jobs...'
 
+  # 'name' and 'keyName' must be lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
+  # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
+  # 'name' is a name of an existing secret in same namespace as jenkins
+  # 'keyName' is the name of one of the keys inside current secret
+  additionalExternalSecrets: []
+  #  - name: secret-name-1
+  #    keyName: username
+  #  - name: secret-name-1
+  #    keyName: password
+
   additionalSecrets: []
   #  - name: nameOfSecret
   #    value: secretText

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -236,10 +236,12 @@ controller:
   #  - |
   #    print 'adding global pipeline libraries, register properties, bootstrap jobs...'
 
+  # 'name' is a name of an existing secret in same namespace as jenkins,
+  # 'keyName' is the name of one of the keys inside current secret.
+  # the 'name' and 'keyName' are concatenated with a '-' in between, so for example:
+  # an existing secret "secret-credentials" and a key inside it named "github-password" should be used in Jcasc as ${secret-credentials-github-password}
   # 'name' and 'keyName' must be lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
   # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
-  # 'name' is a name of an existing secret in same namespace as jenkins
-  # 'keyName' is the name of one of the keys inside current secret
   additionalExistingSecrets: []
   #  - name: secret-name-1
   #    keyName: username

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -240,7 +240,7 @@ controller:
   # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
   # 'name' is a name of an existing secret in same namespace as jenkins
   # 'keyName' is the name of one of the keys inside current secret
-  additionalExternalSecrets: []
+  additionalExistingSecrets: []
   #  - name: secret-name-1
   #    keyName: username
   #  - name: secret-name-1


### PR DESCRIPTION
@maorfr @torstenwalter @mogaal 

# What this PR does / why we need it
adds the ability to mount existing secrets to use with [kubernetes secrets jcasc](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets)

# Which issue this PR fixes

- fixes #334(, fixes #334)
# Special notes for your reviewer
the [Additional Secrets](https://github.com/jenkinsci/helm-charts/tree/main/charts/jenkins#additional-secrets) feature by itself does not resolve the issue of providing sensitive info to the chart.  
since the `value` key expects a sensitive secret, it cannot commit to git, thus the problem moved from `JCasC` property to `additionalSecrets`.
this feature aims to resolve the issue above.

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
