### PR TITLE
Add suppot for disabling the Agent listener service.

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,9 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
-## 3.3.10
+## 3.3.11
 Add support for disabling the Agent listener service via `controller.agentListenerEnabled`.
 
+## 3.3.10
 Update Jenkins image and appVersion to jenkins lts release version 2.277.4
 
 ## 3.3.9

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.10
+Add support for disabling the Agent listener service via `controller.agentListenerEnabled`.
+
 ## 3.3.9
 * Change helper template so user defined `agent.jenkinsUrl` value will always be used, if set
 * Simplify logic for `jenkinsUrl` and `jenkinsTunnel` generation: always use fully qualified address

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.10
+version: 3.3.11
 appVersion: 2.277.4
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.9
+version: 3.3.10
 appVersion: 2.277.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -84,6 +84,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Parameter                                    | Description                                     | Default      |
 | -------------------------------------------- | ----------------------------------------------- | ------------ |
+| `controller.agentListenerEnabled`            | Create Agent listener service                   | `true`       |
 | `controller.agentListenerPort`               | Listening port for agents                       | `50000`      |
 | `controller.agentListenerHostPort`           | Host port to listen for agents                  | Not set      |
 | `controller.agentListenerNodePort`           | Node port to listen for agents                  | Not set      |

--- a/charts/jenkins/templates/jenkins-agent-svc.yaml
+++ b/charts/jenkins/templates/jenkins-agent-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.agentListenerEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,4 +30,5 @@ spec:
   type: {{ .Values.controller.agentListenerServiceType }}
   {{- if and (eq .Values.controller.agentListenerServiceType "LoadBalancer") (.Values.controller.agentListenerLoadBalancerIP) }}
   loadBalancerIP: {{  .Values.controller.agentListenerLoadBalancerIP }}
+  {{- end }}
   {{- end }}

--- a/charts/jenkins/tests/jenkins-agent-svc-test.yaml
+++ b/charts/jenkins/tests/jenkins-agent-svc-test.yaml
@@ -119,3 +119,10 @@ tests:
             app.kubernetes.io/instance: my-release
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: jenkins
+  - it: disable agent service
+    set:
+      controller:
+        agentListenerEnabled: false
+    asserts:
+    - hasDocuments:
+        count: 0

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -154,6 +154,8 @@ controller:
       # If Startup Probe is not supported on your Kubernetes cluster, you might want to use "initialDelaySeconds" instead.
       # It delays the initial readyness probe while Jenkins is starting
       # initialDelaySeconds: 60
+
+  agentListenerEnabled: true
   agentListenerPort: 50000
   agentListenerHostPort:
   agentListenerNodePort:


### PR DESCRIPTION
# What this PR does / why we need it

This can be useful in cases where all agents are using Websocket
connections via the primary HTTP(s) service.

Defaulted new parameter to `true` in `values.yaml` to maintain existing
behaviour.
Added parameter to `VALUES_SUMMARY.md`.
Also added a test to verify that the service doesn't get created when
setting `controller.agentListenerEnabled` to `false`.

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
