### PR TITLE
chore(deps): bump cac to 1.51 and k8s to 1.29.4

### DIFF
--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -204,10 +204,10 @@ controller:
 
   # List of plugins to be install during Jenkins controller start
   installPlugins:
-    - kubernetes:1.29.2
+    - kubernetes:1.29.4
     - workflow-aggregator:2.6
     - git:4.7.1
-    - configuration-as-code:1.47
+    - configuration-as-code:1.51
 
   # Set to false to download the minimum required version of all dependencies.
   installLatestPlugins: false


### PR DESCRIPTION
# What this PR does / why we need it
I was getting the following errors:
```
$ kubectl logs pod/jenkins-0 init
disable Setup Wizard
download plugins
Multiple plugin prerequisites not met:
Plugin kubernetes:1.29.2 (via credentials:2.3.19) depends on configuration-as-code:1.51, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin workflow-aggregator:2.6 (via credentials:2.3.19) depends on configuration-as-code:1.51, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin workflow-aggregator:2.6 (via git-client:3.7.1) depends on configuration-as-code:1.51, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin git:4.7.1 depends on configuration-as-code:1.51, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin git:4.7.1 (via credentials:2.3.19) depends on configuration-as-code:1.51, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin git:4.7.1 (via git-client:3.7.1) depends on configuration-as-code:1.51, but there is an older version defined on the top level - configuration-as-code:1.47
```
Bumping configuration-as-code solved it along with some UI errors because of this dependency.

# Which issue this PR fixes

Did not find any.

# Checklist
- [ ] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] CHANGELOG.md was updated
