### PR TITLE
Correct documentation for disabling plugin download

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,12 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.14
+Correct docs on disabling plugin installation
+
+## 3.3.13
+Update plugins
+
 ## 3.3.12
 Add `controller.additionalExistingSecrets` property
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.12
+version: 3.3.14
 appVersion: 2.277.4
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -109,10 +109,10 @@ Once you built the image and pushed it to your registry you can specify it in yo
 controller:
   image: "registry/my-jenkins"
   tag: "v1.2.3"
-  installPlugins: []
+  installPlugins: false
 ```
 
-Notice: `installPlugins` is set to an empty list to disable plugin download. In this case, the image `registry/my-jenkins:v1.2.3` must have the plugins specified as default value for [the `controller.installPlugins` directive](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES_SUMMARY.md#jenkins-plugins) to ensure that the configuration side-car system works as expected.
+Notice: `installPlugins` is set to false to disable plugin download. In this case, the image `registry/my-jenkins:v1.2.3` must have the plugins specified as default value for [the `controller.installPlugins` directive](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES_SUMMARY.md#jenkins-plugins) to ensure that the configuration side-car system works as expected.
 
 In case you are using a private registry you can use 'imagePullSecretName' to specify the name of the secret to use when pulling the image:
 
@@ -121,7 +121,7 @@ controller:
   image: "registry/my-jenkins"
   tag: "v1.2.3"
   imagePullSecretName: registry-secret
-  installPlugins: []
+  installPlugins: false
 ```
 
 ### External URL Configuration


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

the documentation recommends setting `installPlugins` to an empty list, but that doesn't work

```
$ helm template jenkins/jenkins --set controller.installPlugins=[] -s templates/config.yaml
Error: template: jenkins/templates/jenkins-controller-statefulset.yaml:47:28: executing "jenkins/templates/jenkins-controller-statefulset.yaml" at <include (print $.Template.BasePath "/config.yaml") .>: error calling include: template: jenkins/templates/config.yaml:71:37: executing "jenkins/templates/config.yaml" at <.Values.controller.installPlugins>: range can't iterate over []
```

Originally we had set it to null to clear it out, which worked:
```
$ helm template jenkins/jenkins --set controller.installPlugins= -s templates/config.yaml
```

But we're deploying it through kustomize and today our Jenkins didn't restart after some kured patching, after investigating I found that kustomize was silently dropping the empty `installPlugins`, I tracked it back to https://github.com/kubernetes-sigs/kustomize/issues/2697 which has not been fixed for `null` values.

I found that setting the value to `false` instead seems to work in all cases, so correcting the documentation here and that's what we are using now

```
helm template jenkins/jenkins --set controller.installPlugins=false -s templates/config.yaml
```

Use --debug flag to render out invalid YAML

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] CHANGELOG.md was updated
