### PR TITLE
feat: Add support for `SecretClaim` resources

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,7 +12,7 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
-# 3.3.16
+## 3.3.16
 Support generating `SecretClaim` resources in order to read secrets from HashiCorp Vault into Kubernetes using `kube-vault-controller`.
 
 ## 3.3.15

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+# 3.3.16
+Support generating `SecretClaim` resources in order to read secrets from HashiCorp Vault into Kubernetes using `kube-vault-controller`.
+
 ## 3.3.15
 Prevent `controller.httpsKeyStore` from improperly being quoted, leading to an invalid location on disk
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.15
+version: 3.3.16
 appVersion: 2.277.4
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -339,7 +339,7 @@ It is possible to define which storage class to use, by setting `persistence.sto
 If set to a dash (`-`), dynamic provisioning is disabled.
 If the storage class is set to null or left undefined (`""`), the default provisioner is used (gp2 on AWS, standard on GKE, AWS & OpenStack).
 
-#### Additional Secrets
+### Additional Secrets
 
 Additional secrets and Additional Existing Secrets,
 can be mounted into the Jenkins controller through the chart or created using `controller.additionalSecrets` or `controller.additionalExistingSecrets`.  
@@ -392,6 +392,23 @@ controller:
 ```
 
 For more information, see [JCasC documentation](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets).
+
+### Secret Claims from HashiCorp Vault
+
+It's possible for this chart to generate `SecretClaim` resources in order to automatically create and maintain Kubernetes `Secrets` from HashiCorp [Vault](https://www.vaultproject.io/) via [`kube-vault-controller`](https://github.com/roboll/kube-vault-controller)
+
+These `Secrets` can then be referenced in the same manner as Additional Secrets above.
+
+This can be achieved by defining required Secret Claims within `controller.secretClaims`, as follows:
+```yaml
+controller:
+  secretClaims:
+    - name: jenkins-secret
+      path: secret/path
+    - name: jenkins-short-ttl
+      path: secret/short-ttl-path
+      renew: 60
+```
 
 ### RBAC
 

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -228,6 +228,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.adminPassword`            | Admin password (and user) created as a secret if adminSecret is true | Random value |
 | `controller.additionalSecrets`        | List of additional secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
 | `controller.additionalExistingSecrets`| List of additional existing secrets to mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
+| `controller.secretClaims`             | List of `SecretClaim` resources to create | `[]` |
 
 #### Kubernetes NetworkPolicy
 

--- a/charts/jenkins/templates/secret-claims.yaml
+++ b/charts/jenkins/templates/secret-claims.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.controller.secretClaims -}}
+{{- $r := .Release -}}
+{{- $v := .Values -}}
+{{- $chart := printf "%s-%s" .Chart.Name .Chart.Version -}}
+{{- $namespace := include "jenkins.namespace" . -}}
+{{- $serviceName := include "jenkins.fullname" . -}}
+{{ range .Values.controller.secretClaims }}
+---
+kind: SecretClaim
+apiVersion: vaultproject.io/v1
+metadata:
+  name: {{ $serviceName }}-{{ .name | default .path | lower }}
+  namespace: {{ $namespace }}
+  labels:
+    "app.kubernetes.io/name": '{{ $serviceName }}'
+    {{- if $v.renderHelmLabels }}
+    "helm.sh/chart": "{{ $chart }}"
+    {{- end }}
+    "app.kubernetes.io/managed-by": "{{ $r.Service }}"
+    "app.kubernetes.io/instance": "{{ $r.Name }}"
+    "app.kubernetes.io/component": "{{ $v.controller.componentName }}"
+spec:
+  type: {{ .type | default "Opaque" }}
+  path: {{ .path }}
+{{- if .renew }}
+  renew: {{ .renew }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/jenkins/tests/secret-claims-test.yaml
+++ b/charts/jenkins/tests/secret-claims-test.yaml
@@ -1,0 +1,82 @@
+suite: Controller Secret Claims
+release:
+  name: my-release
+  namespace: my-namespace
+templates:
+  - secret-claims.yaml
+tests:
+  - it: tests defaults
+    asserts:
+    - hasDocuments:
+        count: 0
+  - it: tests 2 secret claims
+    set:
+      controller.secretClaims:
+        - name: simple-secret
+          path: secret/path
+        - name: complex-secret
+          path: secret/complex
+          type: kubernetes.io/tls
+          renew: 60
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: SecretClaim
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: vaultproject.io/v1
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: my-release-jenkins-simple-secret
+      - documentIndex: 0
+        matchRegex:
+          path: metadata.labels.helm\.sh/chart
+          pattern: ^jenkins-
+      - documentIndex: 0
+        isNull:
+          path: metadata.annotations
+      - documentIndex: 0
+        equal:
+          path: spec.type
+          value: Opaque
+      - documentIndex: 0
+        equal:
+          path: spec.path
+          value: secret/path
+      - documentIndex: 0
+        isNull:
+          path: spec.renew
+      - documentIndex: 1
+        isKind:
+          of: SecretClaim
+      - documentIndex: 1
+        equal:
+          path: apiVersion
+          value: vaultproject.io/v1
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: my-release-jenkins-complex-secret
+      - documentIndex: 1
+        matchRegex:
+          path: metadata.labels.helm\.sh/chart
+          pattern: ^jenkins-
+      - documentIndex: 1
+        isNull:
+          path: metadata.annotations
+      - documentIndex: 1
+        equal:
+          path: spec.type
+          value: kubernetes.io/tls
+      - documentIndex: 1
+        equal:
+          path: spec.path
+          value: secret/complex
+      - documentIndex: 1
+        equal:
+          path: spec.renew
+          value: 60

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -254,6 +254,17 @@ controller:
   #  - name: nameOfSecret
   #    value: secretText
 
+  # Generate SecretClaim resources in order to create Kubernetes secrets from HashiCorp Vault using kube-vault-controller.
+  # 'name' is name of the secret that will be created in Kubernetes. The Jenkins fullname is prepended to this value.
+  # 'path' is the fully qualified path to the secret in Vault
+  # 'type' is an optional Kubernetes secret type. Defaults to 'Opaque'
+  # 'renew' is an optional secret renewal time in seconds
+  secretClaims: []
+  # - name: secretName        # required
+  #   path: testPath          # required
+  #   type: kubernetes.io/tls # optional
+  #   renew: 60               # optional
+
   # Below is the implementation of Jenkins Configuration as Code.  Add a key under configScripts for each configuration area,
   # where each corresponds to a plugin or section of the UI.  Each key (prior to | character) is just a label, and can be any value.
   # Keys are only used to give the section a meaningful name.  The only restriction is they may only contain RFC 1123 \ DNS label


### PR DESCRIPTION
This commit adds support for generating `SecretClaim` resources which
can be used to automatically create Kubernetes secrets from HashiCorp
Vault via `kube-vault-controller`.

Tests added.
Changelog updated and version bumped.
README.md and VALUES_SUMMARY.md updated.

Signed-off-by: Gavin Williams <fatmcgav@gmail.com>

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] CHANGELOG.md was updated
