### PR TITLE
Override WAR Arguments

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.18
+Added `controller.overrideArgs` so any cli argument can be passed to the WAR.
+
 ## 3.3.17
 Correct docs on disabling plugin installation
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.17
+version: 3.3.18
 appVersion: 2.277.4
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -140,7 +140,13 @@ spec:
         - name: jenkins
           image: "{{ .Values.controller.image }}:{{ .Values.controller.tag }}"
           imagePullPolicy: "{{ .Values.controller.imagePullPolicy }}"
-          {{- if .Values.controller.httpsKeyStore.enable }}
+          {{- if .Values.controller.overrideArgs }}
+          args: [
+            {{- range $overrideArg := .Values.controller.overrideArgs }}
+              "{{- $overrideArg }}",
+            {{- end }}
+          ]
+          {{- else if .Values.controller.httpsKeyStore.enable }}
           {{- $httpsJKSFilePath :=  printf "%s/%s" .Values.controller.httpsKeyStore.path .Values.controller.httpsKeyStore.fileName }}
           args: [ "--httpPort={{.Values.controller.httpsKeyStore.httpPort}}", "--httpsPort={{.Values.controller.targetPort}}", '--httpsKeyStore={{ $httpsJKSFilePath }}', "--httpsKeyStorePassword=$(JENKINS_HTTPS_KEYSTORE_PASSWORD)" ]
           {{- else }}

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -454,3 +454,14 @@ tests:
           content:
             name: "TEST_ENV_VAR__CONTAINER_TEMPLATED"
             value: 'some-value'
+  - it: overrides container args
+    set:
+      controller.overrideArgs:
+        - --httpPort=8080
+        - --requestHeaderSize=32768
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --httpPort=8080
+            - --requestHeaderSize=32768

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -58,6 +58,9 @@ controller:
   jenkinsRef: "/usr/share/jenkins/ref"
   # Path to the jenkins war file which is used by jenkins-plugin-cli.
   jenkinsWar: "/usr/share/jenkins/jenkins.war"
+  # Overrides the default arguments passed to the war
+  # overrideArgs:
+  #   - --httpPort=8080
   resources:
     requests:
       cpu: "50m"


### PR DESCRIPTION
# What this PR does / why we need it

The current way cli arguments are passed to the WAR is quite opinionated and only supports HTTP & HTTPS options. This change allows a user to override them and specify anything with `overrideArgs`.

I need this to pass `--requestHeaderSize=32768` to the WAR but there are many other arguments that could be supplied https://www.jenkins.io/doc/book/installing/initial-settings/

Example usage:
```
controller:
  overrideArgs:
    - --httpPort=8080
    - --requestHeaderSize=32768
```

Signed-off-by: David Sayers <david@sayers.it>