### PR TITLE
Fixed bug: wrong type of activeDeadlineSeconds in jenkins-backup-cron…

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,7 +12,7 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
-## 3.3.19
+## 3.3.21
 Fix activeDeadlineSeconds wrong type bug in jenkins-backup-cronjob template
 
 ## 3.3.18

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.19
+Fix activeDeadlineSeconds wrong type bug in jenkins-backup-cronjob template
+
 ## 3.3.18
 Added `controller.overrideArgs` so any cli argument can be passed to the WAR.
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.18
+version: 3.3.19
 appVersion: 2.277.4
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/charts/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -19,7 +19,7 @@ spec:
   jobTemplate:
     spec:
 {{- if .Values.backup.activeDeadlineSeconds }}
-      activeDeadlineSeconds: "{{ .Values.backup.activeDeadlineSeconds }}"
+      activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds }}
 {{- end }}
       template:
         metadata:


### PR DESCRIPTION
…job - changed type from string to int

Signed-off-by: LhgLoj1 <Jannic.Lollert@liebherr.com>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

PR to fix a bug in the backup cronjob yaml which lead to errors during deployment.
The value `activeDeadlineSeconds` was passed as a string but it needs to be an integer.

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer
I tested the change locally and it worked.
This is my first contribution ever so if I forgot to do something feel free to comment and I will adjust the PR

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
