### PR TITLE
Add variable to set name of default cloud name in Jenkins configuration

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.19
+version: 3.3.20
 appVersion: 2.277.4
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -16,6 +16,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `namespaceOverride`               | Override the deployment namespace    | Not set (`Release.Namespace`)             |
 | `controller.componentName`            | Jenkins controller name                  | `jenkins-controller`                          |
 | `controller.testEnabled`              | Can be used to disable rendering test resources when using helm template | `true`                         |
+| `controller.cloudName`                       | Name of default cloud configuration  | `kubernetes`                              |
 
 #### Jenkins Configuration as Code (JCasC)
 

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -138,7 +138,7 @@ jenkins:
       webSocket: true
       {{- end }}
       maxRequestsPerHostStr: {{ .Values.agent.maxRequestsPerHostStr | quote }}
-      name: {{ .Values.controller.cloudName }}
+      name: "{{ .Values.controller.cloudName }}"
       namespace: "{{ template "jenkins.agent.namespace" . }}"
       serverUrl: "https://kubernetes.default"
       {{- if .Values.agent.enabled }}

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -138,7 +138,7 @@ jenkins:
       webSocket: true
       {{- end }}
       maxRequestsPerHostStr: {{ .Values.agent.maxRequestsPerHostStr | quote }}
-      name: "kubernetes"
+      name: {{ .Values.controller.cloudName }}
       namespace: "{{ template "jenkins.agent.namespace" . }}"
       serverUrl: "https://kubernetes.default"
       {{- if .Values.agent.enabled }}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -268,6 +268,9 @@ controller:
   #   type: kubernetes.io/tls # optional
   #   renew: 60               # optional
 
+  # Name of default cloud configuration.
+  cloudName: "kubernetes"
+
   # Below is the implementation of Jenkins Configuration as Code.  Add a key under configScripts for each configuration area,
   # where each corresponds to a plugin or section of the UI.  Each key (prior to | character) is just a label, and can be any value.
   # Keys are only used to give the section a meaningful name.  The only restriction is they may only contain RFC 1123 \ DNS label


### PR DESCRIPTION
Signed-off-by: Tomasz Woźniak <tomlee@cybertronika.eu>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

Add variable to set name of default cloud. Default it is "kubernetes" and you have possibility to change it.

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [ ] CHANGELOG.md was updated
