### PR TITLE
Attach custom volume mounts to init container (fixes issue #386)

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.21
+`persistence.mounts` additionally mount to init container to allow custom CA certificate keystore
+
 ## 3.3.18
 Added `controller.overrideArgs` so any cli argument can be passed to the WAR.
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.20
+version: 3.3.21
 appVersion: 2.277.4
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -117,6 +117,9 @@ spec:
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
           volumeMounts:
+            {{- if .Values.persistence.mounts }}
+{{ toYaml .Values.persistence.mounts | indent 12 }}
+            {{- end }}
             - mountPath: {{ .Values.controller.jenkinsHome }}
               name: jenkins-home
               {{- if .Values.persistence.subPath }}


### PR DESCRIPTION
# What this PR does / why we need it
Allows a java keystore containing CA certificate to be mounted in init container.  This is needed to download plugins from https endpoints via a TLS-inspecting proxy server.

# Which issue this PR fixes
- fixes #386

# Special notes for your reviewer
While attaching `controller.httpsKeyStore` to init would also have fixed, this [forces enabling end-to-end TLS](https://github.com/jenkinsci/helm-charts/blob/330c61cebe3393b3d7fdd6216805338a59d4e7cd/charts/jenkins/templates/jenkins-controller-statefulset.yaml#L151), which isn't wanted.  We have created a secret containing the keystore and refer to it using `persistence.volumes` and just need init to mount it so Jenkins will start via proxy.

# Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated