### PR TITLE
Fix resource root url on k8s >=v1.19.x

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.3.23
+
+Make `controller.ingress.resourceRootUrl` compatible with api version networking.k8s.io/v1 on k8s >= 1.19.x
+
 ## 3.3.22
 
 Update Jenkins image and appVersion to jenkins lts release version 2.289.1

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.3.22
+version: 3.3.23
 appVersion: 2.289.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-ingress.yaml
@@ -63,6 +63,7 @@ spec:
             name: {{ template "jenkins.fullname" . }}
             port:
               number: {{ .Values.controller.servicePort }}
+        pathType: ImplementationSpecific
 {{- else }}
           serviceName: {{ template "jenkins.fullname" . }}
           servicePort: {{ .Values.controller.servicePort }}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -117,6 +117,9 @@ spec:
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
           volumeMounts:
+            {{- if .Values.persistence.mounts }}
+{{ toYaml .Values.persistence.mounts | indent 12 }}
+            {{- end }}
             - mountPath: {{ .Values.controller.jenkinsHome }}
               name: jenkins-home
               {{- if .Values.persistence.subPath }}


### PR DESCRIPTION
# What this PR does / why we need it
Fixes "pathType must be specified" error when trying to deploy with value `controller.ingress.resourceRootUrl` on k8s >=v1.19.x.

# Which issue this PR fixes

- fixes #393


# Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
