### PR TITLE
Allow showRawYaml to be customized for the default agent's pod template.

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.4.1
+
+Allow showRawYaml for the default agent's pod template to be customized.
+
 ## 3.4.0
 
 configAutoReload container updated from `kiwigrid/k8s-sidecar:0.1.275` to `kiwigrid/k8s-sidecar:1.12.2`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.4.0
+version: 3.4.1
 appVersion: 2.289.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -251,7 +251,7 @@ Returns kubernetes pod template configuration as code
 {{- end }}
   nodeUsageMode: "NORMAL"
   podRetention: {{ .Values.agent.podRetention }}
-  showRawYaml: true
+  showRawYaml: {{ .Values.agent.showRawYaml }}
   serviceAccount: "{{ include "jenkins.serviceAccountAgentName" . }}"
   slaveConnectTimeoutStr: "{{ .Values.agent.connectTimeout }}"
 {{- if .Values.agent.volumes }}

--- a/charts/jenkins/tests/jcasc-config-test.yaml
+++ b/charts/jenkins/tests/jcasc-config-test.yaml
@@ -55,7 +55,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: d591f91bc14f64a22ae985a40af25e183925bcf2934d14c02f9026358a3a047c
+                      id: 6cc8dfc88599dce321ef47e1e2430de26d8474fb402b00f38476bd93895f79be
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -174,7 +174,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 113ba7c41c563964c61bde56a8182bcbc271f3e5f0928f8051d7f40804138df8
+                      id: 57d35c635fae23cdd3291522900cf4773e35cb3dc4ecfe37117ff293ea9fed18
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -204,7 +204,7 @@ tests:
                       slaveConnectTimeoutStr: "100"
                       yamlMergeStrategy: override
                     - name: "maven"
-                      id: f5aa423767bb6cae4577f29e62cb472ddc58d8e41f99586b99d0a033cf65454d
+                      id: a0383355806ae7111bd686a03a21c9c35d2607aa83d383752603e536538dcf59
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -234,7 +234,7 @@ tests:
                       slaveConnectTimeoutStr: "100"
                       yamlMergeStrategy: override
                     - name: "python"
-                      id: 5de2cc3d24ddf30644b7a1770d7eb386d311cf402c49f67f03a48c4d7457b733
+                      id: aac530d3ce49e28dbb986c75adb481919324653836bd5300dc3fb7904d569c95
                       containers:
                       - name: "python"
                         alwaysPullImage: false
@@ -472,7 +472,7 @@ tests:
                       annotations:
                       - key: ci.jenkins-agent/test
                         value: "custom"
-                      id: ac0a9ae491a18fa97b086f0786e642fe85285607e6468d5b5e90b113dff78307
+                      id: 0c7f891856d4fe6044c237bec20a3f20ed24645c65f22dd73cc89e3fa813cb11
                       containers:
                       - name: "sideContainer"
                         alwaysPullImage: true
@@ -611,7 +611,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 5ca7c77f4140db7dbe0c9ac8efa353d0580d89002678b89aa7c360ae736b1598
+                      id: d4292becf63ddababea40645e9f463bb44e704ccc31f38db577670858188c323
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -715,7 +715,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 4aa67a6472190f3f941e74fa27d3a9aedce990012334eade3bf1ac3a1e860c50
+                      id: 484943d04f0ed2a778ee2ee56af751aff5f992c81cb2550ba8ece6fe18b9eb43
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -817,7 +817,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: ac2705446d8d4618d77709d5bd6c50943631e6ba2d532897758676c0d74a1be7
+                      id: 1ce144ef1921772a0d77ead46e529f98a50dc16f44e54e612164faed27e84427
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -921,7 +921,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 078862fad89cec657bed7bed7f6871e95fe6c705aed11a3f22221442586c0fce
+                      id: f0ed877593cb895392dc8ea639407c31387b53aa40dc21fafce116c2ce2ef57f
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1026,7 +1026,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: b567cb600dd8183d11309362c23e59c2413c370a5054e4dd478f22f419acb886
+                      id: e783705f28494518ab990ca5f194f7afa6b384120b9a012bb6c90381a3c2dcfd
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1130,7 +1130,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 2c854c0c839cc5e4f76c5fcf70ac0dc1e552fb7e4aa5772c8ee1a26def58d58a
+                      id: 3dadc75712d96785fbbbc6b02adda24931468bfce16a15da98db2bae7c39f9ac
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -572,6 +572,10 @@ agent:
   # Controls how agent pods are retained after the Jenkins build completes
   # Possible values: Always, Never, OnFailure
   podRetention: "Never"
+  # Disable if you do not want the Yaml the agent pod template to show up
+  # in the job Console Output. This can be helpful for either security reasons
+  # or simply to clean up the output to make it easier to read.
+  showRawYaml: true
   # You can define the volumes that you want to mount for this container
   # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, PVC, Secret
   # Configure the attributes as they appear in the corresponding Java class for that type


### PR DESCRIPTION
# What this PR does / why we need it

The current version of this chart does not allow the agent pod template to customize the value of `showRawYaml`.

https://github.com/jenkinsci/helm-charts/blob/b9557c959929b4db83dbde515ee3493bbff7d1af/charts/jenkins/templates/_helpers.tpl#L254

For those of us still looking at the legacy console output, that creates too much noise, making it difficult to understand and diagnose errors.

Other than that, it makes it impossible to use any sensitive information in the pod template.

# Which issue this PR fixes

- fixes https://github.com/jenkinsci/helm-charts/issues/401.

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
