### PR TITLE
feat(controller): use template for controller.podAnnotations

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.5.0
+
+Allow `controller.podAnnotations` to be render as a template
+
 ## 3.4.1
 
 Allow showRawYaml for the default agent's pod template to be customized.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.4.1
+version: 3.5.0
 appVersion: 2.289.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         {{- if .Values.controller.podAnnotations }}
-{{ toYaml .Values.controller.podAnnotations | indent 8 }}
+{{ tpl (toYaml .Values.controller.podAnnotations | indent 8) . }}
         {{- end }}
     spec:
       {{- if .Values.controller.schedulerName }}

--- a/charts/jenkins/tests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/tests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -1,0 +1,5 @@
+render pod annotations:
+  1: |
+    checksum/config: e7818e32b5bbbb17988f6a688ca77fe20facffa3886facf2b27a7c8846cf9df6
+    fixed-annotation: some-fixed-annotation
+    templated-annotations: my-release

--- a/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/tests/jenkins-controller-statefulset-test.yaml
@@ -465,3 +465,12 @@ tests:
           value:
             - --httpPort=8080
             - --requestHeaderSize=32768
+  - it: render pod annotations
+    set:
+      controller:
+        podAnnotations:
+          templated-annotations: '{{ .Release.Name }}'
+          fixed-annotation: some-fixed-annotation
+    asserts:
+      - matchSnapshot:
+          path: spec.template.metadata.annotations


### PR DESCRIPTION
Signed-off-by: Alexis Martinier <a.martinier@gmail.com>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

Allow to use template in podAnnotations for controller (usage ex: trigger a rollout when a custom config file have changed)

# Which issue this PR fixes

# Special notes for your reviewer

I have written a test case for `podAnnotations` template using **snapshot** feature of unittest.  
This could impact the CI like the `checksum/config`annotation could change (config.yaml update) and require a snapshot update using `-u` option. Developers could handle this on their local dev machine before submitting a PR

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
