### PR TITLE
Allow using custom secret key with httpsKeyStore.jenkinsHttpsJksSecretName

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.5.0
+
+Added `controller.httpsKeyStore.jenkinsHttpsJksSecretFileKey` and `controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName` for the default keystore secret key to be customized.
+
 ## 3.4.1
 
 Allow showRawYaml for the default agent's pod template to be customized.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.4.1
+version: 3.5.0
 appVersion: 2.289.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -214,9 +214,9 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `controller.httpsKeyStore.enable`     | Enables https keystore on jenkins controller      | `false`      |
-| `controller.httpsKeyStore.jenkinsHttpsJksSecretName`     | Name of the secret that already has ssl keystore      | ``      |
-| `controller.httpsKeyStore.jenkinsHttpsJksSecretFileKey`     | Name of the key that point to ssl keystore in the secret      | ``      |
-| `controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName`     | Name of the secret that already has ssl keystore's password      | ``      |
+| `controller.httpsKeyStore.jenkinsHttpsJksSecretName`     | Name of the secret that already has ssl keystore      | ``|
+| `controller.httpsKeyStore.jenkinsHttpsJksSecretFileKey`     | Name of the key that point to ssl keystore in the secret      |``|
+| `controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName`     | Name of the secret that already has ssl keystore's password      |``|
 | `controller.httpsKeyStore.httpPort`   | Http Port that Jenkins should listen on along with https, it also serves liveness and readiness probs port. When https keystore is enabled servicePort and targetPort will be used as https port  | `8081`   |
 | `controller.httpsKeyStore.path`       | Path of https keystore file                  |     `/var/jenkins_keystore`     |
 | `controller.httpsKeyStore.fileName`  | Jenkins keystore filename which will appear under controller.httpsKeyStore.path      | `keystore.jks` |

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -214,9 +214,9 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `controller.httpsKeyStore.enable`     | Enables https keystore on jenkins controller      | `false`      |
-| `controller.httpsKeyStore.jenkinsHttpsJksSecretName`     | Name of the secret that already has ssl keystore      | ``|
-| `controller.httpsKeyStore.jenkinsHttpsJksSecretFileKey`     | Name of the key that point to ssl keystore in the secret      |``|
-| `controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName`     | Name of the secret that already has ssl keystore's password      |``|
+| `controller.httpsKeyStore.jenkinsHttpsJksSecretName`     | Name of the secret that already has ssl keystore      | ``      |
+| `controller.httpsKeyStore.jenkinsHttpsJksSecretFileKey`     | Name of the key that point to ssl keystore in the secret      | ``      |
+| `controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName`     | Name of the secret that already has ssl keystore's password      | ``      |
 | `controller.httpsKeyStore.httpPort`   | Http Port that Jenkins should listen on along with https, it also serves liveness and readiness probs port. When https keystore is enabled servicePort and targetPort will be used as https port  | `8081`   |
 | `controller.httpsKeyStore.path`       | Path of https keystore file                  |     `/var/jenkins_keystore`     |
 | `controller.httpsKeyStore.fileName`  | Jenkins keystore filename which will appear under controller.httpsKeyStore.path      | `keystore.jks` |

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -215,6 +215,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `controller.httpsKeyStore.enable`     | Enables https keystore on jenkins controller      | `false`      |
 | `controller.httpsKeyStore.jenkinsHttpsJksSecretName`     | Name of the secret that already has ssl keystore      | ``      |
+| `controller.httpsKeyStore.jenkinsHttpsJksSecretFileKey`     | Name of the key that point to ssl keystore in the secret      | ``      |
+| `controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName`     | Name of the secret that already has ssl keystore's password      | ``      |
 | `controller.httpsKeyStore.httpPort`   | Http Port that Jenkins should listen on along with https, it also serves liveness and readiness probs port. When https keystore is enabled servicePort and targetPort will be used as https port  | `8081`   |
 | `controller.httpsKeyStore.path`       | Path of https keystore file                  |     `/var/jenkins_keystore`     |
 | `controller.httpsKeyStore.fileName`  | Jenkins keystore filename which will appear under controller.httpsKeyStore.path      | `keystore.jks` |

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -176,7 +176,13 @@ spec:
             - name: JENKINS_HTTPS_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }} {{ .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }} {{ else }} {{ template "jenkins.fullname" . }}-https-jks  {{ end }}
+                  {{- if .Values.controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName }}
+                  name: {{ .Values.controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName }} 
+                  {{- else if .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }}
+                  name:  {{ .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }}
+                  {{- else }}
+                  name: {{ template "jenkins.fullname" . }}-https-jks
+                  {{- end }}
                   key: {{ "https-jks-password" | quote }}
             {{- end }}
 
@@ -351,7 +357,7 @@ spec:
         secret:
           secretName: {{ if .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }} {{ .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }} {{ else }} {{ template "jenkins.fullname" . }}-https-jks  {{ end }}
           items:
-          - key: jenkins-jks-file
+          - key: {{ .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretFileKey | default "jenkins-jks-file" }} 
             path: {{ .Values.controller.httpsKeyStore.fileName }}
       {{- end }}
       {{- if .Values.controller.adminSecret }}


### PR DESCRIPTION
# What this PR does / why we need it
When Issuing the SSL certificate with Cert-manager it creates Kubernetes secret of type kubernetes.io/tls without the ability to define the secret keys (jks file is stored in keystore.jks). Since the helm chart expects the keystore file in the hardcoded key name it is not possible to use cert-manager issued certificate.

This PR adds the ability to use a secret that already has SSL keystore with a variable name key in the secret and not just the default "jenkins-jks-file".

# Special notes for your reviewer
I make sure that default behavior doesn't change for backward compatibility.

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
