### PR TITLE
update plugins & download latest dependencies

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,10 +12,15 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.5.14
+
+* Updated versions of default plugins
+* Use verbose logging during plugin installation
+* download the latest version of all plugin dependencies (Fixes #442)
+
 ## 3.5.13
 
 Update Jenkins image and appVersion to jenkins lts release version 2.303.1
-
 
 ## 3.5.12
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.5.13
+version: 3.5.14
 appVersion: 2.303.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -35,7 +35,7 @@ data:
     rm -rf {{ .Values.controller.jenkinsRef }}/plugins/*.lock
     version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
     if [ -f "{{ .Values.controller.jenkinsWar }}" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-      jenkins-plugin-cli --war "{{ .Values.controller.jenkinsWar }}" --plugin-file "{{ .Values.controller.jenkinsHome }}/plugins.txt" --latest {{ .Values.controller.installLatestPlugins }}{{- if .Values.controller.installLatestSpecifiedPlugins }} --latest-specified{{- end }};
+      jenkins-plugin-cli --verbose --war "{{ .Values.controller.jenkinsWar }}" --plugin-file "{{ .Values.controller.jenkinsHome }}/plugins.txt" --latest {{ .Values.controller.installLatestPlugins }}{{- if .Values.controller.installLatestSpecifiedPlugins }} --latest-specified{{- end }};
     else
       /usr/local/bin/install-plugins.sh `echo $(cat {{ .Values.controller.jenkinsHome }}/plugins.txt)`;
     fi

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -1,5 +1,5 @@
 render pod annotations:
   1: |
-    checksum/config: e7818e32b5bbbb17988f6a688ca77fe20facffa3886facf2b27a7c8846cf9df6
+    checksum/config: dcf606d26b60483d2cf523616909460c03211c96c949f89488b9fa54866ca405
     fixed-annotation: some-fixed-annotation
     templated-annotations: my-release

--- a/charts/jenkins/unittests/config-test.yaml
+++ b/charts/jenkins/unittests/config-test.yaml
@@ -29,7 +29,7 @@ tests:
             rm -rf /usr/share/jenkins/ref/plugins/*.lock
             version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
             if [ -f "/usr/share/jenkins/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest false;
+              jenkins-plugin-cli --verbose --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest true;
             else
               /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
             fi
@@ -40,10 +40,10 @@ tests:
       - equal:
           path: data.plugins\.txt
           value: |-
-            kubernetes:1.29.4
+            kubernetes:1.30.1
             workflow-aggregator:2.6
-            git:4.7.1
-            configuration-as-code:1.51
+            git:4.8.2
+            configuration-as-code:1.52
   - it: no plugins
     set:
       controller.installPlugins: []
@@ -67,38 +67,16 @@ tests:
               - kubernetes-credentials-provider
     asserts:
       - equal:
-          path: data.apply_config\.sh
-          value: |-
-            set -e
-            echo "disable Setup Wizard"
-            # Prevent Setup Wizard when JCasC is enabled
-            echo $JENKINS_VERSION > /var/jenkins_home/jenkins.install.UpgradeWizard.state
-            echo $JENKINS_VERSION > /var/jenkins_home/jenkins.install.InstallUtil.lastExecVersion
-            echo "download plugins"
-            # Install missing plugins
-            cp /var/jenkins_config/plugins.txt /var/jenkins_home;
-            rm -rf /usr/share/jenkins/ref/plugins/*.lock
-            version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
-            if [ -f "/usr/share/jenkins/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest false;
-            else
-              /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
-            fi
-            echo "copy plugins to shared volume"
-            # Copy plugins to shared volume
-            yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
-            echo "finished initialization"
-      - equal:
           path: data.plugins\.txt
           value: |-
-            kubernetes:1.29.4
+            kubernetes:1.30.1
             workflow-aggregator:2.6
-            git:4.7.1
-            configuration-as-code:1.51
+            git:4.8.2
+            configuration-as-code:1.52
             kubernetes-credentials-provider
   - it: install latest plugins
     set:
-      controller.installLatestPlugins: true
+      controller.installLatestPlugins: false
     asserts:
       - equal:
           path: data.apply_config\.sh
@@ -114,7 +92,7 @@ tests:
             rm -rf /usr/share/jenkins/ref/plugins/*.lock
             version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
             if [ -f "/usr/share/jenkins/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest true;
+              jenkins-plugin-cli --verbose --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest false;
             else
               /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
             fi
@@ -122,13 +100,6 @@ tests:
             # Copy plugins to shared volume
             yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
             echo "finished initialization"
-      - equal:
-          path: data.plugins\.txt
-          value: |-
-            kubernetes:1.29.4
-            workflow-aggregator:2.6
-            git:4.7.1
-            configuration-as-code:1.51
   - it: install latest specified plugins
     set:
       controller.installLatestSpecifiedPlugins: true
@@ -147,7 +118,7 @@ tests:
             rm -rf /usr/share/jenkins/ref/plugins/*.lock
             version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
             if [ -f "/usr/share/jenkins/jenkins.war" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then
-              jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest false --latest-specified;
+              jenkins-plugin-cli --verbose --war "/usr/share/jenkins/jenkins.war" --plugin-file "/var/jenkins_home/plugins.txt" --latest true --latest-specified;
             else
               /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
             fi
@@ -155,11 +126,3 @@ tests:
             # Copy plugins to shared volume
             yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
             echo "finished initialization"
-      - equal:
-          path: data.plugins\.txt
-          value: |-
-            kubernetes:1.29.4
-            workflow-aggregator:2.6
-            git:4.7.1
-            configuration-as-code:1.51
-

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -46,7 +46,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: e7818e32b5bbbb17988f6a688ca77fe20facffa3886facf2b27a7c8846cf9df6
+                  checksum/config: dcf606d26b60483d2cf523616909460c03211c96c949f89488b9fa54866ca405
                 labels:
                   app.kubernetes.io/component: jenkins-controller
                   app.kubernetes.io/instance: my-release

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -218,13 +218,13 @@ controller:
 
   # List of plugins to be install during Jenkins controller start
   installPlugins:
-    - kubernetes:1.29.4
+    - kubernetes:1.30.1
     - workflow-aggregator:2.6
-    - git:4.7.1
-    - configuration-as-code:1.51
+    - git:4.8.2
+    - configuration-as-code:1.52
 
   # Set to false to download the minimum required version of all dependencies.
-  installLatestPlugins: false
+  installLatestPlugins: true
 
   # Set to true to download latest dependencies of any plugin that is requested to have the latest version.
   installLatestSpecifiedPlugins: false


### PR DESCRIPTION
### What this PR does / why we need it

* Updated versions of default plugins
* Use verbose logging during plugin installation
* download the latest version of all plugin dependencies (Fixes #442)


### Which issue this PR fixes

- fixes #442

With `--latest false` we did not download latest versions of transitive dependencies. That caused warnings within Jenkins.


### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
