### PR TITLE
feat: Add support for adding pvc labels

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.5.15
+Add support for adding labels to the Jenkins home Persistent Volume Claim (pvc)
+
 ## 3.5.14
 
 * Updated versions of default plugins

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.5.14
+version: 3.5.15
 appVersion: 2.303.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -334,6 +334,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `persistence.existingClaim` | Provide the name of a PVC       | `nil`           |
 | `persistence.storageClass`  | Storage class for the PVC       | `nil`           |
 | `persistence.annotations`   | Annotations for the PVC         | `{}`            |
+| `persistence.labels`        | Labels for the PVC              | `{}`            |
 | `persistence.accessMode`    | The PVC access mode             | `ReadWriteOnce` |
 | `persistence.size`          | The size of the PVC             | `8Gi`           |
 | `persistence.subPath`       | SubPath for jenkins-home mount  | `nil`           |

--- a/charts/jenkins/templates/home-pvc.yaml
+++ b/charts/jenkins/templates/home-pvc.yaml
@@ -17,6 +17,9 @@ metadata:
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
+{{- if .Values.persistence.labels }}
+{{ toYaml .Values.persistence.labels | indent 4 }}
+{{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/charts/jenkins/unittests/home-pvc-test.yaml
+++ b/charts/jenkins/unittests/home-pvc-test.yaml
@@ -76,3 +76,19 @@ tests:
             app.kubernetes.io/instance: my-release
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: jenkins
+
+  - it: add label
+    set:
+      renderHelmLabels: false
+      persistence:
+        labels:
+          test-label: test-value
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/component: jenkins-controller
+            app.kubernetes.io/instance: my-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: jenkins
+            test-label: test-value

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -738,6 +738,7 @@ persistence:
   ##
   storageClass:
   annotations: {}
+  labels: {}
   accessMode: "ReadWriteOnce"
   size: "8Gi"
   volumes:


### PR DESCRIPTION
This change adds support for specifying additional labels for the
Jenkins home pvc.

Tests added
Changelog updated and version bumped
README.md and VALUES_SUMMARY.md updated.

Signed-off-by: Gavin Williams <fatmcgav@gmail.com>

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
