### PR TITLE
Update icon location

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.5.16
+Update location of icon (wiki.jenkins.io is down)
+
 ## 3.5.15
 Add support for adding labels to the Jenkins home Persistent Volume Claim (pvc)
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.5.15
+version: 3.5.16
 appVersion: 2.303.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
@@ -20,7 +20,7 @@ maintainers:
     email: wmcdona89@gmail.com
   - name: timja
     email: timjacomb1@gmail.com
-icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png
+icon: https://get.jenkins.io/art/jenkins-logo/logo.svg
 annotations:
   artifacthub.io/links: |
     - name: Chart Source


### PR DESCRIPTION
Signed-off-by: Tim Jacomb <timjacomb1+github@gmail.com>

Wiki.jenkins.io is down, I got an email from artifacthub saying there was an issue with the icon

https://helm.sh/docs/topics/charts/#the-chart-yaml-file says we can use an svg so that should be better