### PR TITLE
update workingDir to /home/jenkins/agent

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.5.17
+Update workdingDir to `/home/jenkins/agent`
+
 ## 3.5.16
 Update location of icon (wiki.jenkins.io is down)
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.5.16
+version: 3.5.17
 appVersion: 2.303.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -317,7 +317,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `agent.command`            | Executed command when side container starts     | Not set                |
 | `agent.args`               | Arguments passed to executed command            | `${computer.jnlpmac} ${computer.name}` |
 | `agent.TTYEnabled`         | Allocate pseudo tty to the side container       | false                  |
-| `agent.workingDir`         | Configure working directory for default agent   | `/home/jenkins`        |
+| `agent.workingDir`         | Configure working directory for default agent   | `/home/jenkins/agent`        |
 
 #### Other
 

--- a/charts/jenkins/ci/other-values.yaml
+++ b/charts/jenkins/ci/other-values.yaml
@@ -35,7 +35,7 @@ agent:
       memory: "2048Mi"
   envVars:
     - name: HOME
-      value: /home/jenkins
+      value: /home/jenkins/agent
     - name: PATH
       value: /usr/local/bin
   nodeSelector:

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -61,7 +61,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -72,10 +72,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent "
@@ -95,7 +95,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
   - it: agent namespace and templates
     release:
@@ -181,7 +181,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -192,10 +192,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent "
@@ -211,7 +211,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -222,10 +222,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent maven"
@@ -252,10 +252,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: true
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent python"
@@ -279,7 +279,7 @@ tests:
                           resourceRequestMemory: "512Mi"
                           resourceLimitCpu: "1"
                           resourceLimitMemory: "1024Mi"
-                    
+
               crumbIssuer:
                 standard:
                   excludeClientIPFromCrumb: true
@@ -290,7 +290,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
   - it: customized config
     set:
@@ -620,7 +620,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -631,10 +631,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent "
@@ -659,7 +659,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom emptyDir workspace volume
     set:
@@ -725,7 +725,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -736,10 +736,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent "
@@ -762,7 +762,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom hostPath workspace volume
     set:
@@ -828,7 +828,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -839,10 +839,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent "
@@ -865,7 +865,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom nfs workspace volume
     set:
@@ -933,7 +933,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -944,10 +944,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent "
@@ -972,7 +972,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom pvc workspace volume
     set:
@@ -1039,7 +1039,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -1050,10 +1050,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent "
@@ -1077,7 +1077,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom other workspace volume
     set:
@@ -1144,7 +1144,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -1155,10 +1155,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent "
@@ -1182,7 +1182,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
   - it: disable helm.sh label
     set:
@@ -1248,7 +1248,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
   - it: disable default config
     set:
@@ -1318,7 +1318,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
+                        command:
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -1329,10 +1329,10 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
+                        runAsUser:
+                        runAsGroup:
                         ttyEnabled: false
-                        workingDir: /home/jenkins
+                        workingDir: /home/jenkins/agent
                       idleMinutes: 0
                       instanceCap: 2147483647
                       label: "RELEASE-NAME-jenkins-agent "
@@ -1352,5 +1352,5 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress: 
+                adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -61,7 +61,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -72,8 +72,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -95,7 +95,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
   - it: agent namespace and templates
     release:
@@ -181,7 +181,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -192,8 +192,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -211,7 +211,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -222,8 +222,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -252,8 +252,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: true
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -279,7 +279,7 @@ tests:
                           resourceRequestMemory: "512Mi"
                           resourceLimitCpu: "1"
                           resourceLimitMemory: "1024Mi"
-
+                    
               crumbIssuer:
                 standard:
                   excludeClientIPFromCrumb: true
@@ -290,7 +290,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
   - it: customized config
     set:
@@ -620,7 +620,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -631,8 +631,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -659,7 +659,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom emptyDir workspace volume
     set:
@@ -725,7 +725,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -736,8 +736,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -762,7 +762,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom hostPath workspace volume
     set:
@@ -828,7 +828,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -839,8 +839,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -865,7 +865,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom nfs workspace volume
     set:
@@ -933,7 +933,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -944,8 +944,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -972,7 +972,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom pvc workspace volume
     set:
@@ -1039,7 +1039,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -1050,8 +1050,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -1077,7 +1077,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
   - it: custom other workspace volume
     set:
@@ -1144,7 +1144,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -1155,8 +1155,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -1182,7 +1182,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
   - it: disable helm.sh label
     set:
@@ -1248,7 +1248,7 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
   - it: disable default config
     set:
@@ -1318,7 +1318,7 @@ tests:
                       - name: "jnlp"
                         alwaysPullImage: false
                         args: "^${computer.jnlpmac} ^${computer.name}"
-                        command:
+                        command: 
                         envVars:
                           - envVar:
                               key: "JENKINS_URL"
@@ -1329,8 +1329,8 @@ tests:
                         resourceLimitMemory: 512Mi
                         resourceRequestCpu: 512m
                         resourceRequestMemory: 512Mi
-                        runAsUser:
-                        runAsGroup:
+                        runAsUser: 
+                        runAsGroup: 
                         ttyEnabled: false
                         workingDir: /home/jenkins/agent
                       idleMinutes: 0
@@ -1352,5 +1352,5 @@ tests:
                 usageStatisticsEnabled: true
             unclassified:
               location:
-                adminAddress:
+                adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -56,7 +56,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 39698bb1fb92f2e49811b1514ddba69a93e9a734af456f227baa88a887431b41
+                      id: 8e87a0373bebcc6a10449d2a90262bb02a7cf7e5ec63c98cc4e123b67e58650a
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -176,7 +176,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: ea9b1bd1a53689cacf8464096fd4cb61dad0b77da3f0a1da422a6e732c8cbfd2
+                      id: 7f0e77752c448c03efc67d90ced2c63b7c97d78ffe57cb9d9930aa3d75bd9684
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -206,7 +206,7 @@ tests:
                       slaveConnectTimeoutStr: "100"
                       yamlMergeStrategy: override
                     - name: "maven"
-                      id: 3deafdceb090397579777ff03befc1e5c7405eeae8254eb9fc3003e64fa59a86
+                      id: d204e244404e97e456aa1641883174c59de76250356af9148e1e38059d6fc6c2
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -236,7 +236,7 @@ tests:
                       slaveConnectTimeoutStr: "100"
                       yamlMergeStrategy: override
                     - name: "python"
-                      id: 205cfe5e675ce593f15d07a86b0046a8edb144fba79f42898c754cd16ce857f5
+                      id: 8a44a96bd58091511ff4d749c8b7d91f5de04a750c284d144f464dd6234db3b3
                       containers:
                       - name: "python"
                         alwaysPullImage: false
@@ -615,7 +615,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: eca0dd95c77e2ff790d5046302ed3aaf214b619d07a1563ccf7b1ed22452acb9
+                      id: e4e2285e615c830c1ba647c108598c2bac7399537b6a4ceae64ace58a20847de
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -720,7 +720,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 7542e821a69f9876fc40e21d353520e3e81511c7145355dd45eab1892690e236
+                      id: 8d40959ed4bc63447ce4e98a8c824985644b0f7de86ec42baf851d18ac7fb9e4
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -823,7 +823,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: e5b46ea61079348c069ad58f5d671c4ceac9a7b82496a56454e78a92851d3439
+                      id: e8801493e50fd88f2fd677b5ad126776363d3764311d7875a20ffed439f07c75
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -928,7 +928,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 3a81a44afbcdd1b0e56d44d7df671bfed4943a447b02d6e98a2df5dd9c57ef19
+                      id: 748f16a465d93034ab811866b52d1dbbc629d1181e2af44347c8a4ca6d84eefa
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1034,7 +1034,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 2ac491f4c8cb6fd99532256a0e53f6e26a788d0edc6b2964e976d294f8cb4466
+                      id: 1e040540e1ee1cd3b2514de7dd2f012f7b1b8a7857d46d306ad57ad7093fd386
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1139,7 +1139,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: e28377a534e272c951d72e47495466f893da5069ceea1fe98ff42083c8458b47
+                      id: bd99fe604a67f37d9661f1303f08d3f258b27da9517c88a6d493503bf35866d8
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1313,7 +1313,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 39698bb1fb92f2e49811b1514ddba69a93e9a734af456f227baa88a887431b41
+                      id: 8e87a0373bebcc6a10449d2a90262bb02a7cf7e5ec63c98cc4e123b67e58650a
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -565,7 +565,7 @@ agent:
   namespace:
   image: "jenkins/inbound-agent"
   tag: "4.6-1"
-  workingDir: "/home/jenkins"
+  workingDir: "/home/jenkins/agent"
   nodeUsageMode: "NORMAL"
   customJenkinsLabels: []
   # name of the secret to be used for image pulling


### PR DESCRIPTION
Signed-off-by: joelee2012 <lj_2005@163.com>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it
The kubernetes plugin and inbound-agent are using `/home/jenkins/agent` as default workingDir,  but jenkins chart is still using '/home/jenkins' which may cause issue https://issues.jenkins.io/browse/JENKINS-58766.


### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
