### PR TITLE
feat: Add support for creating a Pod Disruption Budget for Jenkins controller

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.5.18
+Add support for creating a Pod Disruption Budget for Jenkins controller
+
 ## 3.5.17
 Update workdingDir to `/home/jenkins/agent`
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.5.17
+version: 3.5.18
 appVersion: 2.303.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -145,8 +145,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `controller.podDisruptionBudget.enabled` | Enable [Kubernetes Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) configuration from `controller.podDisruptionBudget` (see below) | `false` |
-| `controller.podDisruptionBudget.maxUnavailable` | Number of pods that can be unavailable. Either an absolute number or a percentage. | `1` |
-| `controller.podDisruptionBudget.minAvailable` | Number of pods that must be available. Either an absolute number or a percentage. | Not set |
+| `controller.podDisruptionBudget.maxUnavailable` | Number of pods that can be unavailable. Either an absolute number or a percentage. | Not set |
 
 #### Kubernetes Health Probes
 

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -140,6 +140,14 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.customInitContainers`     | Custom init-container specification in raw-yaml format | Not set                 |
 | `controller.sidecars.other`           | Configures additional sidecar container(s) for Jenkins controller | `[]`             |
 
+#### Kubernetes Pod Disruption Budget
+
+| Parameter                         | Description                          | Default                                   |
+| --------------------------------- | ------------------------------------ | ----------------------------------------- |
+| `controller.podDisruptionBudget.enabled` | Enable [Kubernetes Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) configuration from `controller.podDisruptionBudget` (see below) | `false` |
+| `controller.podDisruptionBudget.maxUnavailable` | Number of pods that can be unavailable. Either an absolute number or a percentage. | `1` |
+| `controller.podDisruptionBudget.minAvailable` | Number of pods that must be available. Either an absolute number or a percentage. | Not set |
+
 #### Kubernetes Health Probes
 
 | Parameter                         | Description                          | Default                                   |

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -145,6 +145,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `controller.podDisruptionBudget.enabled` | Enable [Kubernetes Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) configuration from `controller.podDisruptionBudget` (see below) | `false` |
+| `controller.podDisruptionBudget.apiVersion` | Policy API version | `policy/v1beta1` |
 | `controller.podDisruptionBudget.maxUnavailable` | Number of pods that can be unavailable. Either an absolute number or a percentage. | Not set |
 
 #### Kubernetes Health Probes

--- a/charts/jenkins/templates/jenkins-controller-pdb.yaml
+++ b/charts/jenkins/templates/jenkins-controller-pdb.yaml
@@ -1,5 +1,12 @@
 {{- if .Values.controller.podDisruptionBudget.enabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare ">=1.21-0" $kubeTargetVersion -}}
 apiVersion: policy/v1
+{{- else if semverCompare ">=1.5-0" $kubeTargetVersion -}}
+apiVersion: policy/v1beta1
+{{- else -}}
+apiVersion: {{ .Values.controller.podDisruptionBudget.apiVersion }}
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "jenkins.fullname" . }}-pdb
@@ -19,7 +26,7 @@ metadata:
   annotations: {{ toYaml .Values.controller.podDisruptionBudget.annotations | nindent 4 }}
   {{- end }}
 spec:
-  maxUnavailable: "{{ .Values.controller.podDisruptionBudget.maxUnavailable }}"
+  maxUnavailable: {{ .Values.controller.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
       "app.kubernetes.io/instance": "{{ .Release.Name }}"

--- a/charts/jenkins/templates/jenkins-controller-pdb.yaml
+++ b/charts/jenkins/templates/jenkins-controller-pdb.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.controller.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "jenkins.fullname" . }}-pdb
+  namespace: {{ template "jenkins.namespace" . }}
+  labels:
+    "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ template "jenkins.label" .}}"
+    {{- end }}
+    "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
+    "app.kubernetes.io/instance": "{{ .Release.Name }}"
+    "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
+    {{- if .Values.controller.podDisruptionBudget.labels -}}
+    {{ toYaml .Values.controller.podDisruptionBudget.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.controller.podDisruptionBudget.annotations }}
+  annotations: {{ toYaml .Values.controller.podDisruptionBudget.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  maxUnavailable: "{{ .Values.controller.podDisruptionBudget.maxUnavailable }}"
+  selector:
+    matchLabels:
+      "app.kubernetes.io/instance": "{{ .Release.Name }}"
+      "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
+{{- end }}

--- a/charts/jenkins/unittests/jenkins-controller-pdb-1.21-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-pdb-1.21-test.yaml
@@ -6,7 +6,7 @@ templates:
   - jenkins-controller-pdb.yaml
 capabilities:
   majorVersion: 1
-  minorVersion: 18
+  minorVersion: 21
 tests:
   - it: test defaults
     asserts:
@@ -22,7 +22,7 @@ tests:
           of: PodDisruptionBudget
       - equal:
           path: apiVersion
-          value: policy/v1beta1
+          value: policy/v1
       - equal:
           path: metadata.name
           value: my-release-jenkins-pdb
@@ -42,16 +42,3 @@ tests:
               matchLabels:
                 "app.kubernetes.io/instance": "my-release"
                 "app.kubernetes.io/name": "jenkins"
-  - it: disable helm.sh label
-    set:
-      renderHelmLabels: false
-      controller.podDisruptionBudget:
-        enabled: true
-    asserts:
-      - equal:
-          path: metadata.labels
-          value:
-            app.kubernetes.io/component: jenkins-controller
-            app.kubernetes.io/instance: my-release
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: jenkins

--- a/charts/jenkins/unittests/jenkins-controller-pdb-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-pdb-test.yaml
@@ -1,0 +1,57 @@
+suite: Controller Pod Disruption Budget
+release:
+  name: my-release
+  namespace: my-namespace
+templates:
+  - jenkins-controller-pdb.yaml
+capabilities:
+  majorVersion: 1
+  minorVersion: 18
+tests:
+  - it: test defaults
+    asserts:
+    - hasDocuments:
+        count: 0
+  - it: enabled
+    set:
+      controller.podDisruptionBudget:
+        enabled: true
+        maxUnavailable: "0"
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - equal:
+          path: metadata.name
+          value: my-release-jenkins-pdb
+      - equal:
+          path: metadata.namespace
+          value: my-namespace
+      - matchRegex:
+          path: metadata.labels.helm\.sh/chart
+          pattern: ^jenkins-
+      - isNull:
+          path: metadata.annotations
+      - equal:
+          path: spec
+          value:
+            maxUnavailable: "0"
+            selector:
+              matchLabels:
+                "app.kubernetes.io/instance": "my-release"
+                "app.kubernetes.io/name": "jenkins"
+  - it: disable helm.sh label
+    set:
+      renderHelmLabels: false
+      controller.podDisruptionBudget:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/component: jenkins-controller
+            app.kubernetes.io/instance: my-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: jenkins

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -174,9 +174,6 @@ controller:
     enabled: false
     annotations: {}
     labels: {}
-    # Default to not allowing any unavailable nodes
-    # This ensures that Jenkins is available as much as possible
-    maxUnavailable: "0"
 
   agentListenerEnabled: true
   agentListenerPort: 50000

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -169,6 +169,15 @@ controller:
       # It delays the initial readyness probe while Jenkins is starting
       # initialDelaySeconds: 60
 
+  # PodDisruptionBudget config
+  podDisruptionBudget:
+    enabled: false
+    annotations: {}
+    labels: {}
+    # Default to not allowing any unavailable nodes
+    # This ensures that Jenkins is available as much as possible
+    maxUnavailable: "0"
+
   agentListenerEnabled: true
   agentListenerPort: 50000
   agentListenerHostPort:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -172,6 +172,9 @@ controller:
   # PodDisruptionBudget config
   podDisruptionBudget:
     enabled: false
+    # For Kubernetes v1.5+, use 'policy/v1beta1'
+    # For Kubernetes v1.21+, use 'policy/v1'
+    apiVersion: "policy/v1beta1"
     annotations: {}
     labels: {}
     # maxUnavailable: "0"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -174,6 +174,7 @@ controller:
     enabled: false
     annotations: {}
     labels: {}
+    # maxUnavailable: "0"
 
   agentListenerEnabled: true
   agentListenerPort: 50000


### PR DESCRIPTION


<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it
This can be useful to ensure that Jenkins controller doesn't get
restarted un-necessarily or un-expectedly.
Defaulted `maxUnavailable` to `0` in order to prevent Jenkins
controller pod being voluntarily terminated.

Add unit test and updated `VALUES_SUMMARY.md`

Signed-off-by: Gavin Williams <fatmcgav@gmail.com>


### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
