### PR TITLE
Add support for container termination logs

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.5.19
+Add support for specifying termination-log behaviour for Jenkins controller
+
 ## 3.5.18
 Add support for creating a Pod Disruption Budget for Jenkins controller
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.5.18
+version: 3.5.19
 appVersion: 2.303.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -128,6 +128,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.affinity`                 | Affinity settings                    | `{}`                                      |
 | `controller.schedulerName`            | Kubernetes scheduler name            | Not set                                   |
 | `controller.terminationGracePeriodSeconds` | Set TerminationGracePeriodSeconds   | Not set                               |
+| `controller.terminationMessage` | Set the termination log properties   | `{terminationMessagePath: /dev/termination-log, terminationMessagePolicy: File}`|
 | `controller.tolerations`              | Toleration labels for pod assignment | `[]`                                      |
 | `controller.podAnnotations`           | Annotations for controller pod           | `{}`                                      |
 | `controller.statefulSetAnnotations`   | Annotations for controller StatefulSet   | `{}`                                      |

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -128,7 +128,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.affinity`                 | Affinity settings                    | `{}`                                      |
 | `controller.schedulerName`            | Kubernetes scheduler name            | Not set                                   |
 | `controller.terminationGracePeriodSeconds` | Set TerminationGracePeriodSeconds   | Not set                               |
-| `controller.terminationMessage` | Set the termination log properties   | `{terminationMessagePath: /dev/termination-log, terminationMessagePolicy: File}`|
+| `controller.terminationMessagePath` | Set the termination message path   | Not set                               |
+| `controller.terminationMessagePolicy` | Set the termination message policy   | Not set                               |
 | `controller.tolerations`              | Toleration labels for pod assignment | `[]`                                      |
 | `controller.podAnnotations`           | Annotations for controller pod           | `{}`                                      |
 | `controller.statefulSetAnnotations`   | Annotations for controller StatefulSet   | `{}`                                      |

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -163,9 +163,11 @@ spec:
           lifecycle:
 {{ toYaml .Values.controller.lifecycle | indent 12 }}
           {{- end }}
-{{- if .Values.controller.terminationMessage }}
-          terminationMessagePath: {{ .Values.controller.terminationMessage.terminationMessagePath }}
-          terminationMessagePolicy: {{ .Values.controller.terminationMessage.terminationMessagePolicy }}
+{{- if .Values.controller.terminationMessagePath }}
+          terminationMessagePath: {{ .Values.controller.terminationMessagePath }}
+{{- end }}
+{{- if .Values.controller.terminationMessagePolicy }}
+          terminationMessagePolicy: {{ .Values.controller.terminationMessagePolicy }}
 {{- end }}
           env:
             - name: POD_NAME

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -163,6 +163,10 @@ spec:
           lifecycle:
 {{ toYaml .Values.controller.lifecycle | indent 12 }}
           {{- end }}
+{{- if .Values.controller.terminationMessage }}
+          terminationMessagePath: {{ .Values.controller.terminationMessage.terminationMessagePath }}
+          terminationMessagePolicy: {{ .Values.controller.terminationMessage.terminationMessagePolicy }}
+{{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -105,6 +105,8 @@ tests:
                     periodSeconds: 10
                     timeoutSeconds: 5
                     failureThreshold: 12
+                  terminationMessagePath: /dev/termination-log
+                  terminationMessagePolicy: File
                   volumeMounts:
                   - mountPath: /var/jenkins_home
                     name: jenkins-home
@@ -229,6 +231,9 @@ tests:
           drop:
             - NET_RAW
         hostNetworking: true
+        terminationMessage:
+          terminationMessagePath: /tmp/termination-log-diff
+          terminationMessagePolicy: FallbackToLogsOnError
         hostAliases:
           - ip: 192.168.50.50
             hostnames:
@@ -287,6 +292,12 @@ tests:
     - equal:
         path: spec.template.spec.hostNetwork
         value: true
+    - equal:
+        path: spec.template.spec.containers[0].terminationMessagePath
+        value: /tmp/termination-log-diff
+    - equal:
+        path: spec.template.spec.containers[0].terminationMessagePolicy
+        value: FallbackToLogsOnError
     - equal:
         path: spec.template.spec.dnsPolicy
         value: ClusterFirstWithHostNet

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -105,8 +105,6 @@ tests:
                     periodSeconds: 10
                     timeoutSeconds: 5
                     failureThreshold: 12
-                  terminationMessagePath: /dev/termination-log
-                  terminationMessagePolicy: File
                   volumeMounts:
                   - mountPath: /var/jenkins_home
                     name: jenkins-home
@@ -231,9 +229,8 @@ tests:
           drop:
             - NET_RAW
         hostNetworking: true
-        terminationMessage:
-          terminationMessagePath: /tmp/termination-log-diff
-          terminationMessagePolicy: FallbackToLogsOnError
+        terminationMessagePath: /tmp/termination-log-diff
+        terminationMessagePolicy: FallbackToLogsOnError
         hostAliases:
           - ip: 192.168.50.50
             hostnames:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -388,9 +388,8 @@ controller:
 
   terminationGracePeriodSeconds:
 
-  terminationMessage:
-    terminationMessagePath: /dev/termination-log
-    terminationMessagePolicy: File
+  terminationMessagePath:
+  terminationMessagePolicy:
 
   tolerations: []
 

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -388,6 +388,10 @@ controller:
 
   terminationGracePeriodSeconds:
 
+  terminationMessage:
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+
   tolerations: []
 
   affinity: {}


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it
This PR allows for configuration of termination log pathing and termination log policy. It configures the StatefulSet (Jenkins container).
Termination logs could be routed to persistent storages and termination log policies can incorporate last chunk of container log output using different policies.
### Which issue this PR fixes

- fixes #433 

### Special notes for your reviewer
This is my very first open source contribution. I adhered to the contribution guide. If I made an error along the way, please take the time to lesson me about it, so that I can avoid such mistakes in future contributions. Thank you! :)
### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
