### PR TITLE
feat: Adding tpl to init scripts config map

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.8.7
+
+Adding `tpl` to `initScripts`
+
 ## 3.8.6
 
 Add `controller.tagLabel` to specify the label for the image tag, for example `jdk11` or `alpine`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.8.6
+version: 3.8.7
 appVersion: 2.303.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/config-init-scripts.yaml
+++ b/charts/jenkins/templates/config-init-scripts.yaml
@@ -13,6 +13,6 @@ metadata:
 data:
 {{- range $key, $val := .Values.controller.initScripts }}
   init{{ $key }}.groovy: |-
-{{ $val | indent 4 }}
+{{ tpl $val $ | indent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/jenkins/unittests/config-init-scripts-test.yaml
+++ b/charts/jenkins/unittests/config-init-scripts-test.yaml
@@ -1,0 +1,19 @@
+suite: ConfigMap
+templates:
+  - config-init-scripts.yaml
+tests:
+  - it: config templates
+    set:
+      some.val: val here
+      controller.initScripts:
+        test: |-
+          my script here {{ .Values.some.val }}
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - hasDocuments:
+         count: 1
+      - equal:
+          path: data.inittest\.groovy
+          value: |-
+            my script here val here


### PR DESCRIPTION
### What this PR does / why we need it
Runs `tpl` on all inlined `init` scripts. This is useful when you want to generate a single template that can utilize things like `{{ .Values.some.val }}` inside. 

Follows the same pattern currently used in `config.yaml`

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated

CC - @timja @wmcdona89 @maorfr 
