### PR TITLE
Templates in override args

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.9.1
+
+Adding `tpl` to `controller.overrideArgs`
+
 ## 3.9.0
 
 Added containerSecurityContext

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.9.0
+version: 3.9.1
 appVersion: 2.303.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -158,7 +158,7 @@ spec:
           {{- if .Values.controller.overrideArgs }}
           args: [
             {{- range $overrideArg := .Values.controller.overrideArgs }}
-              "{{- $overrideArg }}",
+              "{{- tpl $overrideArg $ }}",
             {{- end }}
           ]
           {{- else if .Values.controller.httpsKeyStore.enable }}

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -524,6 +524,18 @@ tests:
           value:
             - --httpPort=8080
             - --requestHeaderSize=32768
+  - it: allows templating in container args overrides
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller.overrideArgs:
+        - --httpPort={{.Values.controller.targetPort}}
+        - --requestHeaderSize=32768
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --httpPort=8080
+            - --requestHeaderSize=32768
   - it: render pod annotations
     template: jenkins-controller-statefulset.yaml
     set:


### PR DESCRIPTION
### What this PR does / why we need it

Currently, there is no way of just add custom arguments the default container args. One has to override it completely while copying the default values into the override array. Some of the default options (e.g. port number) are retrieved from values.yaml fields. Using the `controller.overrideArgs` lacks the ability of just referring to such fields.

This PR adds `tpl` to `controller.overrideArgs` to make it easier for Chart users to reuse values across the configuration.

### Checklist

- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
