### PR TITLE
Fix config reload request url when httpsKeystore in use

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.9.3
+
+Fix config reload request url when httpsKeystore in use
+
 ## 3.9.2
 
 Update Jenkins image and appVersion to jenkins lts release version 2.319.1

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.9.2
+version: 3.9.3
 appVersion: 2.319.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -369,3 +369,14 @@ Create a full tag name for controller image
     {{- default .Chart.AppVersion .Values.controller.tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the HTTP port for interacting with the controller
+*/}}
+{{- define "controller.httpPort" -}}
+{{- if .Values.controller.httpsKeyStore.enable -}}
+    {{- .Values.controller.httpsKeyStore.httpPort -}}
+{{- else -}}
+    {{- .Values.controller.targetPort -}}
+{{- end -}}
+{{- end -}}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -305,11 +305,7 @@ spec:
             - name: NAMESPACE
               value: '{{ .Values.controller.sidecars.configAutoReload.searchNamespace | default (include "jenkins.namespace" .) }}'
             - name: REQ_URL
-            {{- if .Values.controller.httpsKeyStore.enable }}
-              value: "http://localhost:{{- .Values.controller.httpsKeyStore.httpPort -}}{{- .Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
-            {{- else }}
-              value: "http://localhost:{{- .Values.controller.targetPort -}}{{- .Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
-            {{- end }}
+              value: "http://localhost:{{- include "controller.httpPort" . -}}{{- .Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
             - name: REQ_METHOD
               value: "POST"
             - name: REQ_RETRY_CONNECT

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -305,7 +305,11 @@ spec:
             - name: NAMESPACE
               value: '{{ .Values.controller.sidecars.configAutoReload.searchNamespace | default (include "jenkins.namespace" .) }}'
             - name: REQ_URL
+            {{- if .Values.controller.httpsKeyStore.enable }}
+              value: "http://localhost:{{- .Values.controller.httpsKeyStore.httpPort -}}{{- .Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
+            {{- else }}
               value: "http://localhost:{{- .Values.controller.targetPort -}}{{- .Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
+            {{- end }}
             - name: REQ_METHOD
               value: "POST"
             - name: REQ_RETRY_CONNECT


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it

Previously, the config reload sidecar's request URL pointed to the `targetPort`, which, when the httpsKeystore is in use, is set to `8443` in our configuration. The sidecar ends up POSTing HTTP->HTTPS, which results in a `BadStatusLine` error when the sidecar attempts a configuration reload. This PR fixes the REQ_URL environment variable's template to correctly use the defined `httpsKeyStore.httpPort` when the httpsKeyStore is enabled, like other uses of `targetPort` do.

### Special notes for your reviewer

@torstenwalter @justusbunsi @nikonorovi 

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
