### PR TITLE
feat(gh-pages): redirect from Helm charts repository index.html to Github repository homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<html>
+    <head>
+        <link rel="canonical" href="https://github.com/jenkinsci/helm-charts/" />
+        <noscript>
+            <meta http-equiv="refresh" content="0; URL=https://github.com/jenkinsci/helm-charts/" />
+        </noscript>
+    </head>
+    <body>
+        <script type="text/javascript">
+            window.location.replace("https://github.com/jenkinsci/helm-charts")
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
The [current gh-pages index](https://jenkinsci.github.io/helm-charts) doesn't provide such useful information:

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/91831478/146548800-79890acc-3b60-4402-be76-9c0dd50de6af.png">

With this PR, consulting https://jenkinsci.github.io/helm-charts with a browser (for the devs) will redirect to this Github repository homepage, which can be handy when wanting to know more about a chart than just the command to add the helm repo.

It doesn't touch the index.yaml, nothing change on the helm side.

