### PR TITLE
Fix definition of startupProbe when deploying on a Kubernetes cluster < 1.16

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.10.2
+
+Fix definition of startupProbe when deploying on a Kubernetes cluster < 1.16
+
 ## 3.10.1
 
 correct VALUES_SUMMARY.md for installLatestPlugins

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.10.1
+version: 3.10.2
 appVersion: 2.319.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -224,7 +224,14 @@ spec:
               name: {{ $port.name }}
 {{- end }}
 {{- if and .Values.controller.healthProbes .Values.controller.probes}}
-{{ tpl (toYaml .Values.controller.probes | indent 10) .}}
+  {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+          startupProbe:
+{{ tpl (toYaml .Values.controller.probes.startupProbe | indent 12) .}}
+  {{- end }}
+          livenessProbe:
+{{ tpl (toYaml .Values.controller.probes.livenessProbe | indent 12) .}}
+          readinessProbe:
+{{ tpl (toYaml .Values.controller.probes.readinessProbe | indent 12) .}}
 {{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -143,7 +143,7 @@ controller:
   podLabels: {}
   # Used to create Ingress record (should used with ServiceType: ClusterIP)
   # nodePort: <to set explicitly, choose port between 30000-32767
-  # Enable Kubernetes Liveness and Readiness Probes
+  # Enable Kubernetes Startup, Liveness and Readiness Probes
   # if Startup Probe is supported, enable it too
   # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout.
   healthProbes: true


### PR DESCRIPTION
### What this PR does / why we need it

When deploying on a Kubernetes cluster 1.14 (technical debt, I know😅), I encountered an issue with the startupProbe : Kubernetes refused to create the Statefulset because this type of probe was added in Kubernetes 1.16.

So I made this fix in order to make it work on legacy Kubernetes clusters like mine.

### Which issue this PR fixes

N/A

### Special notes for your reviewer

### Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
