### PR TITLE
Improve workspaceVolume example

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.11.2
+
+Improve example for workspaceVolume. Clarify that this is not a list.
+
 ## 3.11.1
 
 Update configuration-as-code plugin to 1.55.1

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.11.1
+version: 3.11.2
 appVersion: 2.319.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -648,19 +648,25 @@ agent:
   # Configure the attributes as they appear in the corresponding Java class for that type
   # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace
   workspaceVolume: {}
-  # - type: DynamicPVC
-  #   configMapName: myconfigmap
-  # - type: EmptyDir
-  #   memory: false
-  # - type: HostPath
-  #   hostPath: /var/lib/containers
-  # - type: Nfs
-  #   readOnly: false
-  #   serverAddress: "192.0.2.0"
-  #   serverPath: /var/lib/containers
-  # - type: PVC
-  #   claimName: mypvc
-  #   readOnly: false
+  ## DynamicPVC example
+  # type: DynamicPVC
+  # configMapName: myconfigmap
+  ## EmptyDir example
+  # type: EmptyDir
+  # memory: false
+  ## HostPath example
+  # type: HostPath
+  # hostPath: /var/lib/containers
+  ## NFS example
+  # type: Nfs
+  # readOnly: false
+  # serverAddress: "192.0.2.0"
+  # serverPath: /var/lib/containers
+  ## PVC example
+  # type: PVC
+  # claimName: mypvc
+  # readOnly: false
+  #
   # Pod-wide environment, these vars are visible to any container in the agent pod
   envVars: []
   # - name: PATH


### PR DESCRIPTION
### What this PR does / why we need it

Have a look at #541 the current example is a bit misleading as one could thing that one should specify list entries.

So instead of:
```yaml
agent:
  workspaceVolume:
    - type: Nfs
      readOnly: false
      serverAddress: "192.0.2.0"
      serverPath: /var/lib/containers
```

one should specify it like:

```yaml
agent:
  workspaceVolume:
    type: Nfs
    readOnly: false
    serverAddress: "192.0.2.0"
    serverPath: /var/lib/containers
```

### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #541

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
