### PR TITLE
Make namespace overwritable for agents and additional agents.

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -11,6 +11,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
+## 3.12.1
+
+Make namespace configurable for agents and additional agents.
 
 ## 3.12.0
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.12.0
+version: 3.12.1
 appVersion: 2.332.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -215,6 +215,7 @@ Returns kubernetes pod template configuration as code
 */}}
 {{- define "jenkins.casc.podTemplate" -}}
 - name: "{{ .Values.agent.podName }}"
+  namespace: "{{ template "jenkins.agent.namespace" . }}"
 {{- if .Values.agent.annotations }}
   annotations:
   {{- range $key, $value := .Values.agent.annotations }}

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -54,6 +54,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "default"
                       id: be62f2fe67fa3e83c0157edaa53417c084c49a8aa88c3702e3ca1cc8df3fcbe2
                       containers:
                       - name: "jnlp"
@@ -101,6 +102,7 @@ tests:
     set:
       additionalAgents:
         maven:
+          namespace: maven
           podName: maven
           customJenkinsLabels: maven
           image: jenkins/jnlp-agent-maven
@@ -172,6 +174,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "jenkins-agents"
                       id: fb186b04e498a07ac381b138f97f45cd407b0e542abf1b26f44ad3df4031b91f
                       containers:
                       - name: "jnlp"
@@ -202,7 +205,8 @@ tests:
                       slaveConnectTimeoutStr: "100"
                       yamlMergeStrategy: override
                     - name: "maven"
-                      id: df0244d29bd7312f2ce8eec55e63bd08c0ec8b07594a183a13e01c8dfc8ad0e5
+                      namespace: "maven"
+                      id: a2b13e847c4e27a7dff0a45a86d56d2accc1afc806de3a53c7f7e9d0d2275573
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -232,6 +236,7 @@ tests:
                       slaveConnectTimeoutStr: "100"
                       yamlMergeStrategy: override
                     - name: "python"
+                      namespace: "jenkins-agents"
                       id: 08d5db5de8b6a314bcc143600d3fb55332126f02c96c167221fba262ba75c516
                       containers:
                       - name: "python"
@@ -313,6 +318,7 @@ tests:
                 - jenkins.example.com
               secretName: tlsSecret
       agent:
+        namespace: default
         containerCap: 22
         defaultsProviderTemplate: my-defaults
         kubernetesConnectTimeout: 11
@@ -459,17 +465,18 @@ tests:
                   jenkinsTunnel: "my-release-jenkins-agent.other.svc.cluster.local:50000"
                   maxRequestsPerHostStr: "32"
                   name: "kubernetes"
-                  namespace: "other"
+                  namespace: "default"
                   serverUrl: "https://kubernetes.default"
                   podLabels:
                   - key: "jenkins/my-release-jenkins-agent"
                     value: "true"
                   templates:
                     - name: "my-agent"
+                      namespace: "default"
                       annotations:
                       - key: ci.jenkins-agent/test
                         value: "custom"
-                      id: 65241d1dcc7c5ab09096e3109ad3032ed82f771c8005b1db4b66ffeea179b4d4
+                      id: b23926d294f4506acd7bf4dd06d992d4f8f0baeb12bc2967fc962255c6362580
                       containers:
                       - name: "sideContainer"
                         alwaysPullImage: true
@@ -607,6 +614,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "default"
                       id: ad22f5309074ca9d1cfb473f2a70f87e647be9d85f4f73238c0fe312e07f169b
                       containers:
                       - name: "jnlp"
@@ -710,6 +718,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "default"
                       id: 34616e288fd4876ce8d28efd47e114b5eb1de8bb725ce8c3d9798b2f06987cbf
                       containers:
                       - name: "jnlp"
@@ -811,6 +820,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "default"
                       id: b4cbcc759d506d82f7f4fca44406303e85dcd0949968116da31a3dd031bbae3b
                       containers:
                       - name: "jnlp"
@@ -914,6 +924,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "default"
                       id: 80a11a5a66bdd2fecb8562311ad8d36161dec311cbb3e4c4cde867ef2b1c2dbb
                       containers:
                       - name: "jnlp"
@@ -1018,6 +1029,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "default"
                       id: a8a87eb5b5691a7a71b301118b15f69c125532106334cc5c80bb7fb7f07675e2
                       containers:
                       - name: "jnlp"
@@ -1121,6 +1133,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "default"
                       id: be86521933b05ad71d1c272af3378b422c9725e2f91a4070f9f40d32b4765ede
                       containers:
                       - name: "jnlp"
@@ -1291,6 +1304,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "default"
                       id: be62f2fe67fa3e83c0157edaa53417c084c49a8aa88c3702e3ca1cc8df3fcbe2
                       containers:
                       - name: "jnlp"
@@ -1391,6 +1405,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "NAMESPACE"
                       id: b756d76152a021e2370bac48b60b44a0755d3a53fa3e074d8cda4e6711bbd7d5
                       containers:
                       - name: "jnlp"
@@ -1489,6 +1504,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
+                      namespace: "default"
                       id: be62f2fe67fa3e83c0157edaa53417c084c49a8aa88c3702e3ca1cc8df3fcbe2
                       containers:
                       - name: "jnlp"


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it
Currently, the namespace for Kubernetes cloud agents is set to the chart namespace however a value does exist for its Values.agent.namespace.
This change should allow the user to set a different namespace for agents in general and also overwrite the namespace for additional agents.

### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
