### PR TITLE
Added Value for disabling default Jenkins Agent

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.12.0
+
+Added a flag for disabling the default Jenkins Agent configuration.
+
 ## 3.11.10
 
 Update Jenkins image and appVersion to jenkins lts release version 2.332.2

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.11.10
+version: 3.12.0
 appVersion: 2.332.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -338,10 +338,11 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 #### Other
 
-| Parameter                  | Description                                     | Default                |
-| -------------------------- | ----------------------------------------------- | ---------------------- |
-| `agent.podTemplates`       | Configures extra pod templates for the default kubernetes cloud | `{}`   |
-| `additionalAgents`         | Configure additional agents which inherit values from `agent` | `{}`     |
+| Parameter                   | Description                                     | Default                |
+| --------------------------  | ----------------------------------------------- | ---------------------- |
+| `agent.disableDefaultAgent` | Ignore the default Jenkins Agent configuration  | false                  |
+| `agent.podTemplates`        | Configures extra pod templates for the default kubernetes cloud | `{}`   |
+| `additionalAgents`          | Configure additional agents which inherit values from `agent` | `{}`     |
 
 ### Persistence
 

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -165,7 +165,9 @@ jenkins:
         value: {{ $val | quote }}
       {{- end }}
       templates:
+    {{- if not .Values.agent.disableDefaultAgent }}
       {{- include "jenkins.casc.podTemplate" . | nindent 8 }}
+    {{- end }}
     {{- if .Values.additionalAgents }}
       {{- /* save .Values.agent */}}
       {{- $agent := .Values.agent }}

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -54,7 +54,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 1d5e7358aa57e8d8fb5290164936179288c8018247360a8e6c5bbd48e05cbb40
+                      id: be62f2fe67fa3e83c0157edaa53417c084c49a8aa88c3702e3ca1cc8df3fcbe2
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -172,7 +172,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: ef511ee9cd7e0218b92488675d593e1db3ceedc9030331d6206999f9fa9f35c6
+                      id: fb186b04e498a07ac381b138f97f45cd407b0e542abf1b26f44ad3df4031b91f
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -202,7 +202,7 @@ tests:
                       slaveConnectTimeoutStr: "100"
                       yamlMergeStrategy: override
                     - name: "maven"
-                      id: d204e244404e97e456aa1641883174c59de76250356af9148e1e38059d6fc6c2
+                      id: df0244d29bd7312f2ce8eec55e63bd08c0ec8b07594a183a13e01c8dfc8ad0e5
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -232,7 +232,7 @@ tests:
                       slaveConnectTimeoutStr: "100"
                       yamlMergeStrategy: override
                     - name: "python"
-                      id: 8a44a96bd58091511ff4d749c8b7d91f5de04a750c284d144f464dd6234db3b3
+                      id: 08d5db5de8b6a314bcc143600d3fb55332126f02c96c167221fba262ba75c516
                       containers:
                       - name: "python"
                         alwaysPullImage: false
@@ -469,7 +469,7 @@ tests:
                       annotations:
                       - key: ci.jenkins-agent/test
                         value: "custom"
-                      id: 47e9695830400ef49ba31b6ae7769ee65d3703c0d13dccc175f9565f62ddfd2a
+                      id: 65241d1dcc7c5ab09096e3109ad3032ed82f771c8005b1db4b66ffeea179b4d4
                       containers:
                       - name: "sideContainer"
                         alwaysPullImage: true
@@ -607,7 +607,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 9ac232a228983c3f8cf350915bfa487223e818baff6f316461b4f2f45c95af21
+                      id: ad22f5309074ca9d1cfb473f2a70f87e647be9d85f4f73238c0fe312e07f169b
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -710,7 +710,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: c383c2aa2156720dbefb12f76200b23b6b011f8d3f499ef418f76d04e383f39c
+                      id: 34616e288fd4876ce8d28efd47e114b5eb1de8bb725ce8c3d9798b2f06987cbf
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -811,7 +811,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 4c6548123981cce394208b5d39fa8ff8588f1939ad7a39a8c95f74dad4ad8e28
+                      id: b4cbcc759d506d82f7f4fca44406303e85dcd0949968116da31a3dd031bbae3b
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -914,7 +914,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 8f7c750a732cd7bf41991060e953f6dc152a3b989f0c80670ecdaa2d29e9ab20
+                      id: 80a11a5a66bdd2fecb8562311ad8d36161dec311cbb3e4c4cde867ef2b1c2dbb
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1018,7 +1018,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 2a6303f5ba784e173e355c66dd64546aadd74c3eb8798890c2693342b601846b
+                      id: a8a87eb5b5691a7a71b301118b15f69c125532106334cc5c80bb7fb7f07675e2
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1121,7 +1121,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: eac322f6c9065f6f288b7543745f5d72c9a02841dc016b14685e5bd1746273f1
+                      id: be86521933b05ad71d1c272af3378b422c9725e2f91a4070f9f40d32b4765ede
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1291,7 +1291,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 1d5e7358aa57e8d8fb5290164936179288c8018247360a8e6c5bbd48e05cbb40
+                      id: be62f2fe67fa3e83c0157edaa53417c084c49a8aa88c3702e3ca1cc8df3fcbe2
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1391,7 +1391,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: c33e44054ae465f9813a27d455dc45f15dacefe7dbc41633043d38266de19459
+                      id: b756d76152a021e2370bac48b60b44a0755d3a53fa3e074d8cda4e6711bbd7d5
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1489,7 +1489,7 @@ tests:
                     value: "true"
                   templates:
                     - name: "default"
-                      id: 1d5e7358aa57e8d8fb5290164936179288c8018247360a8e6c5bbd48e05cbb40
+                      id: be62f2fe67fa3e83c0157edaa53417c084c49a8aa88c3702e3ca1cc8df3fcbe2
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -711,6 +711,10 @@ agent:
   # Annotations to apply to the pod.
   annotations: {}
 
+  # Disable the default Jenkins Agent configuration.
+  # Useful when configuring agents only with the podTemplates value, since the default podTemplate populated by values mentioned above will be excluded in the rendered template.
+  disableDefaultAgent: false
+
   # Below is the implementation of custom pod templates for the default configured kubernetes cloud.
   # Add a key under podTemplates for each pod template. Each key (prior to | character) is just a label, and can be any value.
   # Keys are only used to give the pod template a meaningful name.  The only restriction is they may only contain RFC 1123 \ DNS label


### PR DESCRIPTION
### What this PR does / why we need it
When specifying podTemplates for the Jenkins Agent configuration, there is always a default agent configuration which you cannot get rid of. This PR adds a flag which allows you to disable to default Jenkins Agent configuration which defaults to false, the current behaviour.

### Which issue this PR fixes
- fixes #608

### Special notes for your reviewer

### Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
