### PR TITLE
Add `legacyRemotingSecurityEnabled` flag

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,9 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
-## 3.13.0
+## 4.0.0
 
-Introduced a `.controller.legacyRemotingSecurityEnabled` flag, to explicitly enable or disable `remotingSecurity` (introduced in [`3.11.7`](#3117)) when the `.container.tag` is custom (e.g. `lts-alpine` or using a custom image which does not follow the Jenkins versioning).
+Removes automatic `remotingSecurity` setting when using a container tag older than `2.236` (introduced in [`3.11.7`](#3117)). If you're using a version older than `2.236`, you should explicitly set `.controller.legacyRemotingSecurityEnabled` to `true`. 
 
 ## 3.12.2
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 4.0.0
 
-Removes automatic `remotingSecurity` setting when using a container tag older than `2.236` (introduced in [`3.11.7`](#3117)). If you're using a version older than `2.236`, you should explicitly set `.controller.legacyRemotingSecurityEnabled` to `true`. 
+Removes automatic `remotingSecurity` setting when using a container tag older than `2.326` (introduced in [`3.11.7`](#3117)). If you're using a version older than `2.326`, you should explicitly set `.controller.legacyRemotingSecurityEnabled` to `true`.
 
 ## 3.12.2
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 3.13.0
+
+Introduced a `.controller.legacyRemotingSecurityEnabled` flag, to explicitly enable or disable `remotingSecurity` (introduced in [`3.11.7`](#3117)) when the `.container.tag` is custom (e.g. `lts-alpine` or using a custom image which does not follow the Jenkins versioning). 
+
 ## 3.12.2
 
 Update Jenkins image and appVersion to jenkins lts release version 2.332.3

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 3.13.0
 
-Introduced a `.controller.legacyRemotingSecurityEnabled` flag, to explicitly enable or disable `remotingSecurity` (introduced in [`3.11.7`](#3117)) when the `.container.tag` is custom (e.g. `lts-alpine` or using a custom image which does not follow the Jenkins versioning). 
+Introduced a `.controller.legacyRemotingSecurityEnabled` flag, to explicitly enable or disable `remotingSecurity` (introduced in [`3.11.7`](#3117)) when the `.container.tag` is custom (e.g. `lts-alpine` or using a custom image which does not follow the Jenkins versioning).
 
 ## 3.12.2
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.12.2
+version: 3.13.0
 appVersion: 2.332.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 3.13.0
+version: 4.0.0
 appVersion: 2.332.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -6,17 +6,18 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 ### Jenkins Controller
 
-| Parameter                         | Description                          | Default                                   |
-| --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `checkDeprecation`                | Checks for deprecated values used    | `true`                                 |
-| `clusterZone`                     | Override the cluster name for FQDN resolving    | `cluster.local`                |
-| `nameOverride`                    | Override the resource name prefix    | `jenkins`                                 |
-| `renderHelmLabels`                | Enables rendering of the helm.sh/chart label to the annotations    | `true`                                 |
-| `fullnameOverride`                | Override the full resource names     | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`) |
-| `namespaceOverride`               | Override the deployment namespace    | Not set (`Release.Namespace`)             |
-| `controller.componentName`            | Jenkins controller name                  | `jenkins-controller`                          |
-| `controller.testEnabled`              | Can be used to disable rendering test resources when using helm template | `true`                         |
-| `controller.cloudName`                       | Name of default cloud configuration  | `kubernetes`                              |
+| Parameter                                   | Description                                                              | Default                                                               |
+|---------------------------------------------|--------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| `checkDeprecation`                          | Checks for deprecated values used                                        | `true`                                                                |
+| `clusterZone`                               | Override the cluster name for FQDN resolving                             | `cluster.local`                                                       |
+| `nameOverride`                              | Override the resource name prefix                                        | `jenkins`                                                             |
+| `renderHelmLabels`                          | Enables rendering of the helm.sh/chart label to the annotations          | `true`                                                                |
+| `fullnameOverride`                          | Override the full resource names                                         | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`)  |
+| `namespaceOverride`                         | Override the deployment namespace                                        | Not set (`Release.Namespace`)                                         |
+| `controller.componentName`                  | Jenkins controller name                                                  | `jenkins-controller`                                                  |
+| `controller.testEnabled`                    | Can be used to disable rendering test resources when using helm template | `true`                                                                |
+| `controller.cloudName`                      | Name of default cloud configuration                                      | `kubernetes`                                                          |
+| `controller.legacyRemotingSecurityEnabled`  | Is remoting security enabled?                                            | `true` when `controller.tag` is older than `2.326`, `false` otherwise | 
 
 #### Jenkins Configuration as Code (JCasC)
 

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -6,18 +6,18 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 ### Jenkins Controller
 
-| Parameter                                   | Description                                                              | Default                                                               |
-|---------------------------------------------|--------------------------------------------------------------------------|-----------------------------------------------------------------------|
-| `checkDeprecation`                          | Checks for deprecated values used                                        | `true`                                                                |
-| `clusterZone`                               | Override the cluster name for FQDN resolving                             | `cluster.local`                                                       |
-| `nameOverride`                              | Override the resource name prefix                                        | `jenkins`                                                             |
-| `renderHelmLabels`                          | Enables rendering of the helm.sh/chart label to the annotations          | `true`                                                                |
-| `fullnameOverride`                          | Override the full resource names                                         | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`)  |
-| `namespaceOverride`                         | Override the deployment namespace                                        | Not set (`Release.Namespace`)                                         |
-| `controller.componentName`                  | Jenkins controller name                                                  | `jenkins-controller`                                                  |
-| `controller.testEnabled`                    | Can be used to disable rendering test resources when using helm template | `true`                                                                |
-| `controller.cloudName`                      | Name of default cloud configuration                                      | `kubernetes`                                                          |
-| `controller.legacyRemotingSecurityEnabled`  | Is remoting security enabled?                                            | `true` when `controller.tag` is older than `2.326`, `false` otherwise |
+| Parameter                                   | Description                                                              | Default                                                              |
+|---------------------------------------------|--------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `checkDeprecation`                          | Checks for deprecated values used                                        | `true`                                                               |
+| `clusterZone`                               | Override the cluster name for FQDN resolving                             | `cluster.local`                                                      |
+| `nameOverride`                              | Override the resource name prefix                                        | `jenkins`                                                            |
+| `renderHelmLabels`                          | Enables rendering of the helm.sh/chart label to the annotations          | `true`                                                               |
+| `fullnameOverride`                          | Override the full resource names                                         | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`) |
+| `namespaceOverride`                         | Override the deployment namespace                                        | Not set (`Release.Namespace`)                                        |
+| `controller.componentName`                  | Jenkins controller name                                                  | `jenkins-controller`                                                 |
+| `controller.testEnabled`                    | Can be used to disable rendering test resources when using helm template | `true`                                                               |
+| `controller.cloudName`                      | Name of default cloud configuration                                      | `kubernetes`                                                         |
+| `controller.legacyRemotingSecurityEnabled`  | Is remoting security enabled?                                            | Not set (i.e. not enabled)                                           |
 
 #### Jenkins Configuration as Code (JCasC)
 

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -17,7 +17,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.componentName`                  | Jenkins controller name                                                  | `jenkins-controller`                                                  |
 | `controller.testEnabled`                    | Can be used to disable rendering test resources when using helm template | `true`                                                                |
 | `controller.cloudName`                      | Name of default cloud configuration                                      | `kubernetes`                                                          |
-| `controller.legacyRemotingSecurityEnabled`  | Is remoting security enabled?                                            | `true` when `controller.tag` is older than `2.326`, `false` otherwise | 
+| `controller.legacyRemotingSecurityEnabled`  | Is remoting security enabled?                                            | `true` when `controller.tag` is older than `2.326`, `false` otherwise |
 
 #### Jenkins Configuration as Code (JCasC)
 

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -98,6 +98,17 @@ Returns the Jenkins URL
 {{- end}}
 {{- end -}}
 
+{{- define "jenkins.casc.isLegacyRemotingSecurityEnabled" }}
+{{- if hasKey .Values.controller "legacyRemotingSecurityEnabled" -}}
+{{- /* set remotingSecurity based on the .Values, if provided */ -}}
+{{- (.Values.controller.legacyRemotingSecurityEnabled | toString) -}}
+{{- else -}}
+{{- $controllerVersion := semver (default .Chart.AppVersion .Values.controller.tag) -}}
+{{- /* remove remotingSecurity in jenkins 2.326 or newer */ -}}
+{{- (lt 0 ($controllerVersion | (semver "2.326").Compare)) | toString -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Returns configuration as code default config
 */}}
@@ -113,9 +124,7 @@ jenkins:
     {{- tpl .Values.controller.JCasC.securityRealm . | nindent 4 }}
   {{- end }}
   disableRememberMe: {{ .Values.controller.disableRememberMe }}
-  {{- /* remove remotingSecurity in jenkins 2.326 or newer */}}
-  {{- $controllerVersion := semver (default .Chart.AppVersion .Values.controller.tag) }}
-  {{- if lt 0 ($controllerVersion | (semver "2.326").Compare) }}
+  {{- if (eq (include "jenkins.casc.isLegacyRemotingSecurityEnabled" .) "true") }}
   remotingSecurity:
     enabled: true
   {{- end }}

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -124,7 +124,7 @@ jenkins:
     {{- tpl .Values.controller.JCasC.securityRealm . | nindent 4 }}
   {{- end }}
   disableRememberMe: {{ .Values.controller.disableRememberMe }}
-  {{- if (eq (include "jenkins.casc.isLegacyRemotingSecurityEnabled" .) "true") }}
+  {{- if .Values.controller.legacyRemotingSecurityEnabled }}
   remotingSecurity:
     enabled: true
   {{- end }}

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -98,17 +98,6 @@ Returns the Jenkins URL
 {{- end}}
 {{- end -}}
 
-{{- define "jenkins.casc.isLegacyRemotingSecurityEnabled" }}
-{{- if hasKey .Values.controller "legacyRemotingSecurityEnabled" -}}
-{{- /* set remotingSecurity based on the .Values, if provided */ -}}
-{{- (.Values.controller.legacyRemotingSecurityEnabled | toString) -}}
-{{- else -}}
-{{- $controllerVersion := semver (default .Chart.AppVersion .Values.controller.tag) -}}
-{{- /* remove remotingSecurity in jenkins 2.326 or newer */ -}}
-{{- (lt 0 ($controllerVersion | (semver "2.326").Compare)) | toString -}}
-{{- end -}}
-{{- end -}}
-
 {{/*
 Returns configuration as code default config
 */}}

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -1447,112 +1447,11 @@ tests:
               location:
                 adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
-  - it: default config for jenkins 2.325 or older
-    release:
-      namespace: default
-    set:
-      controller:
-        tag: "2.325-jdk11"
-    asserts:
-      - isKind:
-          of: ConfigMap
-      - hasDocuments:
-         count: 1
-      - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
-      - matchRegex:
-          path: metadata.labels.helm\.sh/chart
-          pattern: ^jenkins-
-      - equal:
-          path: data.jcasc-default-config\.yaml
-          value: |-
-            jenkins:
-              authorizationStrategy:
-                loggedInUsersCanDoAnything:
-                  allowAnonymousRead: false
-              securityRealm:
-                local:
-                  allowsSignup: false
-                  enableCaptcha: false
-                  users:
-                  - id: "${chart-admin-username}"
-                    name: "Jenkins Admin"
-                    password: "${chart-admin-password}"
-              disableRememberMe: false
-              remotingSecurity:
-                enabled: true
-              mode: NORMAL
-              numExecutors: 0
-              labelString: ""
-              projectNamingStrategy: "standard"
-              markupFormatter:
-                plainText
-              clouds:
-              - kubernetes:
-                  containerCapStr: "10"
-                  defaultsProviderTemplate: ""
-                  connectTimeout: "5"
-                  readTimeout: "15"
-                  jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
-                  jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
-                  maxRequestsPerHostStr: "32"
-                  name: "kubernetes"
-                  namespace: "default"
-                  serverUrl: "https://kubernetes.default"
-                  podLabels:
-                  - key: "jenkins/RELEASE-NAME-jenkins-agent"
-                    value: "true"
-                  templates:
-                    - name: "default"
-                      namespace: "default"
-                      id: be62f2fe67fa3e83c0157edaa53417c084c49a8aa88c3702e3ca1cc8df3fcbe2
-                      containers:
-                      - name: "jnlp"
-                        alwaysPullImage: false
-                        args: "^${computer.jnlpmac} ^${computer.name}"
-                        command: 
-                        envVars:
-                          - envVar:
-                              key: "JENKINS_URL"
-                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
-                        image: "jenkins/inbound-agent:4.11.2-4"
-                        privileged: "false"
-                        resourceLimitCpu: 512m
-                        resourceLimitMemory: 512Mi
-                        resourceRequestCpu: 512m
-                        resourceRequestMemory: 512Mi
-                        runAsUser: 
-                        runAsGroup: 
-                        ttyEnabled: false
-                        workingDir: /home/jenkins/agent
-                      idleMinutes: 0
-                      instanceCap: 2147483647
-                      label: "RELEASE-NAME-jenkins-agent "
-                      nodeUsageMode: "NORMAL"
-                      podRetention: Never
-                      showRawYaml: true
-                      serviceAccount: "default"
-                      slaveConnectTimeoutStr: "100"
-                      yamlMergeStrategy: override
-              crumbIssuer:
-                standard:
-                  excludeClientIPFromCrumb: true
-            security:
-              apiToken:
-                creationOfLegacyTokenEnabled: false
-                tokenGenerationOnCreationEnabled: false
-                usageStatisticsEnabled: true
-            unclassified:
-              location:
-                adminAddress: 
-                url: http://RELEASE-NAME-jenkins:8080
-
   - it: legacyRemotingSecurityEnabled = false (even though jenkins is 2.325 or older)
     release:
       namespace: default
     set:
       controller:
-        tag: "2.325-jdk11"
         legacyRemotingSecurityEnabled: false
     asserts:
     - isKind:
@@ -1652,7 +1551,6 @@ tests:
     set:
       controller:
         legacyRemotingSecurityEnabled: true
-        tag: "lts-alpine"
     asserts:
     - isKind:
         of: ConfigMap

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -1447,7 +1447,7 @@ tests:
               location:
                 adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
-  - it: legacyRemotingSecurityEnabled = false (even though jenkins is 2.325 or older)
+  - it: legacyRemotingSecurityEnabled = false
     release:
       namespace: default
     set:

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -1609,7 +1609,7 @@ tests:
                     - name: "jnlp"
                       alwaysPullImage: false
                       args: "^${computer.jnlpmac} ^${computer.name}"
-                      command:
+                      command: 
                       envVars:
                         - envVar:
                             key: "JENKINS_URL"
@@ -1620,8 +1620,8 @@ tests:
                       resourceLimitMemory: 512Mi
                       resourceRequestCpu: 512m
                       resourceRequestMemory: 512Mi
-                      runAsUser:
-                      runAsGroup:
+                      runAsUser: 
+                      runAsGroup: 
                       ttyEnabled: false
                       workingDir: /home/jenkins/agent
                     idleMinutes: 0
@@ -1643,8 +1643,9 @@ tests:
               usageStatisticsEnabled: true
           unclassified:
             location:
-              adminAddress:
+              adminAddress: 
               url: http://RELEASE-NAME-jenkins:8080
+
   - it: legacyRemotingSecurityEnabled = true
     release:
       namespace: default
@@ -1709,7 +1710,7 @@ tests:
                     - name: "jnlp"
                       alwaysPullImage: false
                       args: "^${computer.jnlpmac} ^${computer.name}"
-                      command:
+                      command: 
                       envVars:
                         - envVar:
                             key: "JENKINS_URL"
@@ -1720,8 +1721,8 @@ tests:
                       resourceLimitMemory: 512Mi
                       resourceRequestCpu: 512m
                       resourceRequestMemory: 512Mi
-                      runAsUser:
-                      runAsGroup:
+                      runAsUser: 
+                      runAsGroup: 
                       ttyEnabled: false
                       workingDir: /home/jenkins/agent
                     idleMinutes: 0
@@ -1743,8 +1744,6 @@ tests:
               usageStatisticsEnabled: true
           unclassified:
             location:
-              adminAddress:
+              adminAddress: 
               url: http://RELEASE-NAME-jenkins:8080
-
-
 

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -1546,3 +1546,205 @@ tests:
               location:
                 adminAddress: 
                 url: http://RELEASE-NAME-jenkins:8080
+
+  - it: legacyRemotingSecurityEnabled = false (even though jenkins is 2.325 or older)
+    release:
+      namespace: default
+    set:
+      controller:
+        tag: "2.325-jdk11"
+        legacyRemotingSecurityEnabled: false
+    asserts:
+    - isKind:
+        of: ConfigMap
+    - hasDocuments:
+        count: 1
+    - isNotEmpty:
+        path: data.jcasc-default-config\.yaml
+    - matchRegex:
+        path: metadata.labels.helm\.sh/chart
+        pattern: ^jenkins-
+    - equal:
+        path: data.jcasc-default-config\.yaml
+        value: |-
+          jenkins:
+            authorizationStrategy:
+              loggedInUsersCanDoAnything:
+                allowAnonymousRead: false
+            securityRealm:
+              local:
+                allowsSignup: false
+                enableCaptcha: false
+                users:
+                - id: "${chart-admin-username}"
+                  name: "Jenkins Admin"
+                  password: "${chart-admin-password}"
+            disableRememberMe: false
+            mode: NORMAL
+            numExecutors: 0
+            labelString: ""
+            projectNamingStrategy: "standard"
+            markupFormatter:
+              plainText
+            clouds:
+            - kubernetes:
+                containerCapStr: "10"
+                defaultsProviderTemplate: ""
+                connectTimeout: "5"
+                readTimeout: "15"
+                jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+                jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                maxRequestsPerHostStr: "32"
+                name: "kubernetes"
+                namespace: "default"
+                serverUrl: "https://kubernetes.default"
+                podLabels:
+                - key: "jenkins/RELEASE-NAME-jenkins-agent"
+                  value: "true"
+                templates:
+                  - name: "default"
+                    namespace: "default"
+                    id: be62f2fe67fa3e83c0157edaa53417c084c49a8aa88c3702e3ca1cc8df3fcbe2
+                    containers:
+                    - name: "jnlp"
+                      alwaysPullImage: false
+                      args: "^${computer.jnlpmac} ^${computer.name}"
+                      command:
+                      envVars:
+                        - envVar:
+                            key: "JENKINS_URL"
+                            value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                      image: "jenkins/inbound-agent:4.11.2-4"
+                      privileged: "false"
+                      resourceLimitCpu: 512m
+                      resourceLimitMemory: 512Mi
+                      resourceRequestCpu: 512m
+                      resourceRequestMemory: 512Mi
+                      runAsUser:
+                      runAsGroup:
+                      ttyEnabled: false
+                      workingDir: /home/jenkins/agent
+                    idleMinutes: 0
+                    instanceCap: 2147483647
+                    label: "RELEASE-NAME-jenkins-agent "
+                    nodeUsageMode: "NORMAL"
+                    podRetention: Never
+                    showRawYaml: true
+                    serviceAccount: "default"
+                    slaveConnectTimeoutStr: "100"
+                    yamlMergeStrategy: override
+            crumbIssuer:
+              standard:
+                excludeClientIPFromCrumb: true
+          security:
+            apiToken:
+              creationOfLegacyTokenEnabled: false
+              tokenGenerationOnCreationEnabled: false
+              usageStatisticsEnabled: true
+          unclassified:
+            location:
+              adminAddress:
+              url: http://RELEASE-NAME-jenkins:8080
+  - it: legacyRemotingSecurityEnabled = true
+    release:
+      namespace: default
+    set:
+      controller:
+        legacyRemotingSecurityEnabled: true
+        tag: "lts-alpine"
+    asserts:
+    - isKind:
+        of: ConfigMap
+    - hasDocuments:
+        count: 1
+    - isNotEmpty:
+        path: data.jcasc-default-config\.yaml
+    - matchRegex:
+        path: metadata.labels.helm\.sh/chart
+        pattern: ^jenkins-
+    - equal:
+        path: data.jcasc-default-config\.yaml
+        value: |-
+          jenkins:
+            authorizationStrategy:
+              loggedInUsersCanDoAnything:
+                allowAnonymousRead: false
+            securityRealm:
+              local:
+                allowsSignup: false
+                enableCaptcha: false
+                users:
+                - id: "${chart-admin-username}"
+                  name: "Jenkins Admin"
+                  password: "${chart-admin-password}"
+            disableRememberMe: false
+            remotingSecurity:
+              enabled: true
+            mode: NORMAL
+            numExecutors: 0
+            labelString: ""
+            projectNamingStrategy: "standard"
+            markupFormatter:
+              plainText
+            clouds:
+            - kubernetes:
+                containerCapStr: "10"
+                defaultsProviderTemplate: ""
+                connectTimeout: "5"
+                readTimeout: "15"
+                jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+                jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                maxRequestsPerHostStr: "32"
+                name: "kubernetes"
+                namespace: "default"
+                serverUrl: "https://kubernetes.default"
+                podLabels:
+                - key: "jenkins/RELEASE-NAME-jenkins-agent"
+                  value: "true"
+                templates:
+                  - name: "default"
+                    namespace: "default"
+                    id: be62f2fe67fa3e83c0157edaa53417c084c49a8aa88c3702e3ca1cc8df3fcbe2
+                    containers:
+                    - name: "jnlp"
+                      alwaysPullImage: false
+                      args: "^${computer.jnlpmac} ^${computer.name}"
+                      command:
+                      envVars:
+                        - envVar:
+                            key: "JENKINS_URL"
+                            value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                      image: "jenkins/inbound-agent:4.11.2-4"
+                      privileged: "false"
+                      resourceLimitCpu: 512m
+                      resourceLimitMemory: 512Mi
+                      resourceRequestCpu: 512m
+                      resourceRequestMemory: 512Mi
+                      runAsUser:
+                      runAsGroup:
+                      ttyEnabled: false
+                      workingDir: /home/jenkins/agent
+                    idleMinutes: 0
+                    instanceCap: 2147483647
+                    label: "RELEASE-NAME-jenkins-agent "
+                    nodeUsageMode: "NORMAL"
+                    podRetention: Never
+                    showRawYaml: true
+                    serviceAccount: "default"
+                    slaveConnectTimeoutStr: "100"
+                    yamlMergeStrategy: override
+            crumbIssuer:
+              standard:
+                excludeClientIPFromCrumb: true
+          security:
+            apiToken:
+              creationOfLegacyTokenEnabled: false
+              tokenGenerationOnCreationEnabled: false
+              usageStatisticsEnabled: true
+          unclassified:
+            location:
+              adminAddress:
+              url: http://RELEASE-NAME-jenkins:8080
+
+
+


### PR DESCRIPTION
### What this PR does / why we need it

- Implementation / reasoning described in #616
- ~~Also updates whitespace in the unit tests - they were failing for me locally. Do they even get executed in CI? I don't see anything in the logs (even though the command is mentioned in `ct.yaml`)?~~ It seems they're only failing for me locally... Is it due to helm version mismatch or smth? Seems CI is running 3.4, while I'm running 3.8...

### Which issue this PR fixes

- Fixes #616
- Alternative for #623 / Workaround for #592

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
