### PR TITLE
Support envFrom.configMapRef

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.1.0
+
+Added `controller.sidecars.configAutoReload.envFrom`, `controller.initContainerEnvFrom`, `controller.containerEnvFrom` 
+
 ## 4.0.1
 
 No code changes - CI updated to run unit tests using Helm 3.8.2.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.0.1
+version: 4.1.0
 appVersion: 2.332.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -31,6 +31,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.sidecars.configAutoReload.enabled` | Jenkins Config as Code auto-reload settings (Attention: rbac needs to be enabled otherwise the sidecar can't read the config map) | `true`                                                      |
 | `controller.sidecars.configAutoReload.image` | Image which triggers the reload | `kiwigrid/k8s-sidecar:0.1.144`           |
 | `controller.sidecars.configAutoReload.reqRetryConnect` | How many connection-related errors to retry on  | `10`          |
+| `controller.sidecars.configAutoReload.envFrom` | Environment variable sources for the Jenkins Config as Code auto-reload container | Not set |
 | `controller.sidecars.configAutoReload.env` | Environment variables for the Jenkins Config as Code auto-reload container  | Not set |
 | `controller.sidecars.configAutoReload.containerSecurityContext` | Enable container security context | `{readOnlyRootFilesystem: true, allowPrivilegeEscalation: false}` |
 
@@ -110,7 +111,9 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.imagePullSecretName`      | Controller image pull secret              | Not set                                   |
 | `controller.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 4096Mi}}`|
 | `controller.initContainerResources`   | Resources allocation (Requests and Limits) for Init Container            | Not set |
+| `controller.initContainerEnvFrom`     | Environment variable sources for Init Container                          | Not set |
 | `controller.initContainerEnv`         | Environment variables for Init Container                                 | Not set |
+| `controller.containerEnvFrom`         | Environment variable sources for Jenkins Container                       | Not set |
 | `controller.containerEnv`             | Environment variables for Jenkins Container                              | Not set |
 | `controller.usePodSecurityContext`    | Enable pod security context (must be `true` if `runAsUser`, `fsGroup`, or `podSecurityContextOverride` are set) | `true` |
 | `controller.runAsUser`                | Deprecated in favor of `controller.podSecurityContextOverride`.  uid that jenkins runs with. | `1000`                                    |

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -113,6 +113,10 @@ spec:
           securityContext: {{- toYaml .Values.controller.containerSecurityContext | nindent 12 }}
           {{- end }}
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
+            {{- if .Values.controller.initContainerEnvFrom }}
+          envFrom:
+{{ (tpl (toYaml .Values.controller.initContainerEnvFrom) .) | indent 12 }}
+            {{- end }}
             {{- if .Values.controller.initContainerEnv }}
           env:
 {{ (tpl (toYaml .Values.controller.initContainerEnv) .) | indent 12 }}
@@ -177,6 +181,10 @@ spec:
 {{- if .Values.controller.terminationMessagePolicy }}
           terminationMessagePolicy: {{ .Values.controller.terminationMessagePolicy }}
 {{- end }}
+            {{- if .Values.controller.containerEnvFrom }}
+          envFrom:
+{{ (tpl ( toYaml .Values.controller.containerEnvFrom) .) | indent 12 }}
+            {{- end }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -299,6 +307,10 @@ spec:
           imagePullPolicy: {{ .Values.controller.sidecars.configAutoReload.imagePullPolicy }}
           {{- if .Values.controller.sidecars.configAutoReload.containerSecurityContext }}
           securityContext: {{- toYaml .Values.controller.sidecars.configAutoReload.containerSecurityContext | nindent 12 }}
+          {{- end }}
+          {{- if .Values.controller.sidecars.configAutoReload.envFrom }}
+          envFrom:
+{{ (tpl (toYaml .Values.controller.sidecars.configAutoReload.envFrom) .) | indent 12 }}
           {{- end }}
           env:
             - name: POD_NAME

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -481,6 +481,15 @@ tests:
         value: "test-env-var-container"
       - name: "TEST_ENV_VAR__CONTAINER_TEMPLATED"
         value: '{{ .Values.testValue }}'
+      controller.initContainerEnvFrom:
+      - configMapRef:
+          name: special-config
+      controller.sidecars.configAutoReload.envFrom:
+      - configMapRef:
+          name: special-config
+      controller.containerEnvFrom:
+      - configMapRef:
+          name: special-config
     asserts:
       - contains:
           path: spec.template.spec.initContainers[0].env
@@ -512,6 +521,21 @@ tests:
           content:
             name: "TEST_ENV_VAR__CONTAINER_TEMPLATED"
             value: 'some-value'
+      - contains:
+          path: spec.template.spec.initContainers[0].envFrom
+          content:
+            configMapRef:
+              name: special-config
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: special-config
+      - contains:
+          path: spec.template.spec.containers[1].envFrom
+          content:
+            configMapRef:
+              name: special-config
   - it: overrides container args
     template: jenkins-controller-statefulset.yaml
     set:


### PR DESCRIPTION
### What this PR does / why we need it

Adds a way to bind all environment variables from a config map to various containers.

### Which issue this PR fixes

- fixes #580 

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
