### PR TITLE
remove references to enableXmlConfig which was removed in c00b41ac

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.1.1
+version: 4.1.2
 appVersion: 2.332.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -978,7 +978,6 @@ Here we show which values have changed and the previous default values:
 
 ```yaml
 controller:
-  enableXmlConfig: false  # was true
   runAsUser: 1000         # was unset before
   fsGroup: 1000           # was unset before
   JCasC:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -319,7 +319,6 @@ controller:
     #    jenkins:
     #      systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.
     # Ignored if securityRealm is defined in controller.JCasC.configScripts and
-    # ignored if controller.enableXmlConfig=true as controller.securityRealm takes precedence
     securityRealm: |-
       local:
         allowsSignup: false


### PR DESCRIPTION
### What this PR does / why we need it

Remove references to `enableXmlConfig` which was removed in c00b41ac

### Which issue this PR fixes
- fixes #635

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] CHANGELOG.md was updated
