### PR TITLE
Fix path of projected secrets from additionalExistingSecrets

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.1.8
+
+Fix path of projected secrets from `additionalExistingSecrets`.
+
 ## 4.1.7
 
 Update README with explanation on the required environmental variable `AWS_REGION` in case of using an S3 bucket.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.1.7
+version: 4.1.8
 appVersion: 2.332.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -380,7 +380,7 @@ spec:
               name: {{ $value.name }}
               items:
                 - key: {{ $value.keyName }}
-                  path: {{ $value.keyName }}
+                  path: {{ $value.name }}-{{ $value.keyName }}
           {{- end }}
           {{- end }}
           {{- if .Values.controller.adminSecret }}

--- a/charts/jenkins/unittests/secret-existing-test.yaml
+++ b/charts/jenkins/unittests/secret-existing-test.yaml
@@ -33,12 +33,12 @@ tests:
                     name: secret-name-1
                     items:
                       - key: username
-                        path: username
+                        path: secret-name-1-username
                 - secret:
                     name: secret-name-1
                     items:
                       - key: password
-                        path: password
+                        path: secret-name-1-password
                 - secret:
                     name: my-release-jenkins
                     items:


### PR DESCRIPTION
Signed-off-by: Sylvain Pasche <sylvain.pasche@gmail.com>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it

#645 changed how secrets are named in JCasC.
This restore previous behavior to keep compatibility.

### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
