### PR TITLE
add mountPath to also mount httpsKeyStore in init pod

### DIFF
--- a/.github/workflows/sync-lts.yaml
+++ b/.github/workflows/sync-lts.yaml
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Update version in Chart.yaml
-        uses: mikefarah/yq@v4.25.2
+        uses: mikefarah/yq@v4.25.3
         if: ${{ steps.update.outputs.available == 'true' }}
         with:
           cmd: yq eval '.version = "${{ steps.nextversion.outputs.version }}"' -i charts/jenkins/Chart.yaml

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.1.11
+
+JCasC ConfigMaps now generate their name from the `jenkins.casc.configName` helper
+
 ## 4.1.10
 
 Update Jenkins image and appVersion to jenkins lts release version 2.346.1

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.1.12
+
+If httpsKeyStore is defined, it is now available in the initContainer as well as the jenkins container.
+
 ## 4.1.11
 
 JCasC ConfigMaps now generate their name from the `jenkins.casc.configName` helper

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.1.11
+version: 4.1.12
 appVersion: 2.346.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.1.10
+version: 4.1.11
 appVersion: 2.346.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -209,6 +209,16 @@ unclassified:
 {{- end -}}
 
 {{/*
+Returns a name template to be used for jcasc configmaps, using 
+suffix passed in at call as index 0
+*/}}
+{{- define "jenkins.casc.configName" -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+"{{- include "jenkins.fullname" $root -}}-jenkins-{{ $name }}"
+{{- end -}}
+
+{{/*
 Returns kubernetes pod template configuration as code
 */}}
 {{- define "jenkins.casc.podTemplate" -}}

--- a/charts/jenkins/templates/jcasc-config.yaml
+++ b/charts/jenkins/templates/jcasc-config.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "jenkins.fullname" $root }}-jenkins-config-{{ $key }}
+  name: {{ template "jenkins.casc.configName" (list (printf "config-%s" $key) $ )}}
   namespace: {{ template "jenkins.namespace" $root }}
   labels:
     "app.kubernetes.io/name": {{ template "jenkins.name" $root}}
@@ -27,7 +27,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "jenkins.fullname" $root }}-jenkins-jcasc-config
+  name: {{ template "jenkins.casc.configName" (list "jcasc-config" $ )}}
   namespace: {{ template "jenkins.namespace" $root }}
   labels:
     "app.kubernetes.io/name": {{ template "jenkins.name" $root}}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -152,6 +152,11 @@ spec:
             - mountPath: {{ .Values.controller.jenkinsHome }}/init.groovy.d
               name: init-scripts
             {{- end }}
+            {{- if .Values.controller.httpsKeyStore.enable }}
+            {{- $httpsJKSDirPath :=  printf "%s" .Values.controller.httpsKeyStore.path }}
+            - mountPath: {{ $httpsJKSDirPath }}
+              name: jenkins-https-keystore
+            {{- end }}
       containers:
         - name: jenkins
           image: "{{ .Values.controller.image }}:{{- include "controller.tag" . -}}"


### PR DESCRIPTION
### What this PR does / why we need it
The helm chart allows a keystore to be specified.  This works great.  However, the init pod does not currently benefit from the existing keystore, if there is one.  This pull request adds the keystore to the init pod by copy/pasting the section already defined to mount the keystore in the jenkins pod to also mount within the init pod.

### Which issue this PR fixes

This fix is a stand alone feature enhancement, making sure that if a keystore is defined, it is also made available in the init pod.

Though not an exact fix, it is possible to use this addition to resolve the following without having to create and manage a custom jenkins image file.

- fixes #658
- fixes #551

### Special notes for your reviewer

Though a more advanced fix would be to define and integrate both a keystore and a truststore into the helm chart for both the jenkins pod and the init pod, this pull request would be good in the meantime as it allows the mounting of the currently implemented keystore to also exist within the init pod.

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
