### PR TITLE
if defined enable keystore in init container, update statefulset as w…

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.1.12
+
+If keystore is defined, it is now also made available in the initContainer.
+
 ## 4.1.11
 
 JCasC ConfigMaps now generate their name from the `jenkins.casc.configName` helper

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.1.11
+version: 4.1.12
 appVersion: 2.346.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -152,6 +152,11 @@ spec:
             - mountPath: {{ .Values.controller.jenkinsHome }}/init.groovy.d
               name: init-scripts
             {{- end }}
+            {{- if .Values.controller.httpsKeyStore.enable }}
+            {{- $httpsJKSDirPath :=  printf "%s" .Values.controller.httpsKeyStore.path }}
+            - mountPath: {{ $httpsJKSDirPath }}
+              name: jenkins-https-keystore
+            {{- end }}
       containers:
         - name: jenkins
           image: "{{ .Values.controller.image }}:{{- include "controller.tag" . -}}"


### PR DESCRIPTION
…ell as Chart & Changelog

Signed-off-by: leland knight <lknite@aarr.xyz>

<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it

The helm chart allows a keystore to be specified. This works great. However, the init pod does not currently benefit from the existing keystore, if there is one. This pull request adds the keystore to the init pod by copy/pasting the section already defined to mount the keystore in the jenkins pod to also mount within the init pod.

### Which issue this PR fixes

This fix is a stand alone feature enhancement, making sure that if a keystore is defined, it is also made available in the init pod.

Though not an exact fix, it is possible to use this addition to resolve the following without having to create and manage a custom jenkins image file.

- fixes #658
- fixes #551

### Special notes for your reviewer

Though a more advanced fix would be to define and integrate both a keystore and a truststore into the helm chart for both the jenkins pod and the init pod, this pull request would be good in the meantime as it allows the mounting of the currently implemented keystore to also exist within the init pod.

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
