### PR TITLE
Don't create plugins volume when not needed

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.1.14
+
+If `installPlugins` is disabled, don't create unused plugins volume.
+
 ## 4.1.13
 
 Update Jenkins image and appVersion to jenkins lts release version 2.346.2

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.1.13
+version: 4.1.14
 appVersion: 2.346.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -345,8 +345,12 @@ spec:
 {{- if .Values.persistence.volumes }}
 {{ tpl (toYaml .Values.persistence.volumes | indent 6) . }}
 {{- end }}
+      {{- if .Values.controller.installPlugins }}
+      {{- if .Values.controller.overwritePluginsFromImage }}
       - name: plugins
         emptyDir: {}
+      {{- end }}
+      {{- end }}
       {{- if and .Values.controller.initScripts .Values.controller.initConfigMap }}
       - name: init-scripts
         projected:

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -575,3 +575,18 @@ tests:
     asserts:
       - matchSnapshot:
           path: spec.template.metadata.annotations
+  - it: 
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        installPlugins: false
+    asserts:
+      - notContains: 
+          path: spec.template.spec.volumes
+          content:
+            name: plugins
+            emptyDir: {}
+      - notContains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: plugins


### PR DESCRIPTION
### What this PR does / why we need it
For plugin installation a volume with emptyDir is created/used. If the plugin installation is disabled the volume still gets created but isn't used anywhere. This can lead to problems in combination with cluster autoscaling since pods with local storage won't get evicted by default.

### Which issue this PR fixes
- relates to #569 

### Special notes for your reviewer

### Checklist
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
