### PR TITLE
Unify the way that image repo/image/tag are generated

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.1.16
+version: 4.1.17
 appVersion: 2.346.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -252,7 +252,7 @@ Returns kubernetes pod template configuration as code
           {{- else }}
           value: "http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.controller.servicePort}}{{ default "/" .Values.controller.jenkinsUriPrefix }}"
           {{- end }}
-    image: "{{ .Values.agent.image }}:{{ .Values.agent.tag }}"
+    image: "{{ .Values.agent.image.image }}:{{- include "image.tag" (dict "ctx" .Values.agent.image) -}}"
     privileged: "{{- if .Values.agent.privileged }}true{{- else }}false{{- end }}"
     resourceLimitCpu: {{.Values.agent.resources.limits.cpu}}
     resourceLimitMemory: {{.Values.agent.resources.limits.memory}}
@@ -382,13 +382,13 @@ Create the name of the service account for Jenkins backup to use
 {{- end -}}
 
 {{/*
-Create a full tag name for controller image
+Create a full tag name for an image
 */}}
-{{- define "controller.tag" -}}
-{{- if .Values.controller.tagLabel -}}
-    {{- default (printf "%s-%s" .Chart.AppVersion .Values.controller.tagLabel) .Values.controller.tag -}}
+{{- define "image.tag" -}}
+{{- if .ctx.tagLabel -}}
+    {{- default (printf "%s-%s" .ver .ctx.tagLabel) .ctx.tag -}}
 {{- else -}}
-    {{- default .Chart.AppVersion .Values.controller.tag -}}
+    {{- default .ver .ctx.tag -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -252,7 +252,7 @@ Returns kubernetes pod template configuration as code
           {{- else }}
           value: "http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.controller.servicePort}}{{ default "/" .Values.controller.jenkinsUriPrefix }}"
           {{- end }}
-    image: "{{ .Values.agent.image.image }}:{{- include "image.tag" (dict "ctx" .Values.agent.image) -}}"
+    image: "{{ .Values.agent.image }}:{{- include "image.tag" (dict "ctx" .Values.agent) -}}"
     privileged: "{{- if .Values.agent.privileged }}true{{- else }}false{{- end }}"
     resourceLimitCpu: {{.Values.agent.resources.limits.cpu}}
     resourceLimitMemory: {{.Values.agent.resources.limits.memory}}

--- a/charts/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/charts/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -53,7 +53,7 @@ spec:
           {{- end }}
           containers:
           - name: jenkins-backup
-            image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"
+            image: "{{ .Values.backup.image.image }}:{{- include "image.tag" (dict "ctx" .Values.backup.image) -}}"
             command: ["kube-tasks"]
             args:
             - simple-backup

--- a/charts/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/charts/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -53,7 +53,7 @@ spec:
           {{- end }}
           containers:
           - name: jenkins-backup
-            image: "{{ .Values.backup.image.image }}:{{- include "image.tag" (dict "ctx" .Values.backup.image) -}}"
+            image: "{{ .Values.backup.image }}:{{- include "image.tag" (dict "ctx" .Values.backup) -}}"
             command: ["kube-tasks"]
             args:
             - simple-backup

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -107,7 +107,7 @@ spec:
 {{ tpl (toYaml .Values.controller.customInitContainers) . | indent 8 }}
 {{- end }}
         - name: "init"
-          image: "{{ .Values.controller.image }}:{{- include "controller.tag" . -}}"
+          image: "{{ .Values.controller.image }}:{{- include "image.tag" (dict "ver" .Chart.AppVersion "ctx" .Values.controller) -}}"
           imagePullPolicy: "{{ .Values.controller.imagePullPolicy }}"
           {{- if .Values.controller.containerSecurityContext }}
           securityContext: {{- toYaml .Values.controller.containerSecurityContext | nindent 12 }}
@@ -159,7 +159,7 @@ spec:
             {{- end }}
       containers:
         - name: jenkins
-          image: "{{ .Values.controller.image }}:{{- include "controller.tag" . -}}"
+          image: "{{ .Values.controller.image }}:{{- include "image.tag" (dict "ver" .Chart.AppVersion "ctx" .Values.controller) -}}"
           imagePullPolicy: "{{ .Values.controller.imagePullPolicy }}"
           {{- if .Values.controller.containerSecurityContext }}
           securityContext: {{- toYaml .Values.controller.containerSecurityContext | nindent 12 }}
@@ -295,7 +295,7 @@ spec:
 
 {{- if .Values.controller.sidecars.configAutoReload.enabled }}
         - name: config-reload
-          image: "{{ .Values.controller.sidecars.configAutoReload.image }}"
+          image: "{{ .Values.controller.sidecars.configAutoReload.image }}:{{- include "image.tag" (dict "ctx" .Values.controller.sidecars.configAutoReload) -}}"
           imagePullPolicy: {{ .Values.controller.sidecars.configAutoReload.imagePullPolicy }}
           {{- if .Values.controller.sidecars.configAutoReload.containerSecurityContext }}
           securityContext: {{- toYaml .Values.controller.sidecars.configAutoReload.containerSecurityContext | nindent 12 }}

--- a/charts/jenkins/templates/tests/jenkins-test.yaml
+++ b/charts/jenkins/templates/tests/jenkins-test.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.testEnabled }}
+{{- if .Values.controller.test.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -17,7 +17,7 @@ spec:
   {{- end }}
   initContainers:
     - name: "test-framework"
-      image: "bats/bats:1.2.1"
+      image: "{{ .Values.controller.test.bats.image }}:{{- include "image.tag" (dict "ctx" .Values.controller.test.bats) -}}"
       command:
         - "bash"
         - "-c"
@@ -31,7 +31,7 @@ spec:
         name: tools
   containers:
     - name: {{ .Release.Name }}-ui-test
-      image: {{ .Values.controller.image }}:{{ .Chart.AppVersion }}-{{ .Values.controller.tagLabel }}
+      image: "{{ .Values.controller.image }}:{{- include "image.tag" (dict "ver" .Chart.AppVersion "ctx" .Values.controller) -}}"
       command: ["/tools/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:
       - mountPath: /tests

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -327,8 +327,9 @@ tests:
         sideContainerName: sideContainer
         alwaysPullImage: true
         command: /bin/command
-        image: my-image/jnlp
-        tag: v1.2.3
+        image:
+          image: my-image/jnlp
+          tag: v1.2.3
         privileged: true
         resources:
           limits:

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -327,9 +327,8 @@ tests:
         sideContainerName: sideContainer
         alwaysPullImage: true
         command: /bin/command
-        image:
-          image: my-image/jnlp
-          tag: v1.2.3
+        image: my-image/jnlp
+        tag: v1.2.3
         privileged: true
         resources:
           limits:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -347,7 +347,8 @@ controller:
       # jcasc changes will cause a reboot and will only be applied at the subsequent start-up.  Auto-reload uses the
       # http://<jenkins_url>/reload-configuration-as-code endpoint to reapply config when changes to the configScripts are detected.
       enabled: true
-      image: kiwigrid/k8s-sidecar:1.15.0
+      image: "kiwigrid/k8s-sidecar"
+      tag: "1.15.0"
       imagePullPolicy: IfNotPresent
       resources: {}
         #   limits:
@@ -528,7 +529,11 @@ controller:
     prometheusRuleNamespace: ""
 
   # Can be used to disable rendering controller test resources when using helm template
-  testEnabled: true
+  test:
+    enabled: true
+    bats:
+      image: "bats/bats"
+      tag: "1.2.1"
 
   httpsKeyStore:
     jenkinsHttpsJksSecretName: ''
@@ -591,8 +596,9 @@ agent:
   kubernetesReadTimeout: 15
   maxRequestsPerHostStr: "32"
   namespace:
-  image: "jenkins/inbound-agent"
-  tag: "4.11.2-4"
+  image:
+    image: "jenkins/inbound-agent"
+    tag: "4.11.2-4"
   workingDir: "/home/jenkins/agent"
   nodeUsageMode: "NORMAL"
   customJenkinsLabels: []
@@ -849,7 +855,7 @@ backup:
   # Set this to terminate the job that is running/failing continously and set the job status to "Failed"
   activeDeadlineSeconds: ""
   image:
-    repository: "maorfr/kube-tasks"
+    image: "maorfr/kube-tasks"
     tag: "0.2.0"
   imagePullSecretName:
   # Additional arguments for kube-tasks

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -596,9 +596,8 @@ agent:
   kubernetesReadTimeout: 15
   maxRequestsPerHostStr: "32"
   namespace:
-  image:
-    image: "jenkins/inbound-agent"
-    tag: "4.11.2-4"
+  image: "jenkins/inbound-agent"
+  tag: "4.11.2-4"
   workingDir: "/home/jenkins/agent"
   nodeUsageMode: "NORMAL"
   customJenkinsLabels: []
@@ -854,9 +853,8 @@ backup:
     # "eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/jenkins-backup"
   # Set this to terminate the job that is running/failing continously and set the job status to "Failed"
   activeDeadlineSeconds: ""
-  image:
-    image: "maorfr/kube-tasks"
-    tag: "0.2.0"
+  image: "maorfr/kube-tasks"
+  tag: "0.2.0"
   imagePullSecretName:
   # Additional arguments for kube-tasks
   # Ref: https://github.com/maorfr/kube-tasks#simple-backup


### PR DESCRIPTION
*Summary*

As requested in the response to #683, here's a PR to fix everywhere that references an image to use the tag generator in `_helpers.tpl` so that custom repositories and sha256 digests can be used. Custom private repositories like [Google Artifact Registry](https://cloud.google.com/artifact-registry) are a requirement in corporate environments and sha256 digests are a requirement for GKE [binary authorization](https://cloud.google.com/binary-authorization) that is often mandated by corporate security policy.

*Test Evidence*

With no custom settings:
```
$ helm template jenkins . --set backup.enabled=true | grep image: | awk '{$1=$1};1'
image: "jenkins/inbound-agent:4.11.2-4"
image: "jenkins/jenkins:2.346.3-jdk11"
image: "jenkins/jenkins:2.346.3-jdk11"
image: "kiwigrid/k8s-sidecar:1.15.0"
image: "maorfr/kube-tasks:0.2.0"
image: "bats/bats:1.2.1"
image: "jenkins/jenkins:2.346.3-jdk11"
```

With custom settings:
```
$ helm template jenkins . --set controller.image=custom-jenkins@sha256 --set controller.tag=jenkins-digest --set controller.test.bats.image=custom-bats@sha256 --set controller.test.bats.tag=bats-digest --set controller.sidecars.configAutoReload.image=custom-auto-reload@sha256 --set controller.sidecars.configAutoReload.tag=autoreload-digest --set backup.enabled=true --set backup.image.image=custom-backup@sha256 --set backup.image.tag=backup-digest --set agent.image.image=custom-agent@sha256 --set agent.image.tag=agent-digest | grep image: | awk '{$1=$
1};1'
image: "custom-agent@sha256:agent-digest"
image: "custom-jenkins@sha256:jenkins-digest"
image: "custom-jenkins@sha256:jenkins-digest"
image: "custom-auto-reload@sha256:autoreload-digest"
image: "custom-backup@sha256:backup-digest"
image: "custom-bats@sha256:bats-digest"
image: "custom-jenkins@sha256:jenkins-digest"
```