### PR TITLE
Remove option to provide command and args in agent as YAML

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.2.1
+
+Remove option to provide command and args of agent as YAML. This feature was never supported by the Jenkins Kubernetes
+plugin.
+
 ## 4.2.0
 
 Add option to provide additional containers to agents

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.2.0
+version: 4.2.1
 appVersion: 2.361.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -243,8 +243,8 @@ Returns kubernetes pod template configuration as code
   containers:
   - name: "{{ .Values.agent.sideContainerName }}"
     alwaysPullImage: {{ .Values.agent.alwaysPullImage }}
-    args: {{ if or (empty .Values.agent.args) (kindIs "string" .Values.agent.args) }}{{ .Values.agent.args | default "" | replace "$" "^$" | quote }}{{ else }}{{ toYaml .Values.agent.args | nindent 4 }}{{ end }}
-    command: {{ if or (empty .Values.agent.command) (kindIs "string" .Values.agent.command) }}{{ .Values.agent.command }}{{ else }}{{ toYaml .Values.agent.command | nindent 4 }}{{ end }}
+    args: "{{ .Values.agent.args | replace "$" "^$" }}"
+    command: {{ .Values.agent.command }}
     envVars:
       - envVar:
           key: "JENKINS_URL"
@@ -266,8 +266,8 @@ Returns kubernetes pod template configuration as code
 {{- range $additionalContainers := .Values.agent.additionalContainers }}
   - name: "{{ $additionalContainers.sideContainerName }}"
     alwaysPullImage: {{ $additionalContainers.alwaysPullImage | default $.Values.agent.alwaysPullImage }}
-    args: {{ if or (empty $additionalContainers.args) (kindIs "string" $additionalContainers.args) }}"{{ $additionalContainers.args | default "" | replace "$" "^$" }}"{{ else }}{{ toYaml $additionalContainers.args | nindent 4 }}{{ end }}
-    command: {{ if or (empty $additionalContainers.command) (kindIs "string" $additionalContainers.command) }}{{ $additionalContainers.command }}{{ else }}{{ toYaml $additionalContainers.command | nindent 4 }}{{ end }}
+    args: "{{ $additionalContainers.args | replace "$" "^$" }}"
+    command: {{ $additionalContainers.command }}
     envVars:
       - envVar:
           key: "JENKINS_URL"

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -2014,7 +2014,7 @@ tests:
             image: docker
             tag: dind
             command: dockerd-entrypoint.sh
-            args:
+            args: ""
             privileged: true
     asserts:
       - equal:
@@ -2057,7 +2057,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: ea8d291bc77df9854d22d7ad61b392cef24edd05aeafff3898c02f28366d58ef
+                      id: 14a4774e31b763fcb8221e158e00895c5d3549b2098bd41f8ecf0d8ba052aa4e
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2126,7 +2126,7 @@ tests:
             image: docker
             tag: dind
             command: dockerd-entrypoint.sh
-            args:
+            args: ""
             privileged: true
       additionalAgents:
         additional-agent:
@@ -2136,9 +2136,7 @@ tests:
               image: my-additional-container-image
               tag: latest
               command: entrypoint.sh
-              args:
-                - arg1
-                - arg2
+              args: arg1 arg2
     asserts:
       - equal:
           path: data.jcasc-default-config\.yaml
@@ -2180,7 +2178,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: ea8d291bc77df9854d22d7ad61b392cef24edd05aeafff3898c02f28366d58ef
+                      id: 14a4774e31b763fcb8221e158e00895c5d3549b2098bd41f8ecf0d8ba052aa4e
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2229,7 +2227,7 @@ tests:
                       yamlMergeStrategy: override
                     - name: "additional-agent"
                       namespace: "default"
-                      id: 3f856cbccbeed5435cc01de2a0806dfb96163294f0d757f1cb1a6be94a358a60
+                      id: e7e44e732821cf87cbdcc849b61a40e2f555780796218d1e735b22459c5671d5
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2251,9 +2249,7 @@ tests:
                         workingDir: /home/jenkins/agent
                       - name: "additional"
                         alwaysPullImage: false
-                        args:
-                        - arg1
-                        - arg2
+                        args: "arg1 arg2"
                         command: entrypoint.sh
                         envVars:
                           - envVar:
@@ -2300,7 +2296,7 @@ tests:
             image: docker
             tag: dind
             command: dockerd-entrypoint.sh
-            args:
+            args: ""
             privileged: true
       additionalAgents:
         additional-agent:
@@ -2347,7 +2343,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: ea8d291bc77df9854d22d7ad61b392cef24edd05aeafff3898c02f28366d58ef
+                      id: 14a4774e31b763fcb8221e158e00895c5d3549b2098bd41f8ecf0d8ba052aa4e
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -726,7 +726,7 @@ agent:
   #    image: docker
   #    tag: dind
   #    command: dockerd-entrypoint.sh
-  #    args:
+  #    args: ""
   #    privileged: true
   #    resources:
   #      requests:


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it

In #699 the option to add additional containers to the default agent templates was introduced. In that change it was also made possible to configure the `command` and `args` of the agent containers as lists. That feature is not supported by the [Jenkins Kubernetes Plugin](https://plugins.jenkins.io/kubernetes/).

### Which issue this PR fixes

- none

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] CHANGELOG.md was updated
