### PR TITLE
Support Google Managed Prometheus monitoring

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.2.2
+
+Support Google Managed Prometheus
+
 ## 4.2.1
 
 Remove option to provide command and args of agent as YAML. This feature was never supported by the Jenkins Kubernetes

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.2.1
+version: 4.2.2
 appVersion: 2.361.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-podmonitor.yaml
+++ b/charts/jenkins/templates/jenkins-controller-podmonitor.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.controller.googlePodMonitor.enabled }}
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+
+metadata:
+  name: {{ template "jenkins.fullname" . }}
+{{- if .Values.controller.googlePodMonitor.serviceMonitorNamespace }}
+  namespace: {{ .Values.controller.googlePodMonitor.serviceMonitorNamespace }}
+{{- else }}
+  namespace: {{ template "jenkins.namespace" . }}
+{{- end }}
+  labels:
+    "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ template "jenkins.label" .}}"
+    {{- end }}
+    "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
+    "app.kubernetes.io/instance": "{{ .Release.Name }}"
+    "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
+
+spec:
+  endpoints:
+  - interval: {{ .Values.controller.googlePodMonitor.scrapeInterval }}
+    port: http
+    path: {{ .Values.controller.jenkinsUriPrefix }}{{ .Values.controller.googlePodMonitor.scrapeEndpoint }}
+  selector:
+    matchLabels:
+      "app.kubernetes.io/instance": "{{ .Release.Name }}"
+      "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
+{{- end }}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -533,6 +533,15 @@ controller:
     # Set a custom namespace where to deploy PrometheusRule resource
     prometheusRuleNamespace: ""
 
+  googlePodMonitor:
+    # If enabled, It creates Google Managed Prometheus scraping config
+    enabled: false
+    # Set a custom namespace where to deploy PodMonitoring resource
+    # serviceMonitorNamespace: ""
+    scrapeInterval: 60s
+    # This is the default endpoint used by the prometheus plugin
+    scrapeEndpoint: /prometheus
+
   # Can be used to disable rendering controller test resources when using helm template
   testEnabled: true
 


### PR DESCRIPTION
Signed-off-by: Chuyen Pham <pkchuyen@users.noreply.github.com>

enabling Google Managed prometheus when running Jenkins on GKE cluster

### Checklist
- [ x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ x] Chart Version bumped
- [ x] CHANGELOG.md was updated
