### PR TITLE
Customise extraports

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.2.5
+Add an extra optional argument to extraPorts in order to specify targetPort
+
 ## 4.2.4
 Remove k8s capibility requirements when setting priority class for controller
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.2.4
+version: 4.2.5
 appVersion: 2.361.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-svc.yaml
+++ b/charts/jenkins/templates/jenkins-controller-svc.yaml
@@ -35,7 +35,11 @@ spec:
 {{- range $index, $port := .Values.controller.extraPorts }}
     - port: {{ $port.port }}
       name: {{ $port.name }}
+      {{- if $port.targetPort }}
+      targetPort: {{ $port.targetPort }}
+      {{- else }}
       targetPort: {{ $port.port }}
+      {{- end -}}
 {{- end }}
   selector:
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/unittests/jenkins-controller-svc-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-svc-test.yaml
@@ -70,6 +70,43 @@ tests:
               app.kubernetes.io/component: jenkins-controller
               app.kubernetes.io/instance: my-release
             type: ClusterIP
+  - it: extraPort with targetPort
+    set:
+      controller:
+        serviceLabels:
+          label: label-value
+        serviceAnnotations:
+          key: value
+        clusterIP: 10.10.10.11
+        servicePort: 8888
+        targetPort: 7777
+        extraPorts:
+          - name: https
+            port: 443
+            targetPort: 8080
+    asserts:
+      - equal:
+          path: metadata.labels.label
+          value: label-value
+      - equal:
+          path: metadata.annotations
+          value:
+            key: value
+      - equal:
+          path: spec
+          value:
+            clusterIP: 10.10.10.11
+            ports:
+            - name: http
+              port: 8888
+              targetPort: 7777
+            - name: https
+              port: 443
+              targetPort: 8080
+            selector:
+              app.kubernetes.io/component: jenkins-controller
+              app.kubernetes.io/instance: my-release
+            type: ClusterIP
   - it: node port
     set:
       controller:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -235,6 +235,7 @@ controller:
   extraPorts: []
   # - name: BuildInfoProxy
   #   port: 9000
+  #   targetPort: 9010 (Optional: Use to explicilty set targePort if different from port)
 
   # List of plugins to be install during Jenkins controller start
   installPlugins:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -235,7 +235,7 @@ controller:
   extraPorts: []
   # - name: BuildInfoProxy
   #   port: 9000
-  #   targetPort: 9010 (Optional: Use to explicilty set targePort if different from port)
+  #   targetPort: 9010 (Optional: Use to explicitly set targetPort if different from port)
 
   # List of plugins to be install during Jenkins controller start
   installPlugins:


### PR DESCRIPTION
Signed-off-by: Daniel Robinson <dan.robinson21@gmail.com>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it
Adds an extra argument to extraPorts in order to specify an optional targetPort
Makes extraPorts more customisable instead of always setting targetPort = port in the controller.svc template.

### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
