### PR TITLE
Remote configuration url

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,9 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.2.7
+Support for remote url for configuration
+
 ## 4.2.6
 Add option to set hostnetwork for agents
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.2.6
+version: 4.2.7
 appVersion: 2.361.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -219,7 +219,7 @@ spec:
 {{ (tpl ( toYaml .Values.controller.containerEnv) .) | indent 12 }}
             {{- end }}
             - name: CASC_JENKINS_CONFIG
-              value: {{ .Values.controller.sidecars.configAutoReload.folder | default (printf "%s/casc_configs" (.Values.controller.jenkinsRef)) }}
+              value: {{ .Values.controller.sidecars.configAutoReload.folder | default (printf "%s/casc_configs" (.Values.controller.jenkinsRef)) }}{{- if .Values.controller.JCasC.configUrls }},{{ join "," .Values.controller.JCasC.configUrls }}{{- end }}
           ports:
             {{- if .Values.controller.httpsKeyStore.enable }}
             - containerPort: {{.Values.controller.httpsKeyStore.httpPort}}

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -590,3 +590,29 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: plugins
+  - it:
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        JCasC:
+          configUrls:
+           - https://acme.org/jenkins.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "CASC_JENKINS_CONFIG"
+            value: "/var/jenkins_home/casc_configs,https://acme.org/jenkins.yaml"
+
+  - it:
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        JCasC:
+          configUrls: []
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "CASC_JENKINS_CONFIG"
+            value: "/var/jenkins_home/casc_configs"

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -609,6 +609,21 @@ tests:
     set:
       controller:
         JCasC:
+          configUrls:
+            - https://acme.org/jenkins.yaml
+            - https://foobar.org/jenkins.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "CASC_JENKINS_CONFIG"
+            value: "/var/jenkins_home/casc_configs,https://acme.org/jenkins.yaml,https://foobar.org/jenkins.yaml"
+
+  - it:
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        JCasC:
           configUrls: []
     asserts:
       - contains:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -318,6 +318,9 @@ controller:
   # etc.  Best reference is https://<jenkins_url>/configuration-as-code/reference.  The example below creates a welcome message:
   JCasC:
     defaultConfig: true
+    configUrls: []
+    # - https://acme.org/jenkins.yaml
+    # Remote URL:s for configuration files.
     configScripts: {}
     #  welcome-message: |
     #    jenkins:


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it

### Which issue this PR fixes

The JCasC plugin supports three variations of providing the value to this environment variable.

Path to a folder containing a set of config files. For example, /var/jenkins_home/casc_configs.
A full path to a single file. For example, /var/jenkins_home/casc_configs/jenkins.yaml.
A URL pointing to a file served on the web. For example, https://acme.org/jenkins.yaml.
The third option is not supported by the helm chart.
This would help to externalize the whole jenkins-casc.yaml from the values.yaml file and store it in git.


- fixes #530 

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
