### PR TITLE
Improve the limitation of configAutoReload condition

### DIFF
--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -47,7 +47,7 @@ data:
     echo "copy configuration as code files"
     mkdir -p {{ .Values.controller.jenkinsHome }}/casc_configs;
     rm -rf {{ .Values.controller.jenkinsHome }}/casc_configs/*
-    {{- if .Values.controller.JCasC.configScripts }}
+    {{- if or .Values.controller.JCasC.defaultConfig .Values.controller.JCasC.configScripts }}
     cp -v /var/jenkins_config/*.yaml {{ .Values.controller.jenkinsHome }}/casc_configs
     {{- end }}
   {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it
This fix would allow the users to safely disable the sidecar's configAutoReload feature in their first deployment with the chart, which still preserves the ability to apply the default JCasC setting values as the sample guidelines for them. In addition, if they do not even want to have those default configuration, which is not highly recommended, they can set the Helm value flag controller.JCasC.defaultConfig to false.

### Which issue this PR fixes

- fixes #618 

### Special notes for your reviewer
@timja @maorfr @torstenwalter @mogaal @wmcdona89 