### PR TITLE
Added the option to mount all the keys from an exisiting k8s secret

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -11,6 +11,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
+## 4.2.14
+
+Added option to mount all keys from an existing k8s secret
+
 
 ## 4.2.13
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.2.13
+version: 4.2.14
 appVersion: 2.361.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -353,6 +353,9 @@ controller:
   # an existing secret "secret-credentials" and a key inside it named "github-password" should be used in Jcasc as ${secret-credentials-github-password}
   # 'name' and 'keyName' must be lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
   # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
+  # existingSecret existing secret "secret-credentials" and a key inside it named "github-username" should be used in Jcasc as ${github-username}
+  # When using existingSecret no need to specify the keyName under additionalExistingSecrets.
+  existingSecret: secret-credentials
   additionalExistingSecrets:
     - name: secret-credentials
       keyName: github-username

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -246,13 +246,14 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 #### Kubernetes Secret
 
-| Parameter                         | Description                          | Default                                   |
-| --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `controller.adminUser`                | Admin username (and password) created as a secret if adminSecret is true | `admin` |
-| `controller.adminPassword`            | Admin password (and user) created as a secret if adminSecret is true | Random value |
-| `controller.additionalSecrets`        | List of additional secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
-| `controller.additionalExistingSecrets`| List of additional existing secrets to mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
-| `controller.secretClaims`             | List of `SecretClaim` resources to create | `[]` |
+| Parameter                              | Description                                                                                                                                                                                   | Default                                   |
+|----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ----------------------------------------- |
+| `controller.adminUser`                 | Admin username (and password) created as a secret if adminSecret is true                                                                                                                      | `admin` |
+| `controller.adminPassword`             | Admin password (and user) created as a secret if adminSecret is true                                                                                                                          | Random value |
+| `controller.existingSecret`            | The name of an existing secret containing keys credentials.                                                                                                                                   | `""`|
+| `controller.additionalSecrets`         | List of additional secrets to create and mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets) | `[]` |
+| `controller.additionalExistingSecrets` | List of additional existing secrets to mount according to [JCasC docs](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#kubernetes-secrets)   | `[]` |
+| `controller.secretClaims`              | List of `SecretClaim` resources to create                                                                                                                                                     | `[]` |
 
 #### Kubernetes NetworkPolicy
 

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -191,7 +191,7 @@ spec:
 {{ (tpl ( toYaml .Values.controller.containerEnvFrom) .) | indent 12 }}
             {{- end }}
           env:
-            {{- if or .Values.controller.additionalSecrets .Values.controller.additionalExistingSecrets .Values.controller.adminSecret }}
+            {{- if or .Values.controller.additionalSecrets .Values.controller.existingSecret .Values.controller.additionalExistingSecrets .Values.controller.adminSecret }}
             - name: SECRETS
               value: /run/secrets/additional
             {{- end }}
@@ -283,7 +283,7 @@ spec:
             - name: sc-config-volume
               mountPath: {{ .Values.controller.sidecars.configAutoReload.folder | default (printf "%s/casc_configs" (.Values.controller.jenkinsRef)) }}
             {{- end }}
-            {{- if or .Values.controller.additionalSecrets .Values.controller.additionalExistingSecrets .Values.controller.adminSecret }}
+            {{- if or .Values.controller.additionalSecrets .Values.controller.existingSecret .Values.controller.additionalExistingSecrets .Values.controller.adminSecret }}
             - name: jenkins-secrets
               mountPath: /run/secrets/additional
               readOnly: true
@@ -375,7 +375,7 @@ spec:
       - name: plugin-dir
         emptyDir: {}
       {{- end }}
-      {{- if or .Values.controller.additionalSecrets .Values.controller.additionalExistingSecrets .Values.controller.adminSecret }}
+      {{- if or .Values.controller.additionalSecrets .Values.controller.existingSecret .Values.controller.additionalExistingSecrets .Values.controller.adminSecret }}
       - name: jenkins-secrets
         projected:
           sources:
@@ -385,6 +385,11 @@ spec:
           {{- end }}
           {{- if .Values.controller.additionalExistingSecrets }}
           {{- range $key, $value := .Values.controller.additionalExistingSecrets }}
+          {{- if .Values.controller.existingSecret }}
+          - secret:
+              name: {{ .Values.controller.existingSecret }}
+          {{- end }}
+
           - secret:
               name: {{ tpl $value.name $ }}
               items:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -385,11 +385,6 @@ spec:
           {{- end }}
           {{- if .Values.controller.additionalExistingSecrets }}
           {{- range $key, $value := .Values.controller.additionalExistingSecrets }}
-          {{- if .Values.controller.existingSecret }}
-          - secret:
-              name: {{ .Values.controller.existingSecret }}
-          {{- end }}
-
           - secret:
               name: {{ tpl $value.name $ }}
               items:
@@ -405,6 +400,10 @@ spec:
                   path: chart-admin-username
                 - key: {{ .Values.controller.admin.passwordKey | default "jenkins-admin-password" }}
                   path: chart-admin-password
+        {{- end }}
+        {{- if .Values.controller.existingSecret }}
+          - secret:
+              name: {{ .Values.controller.existingSecret }}
         {{- end }}
       {{- end }}
       - name: jenkins-cache

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -467,6 +467,73 @@ tests:
                         path: chart-admin-username
                       - key: jenkins-admin-password
                         path: chart-admin-password
+  - it: test existing secret without additionalExistingSecrets
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller.existingSecret: my-exisiting-credentials
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4]
+          value:
+            mountPath: /run/secrets/additional
+            name: jenkins-secrets
+            readOnly: true
+      - equal:
+          path: spec.template.spec.volumes[3]
+          value:
+            name: jenkins-secrets
+            projected:
+              sources:
+                - secret:
+                    name: my-release-jenkins
+                    items:
+                      - key: jenkins-admin-user
+                        path: chart-admin-username
+                      - key: jenkins-admin-password
+                        path: chart-admin-password
+                - secret:
+                    name: my-exisiting-credentials
+  - it: test existing secret with additionalExistingSecrets
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller.existingSecret: my-exisiting-credentials
+      controller.additionalExistingSecrets:
+        - name: my-exisiting-credentials
+          keyName: github-username
+        - name: my-exisiting-credentials
+          keyName: github-password
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4]
+          value:
+            mountPath: /run/secrets/additional
+            name: jenkins-secrets
+            readOnly: true
+      - equal:
+          path: spec.template.spec.volumes[3]
+          value:
+            name: jenkins-secrets
+            projected:
+              sources:
+                - secret:
+                    items:
+                      - key: github-username
+                        path: my-exisiting-credentials-github-username
+                    name: my-exisiting-credentials
+                - secret:
+                    items:
+                      - key: github-password
+                        path: my-exisiting-credentials-github-password
+                    name: my-exisiting-credentials
+                - secret:
+                    name: my-release-jenkins
+                    items:
+                      - key: jenkins-admin-user
+                        path: chart-admin-username
+                      - key: jenkins-admin-password
+                        path: chart-admin-password
+                - secret:
+                    name: my-exisiting-credentials
   - it: test templated environment variables
     template: jenkins-controller-statefulset.yaml
     set:

--- a/charts/jenkins/unittests/secret-existing-test.yaml
+++ b/charts/jenkins/unittests/secret-existing-test.yaml
@@ -14,6 +14,8 @@ tests:
           keyName: username
         - name: "{{ .Release.Name }}-secret"
           keyName: password
+      controller.existingSecret: my-exisiting-credentials
+
     asserts:
       - isKind:
           of: StatefulSet
@@ -46,3 +48,5 @@ tests:
                         path: chart-admin-username
                       - key: jenkins-admin-password
                         path: chart-admin-password
+                - secret:
+                    name: my-exisiting-credentials

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -285,6 +285,9 @@ controller:
   # an existing secret "secret-credentials" and a key inside it named "github-password" should be used in Jcasc as ${secret-credentials-github-password}
   # 'name' and 'keyName' must be lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
   # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
+  # existingSecret existing secret "secret-credentials" and a key inside it named "github-username" should be used in Jcasc as ${github-username}
+  # When using existingSecret no need to specify the keyName under additionalExistingSecrets.
+  existingSecret:
   additionalExistingSecrets: []
   #  - name: secret-name-1
   #    keyName: username


### PR DESCRIPTION
Signed-off-by: papi83dm <papi83dm@gmail.com>

### What this PR does / why we need it
Ability to mount all the keys from an exisiting k8s secrets without having to specify each key name under the `additionalExistingSecrets`

### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #744 

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] CHANGELOG.md was updated
