### PR TITLE
Enable sourcing TLS certs from external issuers

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.3.6
+
+Added `.Values.controller.shareProcessNamespace` and `.Values.controller.httpsKeyStore.disableSecretMount` to enable sourcing TLS certs from external issuers
+
 ## 4.3.5
 
 Added `.Values.helmtest.bats.image` and `.Values.helmtest.bats.image` to allow unit tests to be configurable. Fixes [https://github.com/jenkinsci/helm-charts/issues/683]

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,9 +12,13 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
-## 4.3.6
+## 4.3.7
 
 Added `.Values.controller.shareProcessNamespace` and `.Values.controller.httpsKeyStore.disableSecretMount` to enable sourcing TLS certs from external issuers
+
+## 4.3.6
+
+Update Jenkins image and appVersion to jenkins lts release version 2.387.1
 
 ## 4.3.5
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.3.6
-appVersion: 2.375.3
+version: 4.3.7
+appVersion: 2.387.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
   - https://github.com/jenkinsci/jenkins
@@ -29,7 +29,7 @@ annotations:
       url: https://www.jenkins.io/
   artifacthub.io/images: |
     - name: jenkins
-      image: jenkins/jenkins:2.375.3-jdk11
+      image: jenkins/jenkins:2.387.1-jdk11
     - name: k8s-sidecar
       image: kiwigrid/k8s-sidecar:1.15.0
     - name: inbound-agent

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.3.5
+version: 4.3.6
 appVersion: 2.375.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -70,6 +70,9 @@ spec:
       {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}
       {{- end }}
+      {{- if .Values.controller.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
 {{- if .Values.controller.usePodSecurityContext }}
       securityContext:
   {{- if hasKey .Values.controller "podSecurityContextOverride" }}
@@ -212,10 +215,14 @@ spec:
               value: "{{ .Values.controller.agentListenerPort }}"
             {{- if .Values.controller.httpsKeyStore.enable }}
             - name: JENKINS_HTTPS_KEYSTORE_PASSWORD
+            {{- if not .Values.controller.httpsKeyStore.disableSecretMount }}
               valueFrom:
                 secretKeyRef:
                   name: {{ if .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }} {{ .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }} {{ else }} {{ template "jenkins.fullname" . }}-https-jks  {{ end }}
                   key: {{ "https-jks-password" | quote }}
+            {{- else }}
+              value: {{ .Values.controller.httpsKeyStore.password }}
+            {{- end }}
             {{- end }}
 
             - name: CASC_JENKINS_CONFIG
@@ -256,7 +263,7 @@ spec:
 {{- if .Values.persistence.mounts }}
 {{ toYaml .Values.persistence.mounts | indent 12 }}
 {{- end }}
-            {{- if .Values.controller.httpsKeyStore.enable }}
+            {{- if and .Values.controller.httpsKeyStore.enable (not .Values.controller.httpsKeyStore.disableSecretMount) }}
             {{- $httpsJKSDirPath :=  printf "%s" .Values.controller.httpsKeyStore.path }}
             - mountPath: {{ $httpsJKSDirPath }}
               name: jenkins-https-keystore
@@ -421,7 +428,8 @@ spec:
         emptyDir: {}
       - name: tmp-volume
         emptyDir: {}
-      {{- if .Values.controller.httpsKeyStore.enable }}
+
+      {{- if and .Values.controller.httpsKeyStore.enable (not .Values.controller.httpsKeyStore.disableSecretMount) }}
       - name: jenkins-https-keystore
         secret:
           secretName: {{ if .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }} {{ .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName }} {{ else }} {{ template "jenkins.fullname" . }}-https-jks  {{ end }}

--- a/charts/jenkins/templates/secret-https-jks.yaml
+++ b/charts/jenkins/templates/secret-https-jks.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.httpsKeyStore.enable ( not  .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName ) -}}
+{{- if and .Values.controller.httpsKeyStore.enable ( not  .Values.controller.httpsKeyStore.jenkinsHttpsJksSecretName ) (not .Values.controller.httpsKeyStore.disableSecretMount) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -55,7 +55,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
+                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -175,7 +175,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "jenkins-agents"
-                      id: 6e750ae7b000be7917df5b00a91d0d0923a73357848c683cad33a556119b7a51
+                      id: 1a10b07681897b7cc9139b91f3e853b937636131fd089a0efb8e66e74bc25b30
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -206,7 +206,7 @@ tests:
                       yamlMergeStrategy: override
                     - name: "maven"
                       namespace: "maven"
-                      id: 10c1058e6b2f56024132b1e745b1dc59bb96efc1cb4ce96c7e7eeff69234d2ef
+                      id: 98603b48bbb1de225597bf5880686872d42061c877fee35c4fab6ccb88e272bf
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -237,7 +237,7 @@ tests:
                       yamlMergeStrategy: override
                     - name: "python"
                       namespace: "jenkins-agents"
-                      id: 4b0b84d994ac4c762ae46ea55829ebde7bf02a03315ca47425c61efc160b5709
+                      id: 531bebaf0c72403411727c4707cb4e2059b9b704931b7ad5e4252e764d5271fb
                       containers:
                       - name: "python"
                         alwaysPullImage: false
@@ -476,7 +476,7 @@ tests:
                       annotations:
                       - key: ci.jenkins-agent/test
                         value: "custom"
-                      id: 92000ebb9e31c9d9aa2d2e027689c250a56654ae91324129038586e9872d2c32
+                      id: e79c14afdc6e664e7b1a3b6f34bb7eec6bf98ac59160622d57ab8da1f01d6001
                       containers:
                       - name: "sideContainer"
                         alwaysPullImage: true
@@ -615,7 +615,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 1ad31223960302cee30a36ce3d73e8017b8702e9b3100d9b3de3e11f00208958
+                      id: 6cf53934d4c2f3aab69dea0559ccf421ba8eef504a0c5b1e6635771314433aeb
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -719,7 +719,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 830b3c578ad439b24340052e51aec67362fd63992a9298acaa59bfda3e99391f
+                      id: 308e936f8ec0ec04cc259317b11d0198213abf597f7ae60e8c457e32305b653a
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -821,7 +821,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: f57fed930c6aa9841be0c245fbe803cea2eda8e2c9f0526e17c76e3f8bbd15c1
+                      id: 12dadf8f976c728916ab897d6b9defbde76ae7334bee2204c63207d2bd801f0d
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -925,7 +925,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 187b5b627e42eff0b4f267ba448c4d203ba08467233690bb00bf58d26045d689
+                      id: a4b03974cd2c4fdfb51b0316a9200fce3667ec64f0a3102fc17c93c2705e84d9
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1030,7 +1030,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: e00d701466613fe20ab781b75a1926a4031a76bdd0c219460c2f51559f923704
+                      id: 65f61f69c153a78222e9c29622476c31ec92388e6ccd67f6c3d5ee153490949e
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1134,7 +1134,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: f07d9eb43cda17bd6c3f448332448bd4a3eff51936cde7c7afc44b02dff8e299
+                      id: 01a50fedfff36f9040028fa08f4412e81449043b9962e667ab783e03193d26ed
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1305,7 +1305,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
+                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1406,7 +1406,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "NAMESPACE"
-                      id: bb8414f0110939ce3d28b4c3ef67e5d80466a91db851c429e89951bd7c91882b
+                      id: 2c7b9a92df440929a8b40d336c27063bb92ecb3db1bf5681f6d11adc84902893
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1503,7 +1503,7 @@ tests:
                 templates:
                   - name: "default"
                     namespace: "default"
-                    id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
+                    id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
                     containers:
                     - name: "jnlp"
                       alwaysPullImage: false
@@ -1602,7 +1602,7 @@ tests:
                 templates:
                   - name: "default"
                     namespace: "default"
-                    id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
+                    id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
                     containers:
                     - name: "jnlp"
                       alwaysPullImage: false
@@ -1689,7 +1689,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
+                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1783,7 +1783,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
+                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1874,7 +1874,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
+                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1966,7 +1966,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
+                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2057,7 +2057,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 566cced37b2c61da0c884c892e5c0a58834fce925c6f836de7b65313a94be9e3
+                      id: ae3bc5414a38c8e17f95faa9738e7671edc85c140a9c790a25df648932d61577
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2178,7 +2178,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 566cced37b2c61da0c884c892e5c0a58834fce925c6f836de7b65313a94be9e3
+                      id: ae3bc5414a38c8e17f95faa9738e7671edc85c140a9c790a25df648932d61577
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2227,7 +2227,7 @@ tests:
                       yamlMergeStrategy: override
                     - name: "additional-agent"
                       namespace: "default"
-                      id: 0435d8506bd07c2eefccca326695b5a9a067849c450e3ee9fdcb13bede5c8e7b
+                      id: f47bf9f2671ebf089e17b77474f852c1a140f00b3dd8f7e6577b884e234a3ebb
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2343,7 +2343,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 566cced37b2c61da0c884c892e5c0a58834fce925c6f836de7b65313a94be9e3
+                      id: ae3bc5414a38c8e17f95faa9738e7671edc85c140a9c790a25df648932d61577
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2392,7 +2392,7 @@ tests:
                       yamlMergeStrategy: override
                     - name: "additional-agent"
                       namespace: "default"
-                      id: 0024a08654abb917be24d9bb330a5fc2f6cc003c117e12f685922fceae4a7e93
+                      id: 8d25a214acf09b200930c5f0f88ee5459a16a1e1d8ecaa85e1ba3e4a0ce56a38
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2480,7 +2480,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 6afb0727de6aa635c049662e567ed2d245a99b8b58431273ba5698c3dcb30a1d
+                      id: 31057edbbd35165952988b860022b1c7d8c669f28e5848b1abfd08ea7c498382
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2584,7 +2584,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: fda09c2a838ec94695b64700bb694959c5dd61bd9877d9da406ae93b1707200c
+                      id: 9e0afeef650f4eb8aff5b15ee439caa2c9fb865e4fbe5fce511ecbd63dd5050a
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -55,7 +55,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
+                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -175,7 +175,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "jenkins-agents"
-                      id: 1a10b07681897b7cc9139b91f3e853b937636131fd089a0efb8e66e74bc25b30
+                      id: 6e750ae7b000be7917df5b00a91d0d0923a73357848c683cad33a556119b7a51
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -206,7 +206,7 @@ tests:
                       yamlMergeStrategy: override
                     - name: "maven"
                       namespace: "maven"
-                      id: 98603b48bbb1de225597bf5880686872d42061c877fee35c4fab6ccb88e272bf
+                      id: 10c1058e6b2f56024132b1e745b1dc59bb96efc1cb4ce96c7e7eeff69234d2ef
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -237,7 +237,7 @@ tests:
                       yamlMergeStrategy: override
                     - name: "python"
                       namespace: "jenkins-agents"
-                      id: 531bebaf0c72403411727c4707cb4e2059b9b704931b7ad5e4252e764d5271fb
+                      id: 4b0b84d994ac4c762ae46ea55829ebde7bf02a03315ca47425c61efc160b5709
                       containers:
                       - name: "python"
                         alwaysPullImage: false
@@ -476,7 +476,7 @@ tests:
                       annotations:
                       - key: ci.jenkins-agent/test
                         value: "custom"
-                      id: e79c14afdc6e664e7b1a3b6f34bb7eec6bf98ac59160622d57ab8da1f01d6001
+                      id: 92000ebb9e31c9d9aa2d2e027689c250a56654ae91324129038586e9872d2c32
                       containers:
                       - name: "sideContainer"
                         alwaysPullImage: true
@@ -615,7 +615,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 6cf53934d4c2f3aab69dea0559ccf421ba8eef504a0c5b1e6635771314433aeb
+                      id: 1ad31223960302cee30a36ce3d73e8017b8702e9b3100d9b3de3e11f00208958
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -719,7 +719,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 308e936f8ec0ec04cc259317b11d0198213abf597f7ae60e8c457e32305b653a
+                      id: 830b3c578ad439b24340052e51aec67362fd63992a9298acaa59bfda3e99391f
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -821,7 +821,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 12dadf8f976c728916ab897d6b9defbde76ae7334bee2204c63207d2bd801f0d
+                      id: f57fed930c6aa9841be0c245fbe803cea2eda8e2c9f0526e17c76e3f8bbd15c1
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -925,7 +925,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: a4b03974cd2c4fdfb51b0316a9200fce3667ec64f0a3102fc17c93c2705e84d9
+                      id: 187b5b627e42eff0b4f267ba448c4d203ba08467233690bb00bf58d26045d689
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1030,7 +1030,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 65f61f69c153a78222e9c29622476c31ec92388e6ccd67f6c3d5ee153490949e
+                      id: e00d701466613fe20ab781b75a1926a4031a76bdd0c219460c2f51559f923704
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1134,7 +1134,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 01a50fedfff36f9040028fa08f4412e81449043b9962e667ab783e03193d26ed
+                      id: f07d9eb43cda17bd6c3f448332448bd4a3eff51936cde7c7afc44b02dff8e299
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1305,7 +1305,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
+                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1406,7 +1406,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "NAMESPACE"
-                      id: 2c7b9a92df440929a8b40d336c27063bb92ecb3db1bf5681f6d11adc84902893
+                      id: bb8414f0110939ce3d28b4c3ef67e5d80466a91db851c429e89951bd7c91882b
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1503,7 +1503,7 @@ tests:
                 templates:
                   - name: "default"
                     namespace: "default"
-                    id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
+                    id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
                     containers:
                     - name: "jnlp"
                       alwaysPullImage: false
@@ -1602,7 +1602,7 @@ tests:
                 templates:
                   - name: "default"
                     namespace: "default"
-                    id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
+                    id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
                     containers:
                     - name: "jnlp"
                       alwaysPullImage: false
@@ -1689,7 +1689,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
+                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1783,7 +1783,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
+                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1874,7 +1874,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
+                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -1966,7 +1966,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 47f0bda4071ad97639239317870f0926a1e9f581f942e28b109afdeca222ceb9
+                      id: 474be7705ac6cddeedf68ad2962972dd9921f64c6e534967402794fbf06a21ec
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2057,7 +2057,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: ae3bc5414a38c8e17f95faa9738e7671edc85c140a9c790a25df648932d61577
+                      id: 566cced37b2c61da0c884c892e5c0a58834fce925c6f836de7b65313a94be9e3
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2178,7 +2178,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: ae3bc5414a38c8e17f95faa9738e7671edc85c140a9c790a25df648932d61577
+                      id: 566cced37b2c61da0c884c892e5c0a58834fce925c6f836de7b65313a94be9e3
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2227,7 +2227,7 @@ tests:
                       yamlMergeStrategy: override
                     - name: "additional-agent"
                       namespace: "default"
-                      id: f47bf9f2671ebf089e17b77474f852c1a140f00b3dd8f7e6577b884e234a3ebb
+                      id: 0435d8506bd07c2eefccca326695b5a9a067849c450e3ee9fdcb13bede5c8e7b
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2343,7 +2343,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: ae3bc5414a38c8e17f95faa9738e7671edc85c140a9c790a25df648932d61577
+                      id: 566cced37b2c61da0c884c892e5c0a58834fce925c6f836de7b65313a94be9e3
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2392,7 +2392,7 @@ tests:
                       yamlMergeStrategy: override
                     - name: "additional-agent"
                       namespace: "default"
-                      id: 8d25a214acf09b200930c5f0f88ee5459a16a1e1d8ecaa85e1ba3e4a0ce56a38
+                      id: 0024a08654abb917be24d9bb330a5fc2f6cc003c117e12f685922fceae4a7e93
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2480,7 +2480,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 31057edbbd35165952988b860022b1c7d8c669f28e5848b1abfd08ea7c498382
+                      id: 6afb0727de6aa635c049662e567ed2d245a99b8b58431273ba5698c3dcb30a1d
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -2584,7 +2584,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: 9e0afeef650f4eb8aff5b15ee439caa2c9fb865e4fbe5fce511ecbd63dd5050a
+                      id: fda09c2a838ec94695b64700bb694959c5dd61bd9877d9da406ae93b1707200c
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -71,7 +71,7 @@ tests:
                         value: "50000"
                       - name: CASC_JENKINS_CONFIG
                         value: /var/jenkins_home/casc_configs
-                    image: jenkins/jenkins:2.375.3-jdk11
+                    image: jenkins/jenkins:2.387.1-jdk11
                     imagePullPolicy: Always
                     securityContext:
                       runAsUser: 1000
@@ -164,7 +164,7 @@ tests:
                   - command:
                       - sh
                       - /var/jenkins_config/apply_config.sh
-                    image: jenkins/jenkins:2.375.3-jdk11
+                    image: jenkins/jenkins:2.387.1-jdk11
                     imagePullPolicy: Always
                     securityContext:
                       runAsUser: 1000
@@ -353,7 +353,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: jenkins/jenkins:2.375.3-alpine
+          value: jenkins/jenkins:2.387.1-alpine
   - it: configure empty image tag label
     template: jenkins-controller-statefulset.yaml
     set:
@@ -361,7 +361,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: jenkins/jenkins:2.375.3
+          value: jenkins/jenkins:2.387.1
   - it: custom image
     template: jenkins-controller-statefulset.yaml
     set:

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -642,6 +642,88 @@ tests:
     asserts:
       - matchSnapshot:
           path: spec.template.metadata.annotations
+  - it: test true shareProcessNamespace
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        shareProcessNamespace: true
+    asserts:
+      - equal:
+          path: spec.template.spec.shareProcessNamespace
+          value: true
+  - it: test false shareProcessNamespace
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        shareProcessNamespace: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.shareProcessNamespace
+  - it: test disableSecretMount
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        httpsKeyStore:
+          enable: true
+          disableSecretMount: true
+          password: some-secret-password
+          path: /some/path
+          jenkinsHttpsJksSecretName: some-secret-name
+          fileName: some-file-name
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "JENKINS_HTTPS_KEYSTORE_PASSWORD"
+            value: some-secret-password
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /some/path
+            name: jenkins-https-keystore
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: jenkins-https-keystore
+            secret:
+              secretName: some-secret-name
+              items:
+              - key: jenkins-jks-file
+                path: some-file-name
+
+  - it: test not disableSecretMount
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        httpsKeyStore:
+          enable: true
+          disableSecretMount: false
+          jenkinsHttpsJksSecretName: some-secret-name
+          path: /some/path
+          fileName: some-file-name
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "JENKINS_HTTPS_KEYSTORE_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                name: some-secret-name
+                key: "https-jks-password"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /some/path
+            name: jenkins-https-keystore
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: jenkins-https-keystore
+            secret:
+              secretName: some-secret-name
+              items:
+                - key: jenkins-jks-file
+                  path: some-file-name
   - it:
     template: jenkins-controller-statefulset.yaml
     set:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -69,6 +69,8 @@ controller:
     limits:
       cpu: "2000m"
       memory: "4096Mi"
+  # Share process namespace to allow sidecar containers to interact with processes in other containers in the same pod
+  shareProcessNamespace: false
   # Overrides the init container default values
   # initContainerResources:
   #   requests:
@@ -564,6 +566,7 @@ controller:
   httpsKeyStore:
     jenkinsHttpsJksSecretName: ''
     enable: false
+    disableSecretMount: false
     httpPort: 8081
     path: "/var/jenkins_keystore"
     fileName: "keystore.jks"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -19,7 +19,7 @@ controller:
   # Used for label app.kubernetes.io/component
   componentName: "jenkins-controller"
   image: "jenkins/jenkins"
-  # tag: "2.375.3-jdk11"
+  # tag: "2.387.1-jdk11"
   tagLabel: jdk11
   imagePullPolicy: "Always"
   imagePullSecretName:


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it

- This allows for sidecars to provide TLS certificates and to signal a controller to reload certificates when they change
- Also optionally disables the creation of secrets which won't be used if they're being provided by an external issuer

### Special notes for your reviewer

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
