### PR TITLE
Disable secret mount on initContainer

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.3.10
+
+Correct incorrect env var definition
+Disable volume mount if disableSecretMount enabled
+
 ## 4.3.9
 
 Document `.Values.agent.directConnection` in README.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.3.9
+version: 4.3.10
 appVersion: 2.387.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -254,9 +254,9 @@ Returns kubernetes pod template configuration as code
         {{- if .Values.agent.directConnection }}
           key: "JENKINS_DIRECT_CONNECTION"
           {{- if .Values.agent.jenkinsTunnel }}
-          jenkinsTunnel: "{{ tpl .Values.agent.jenkinsTunnel . }}"
+          value: "{{ tpl .Values.agent.jenkinsTunnel . }}"
           {{- else }}
-          jenkinsTunnel: "{{ template "jenkins.fullname" . }}-agent.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{ .Values.controller.agentListenerPort }}"
+          value: "{{ template "jenkins.fullname" . }}-agent.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{ .Values.controller.agentListenerPort }}"
           {{- end }}
         {{- else }}
           key: "JENKINS_URL"

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -155,7 +155,7 @@ spec:
             - mountPath: {{ .Values.controller.jenkinsHome }}/init.groovy.d
               name: init-scripts
             {{- end }}
-            {{- if .Values.controller.httpsKeyStore.enable }}
+            {{- if and .Values.controller.httpsKeyStore.enable (not .Values.controller.httpsKeyStore.disableSecretMount) }}
             {{- $httpsJKSDirPath :=  printf "%s" .Values.controller.httpsKeyStore.path }}
             - mountPath: {{ $httpsJKSDirPath }}
               name: jenkins-https-keystore

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -2698,7 +2698,7 @@ tests:
                         envVars:
                           - envVar:
                               key: "JENKINS_DIRECT_CONNECTION"
-                              jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                              value: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
                         image: "jenkins/inbound-agent:4.11.2-4"
                         privileged: "false"
                         resourceLimitCpu: 512m

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -682,6 +682,11 @@ tests:
             mountPath: /some/path
             name: jenkins-https-keystore
       - notContains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            mountPath: /some/path
+            name: jenkins-https-keystore
+      - notContains:
           path: spec.template.spec.volumes
           content:
             name: jenkins-https-keystore
@@ -712,6 +717,11 @@ tests:
                 key: "https-jks-password"
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /some/path
+            name: jenkins-https-keystore
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
           content:
             mountPath: /some/path
             name: jenkins-https-keystore


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->

### What this PR does / why we need it

- disables the volume mount of `jenkins-https-keystore` on the initContainer when `disableSecretMount` is set to true. Currently, setting this variable to true will prevent jenkins from starting up as it will attempt to mount a secret on the init container which does not exist (and, if `disableSecretMount` is set to true, is not wanted).
- Corrects the definition of an environment variable. This was mistakenly defined with keys of `name` and `jenkinsTunnel` rather than `name` and `value` due to an incorrectly handled merge

### Which issue this PR fixes

- This corrects bugs from #814 

### Special notes for your reviewer


### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] CHANGELOG.md was updated
