### PR TITLE
Drop DCO requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,5 @@ We would like these checks to pass before we even continue reviewing your change
 
 ### Checklist
 <!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
-- [ ] [DCO](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
 - [ ] Chart Version bumped
 - [ ] CHANGELOG.md was updated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,31 +2,9 @@
 
 Contributions are welcome via GitHub pull requests. This document outlines the process to help get your contribution accepted.
 
-## Sign off Your Work
-
-The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the [DCO](http://developercertificate.org/). Contributors must sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
-
-```text
-This is my commit message
-
-Signed-off-by: Random J Developer <random@developer.example.org>
-```
-
-See `git help commit`:
-
-```text
--s, --signoff
-    Add Signed-off-by line by the committer at the end of the commit log
-    message. The meaning of a signoff depends on the project, but it typically
-    certifies that committer has the rights to submit this work under the same
-    license and agrees to a Developer Certificate of Origin (see
-    http://developercertificate.org/ for more information).
-```
-
 ## How to Contribute
 
 1. Fork this repository, develop, and test your changes
-1. Remember to sign off your commits as described above
 1. Submit a pull request
 
 ***NOTE***: In order to make testing and merging of PRs easier, please submit changes to multiple charts in separate PRs.
@@ -51,7 +29,6 @@ minikube service chart-$CHART
 
 ### Technical Requirements
 
-* Must pass [DCO check](#sign-off-your-work)
 * Must follow [Charts best practices](https://helm.sh/docs/topics/chart_best_practices/)
 * Must pass CI jobs for linting and installing changed charts with the [chart-testing](https://github.com/helm/chart-testing) tool
 * Any change to a chart requires a version bump following [semver](https://semver.org/) principles. See [Immutability](#immutability) and [Versioning](#versioning) below


### PR DESCRIPTION
The Jenkins project strives for a low barrier of entry for everyone. This principle is partly achieved by not requiring (new) contributors to perform any sort of additional chores to get their changes proposed into the codebase, endorsed by the Jenkins project governance.

Signing commits should be voluntary for contributors, that's how repositories are handled within the jenkinsci organization. Therefore, I recommend uninstalling the DCO bot, to comply with the overall project governance.
Contributors, who want to sign off their work, can do that nonetheless.