### PR TITLE
Move to jenkins-infra version of 'jenkins-version'

### DIFF
--- a/.github/workflows/sync-lts.yaml
+++ b/.github/workflows/sync-lts.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Jenkins LTS version
         id: lts
-        uses: garethjevans/jenkins-version@0.1.2
+        uses: jenkins-infra/jenkins-version@0.3.2
         with:
           version-identifier: lts
 


### PR DESCRIPTION
While comparing https://github.com/garethjevans/jenkins-version with https://github.com/jenkins-infra/jenkins-version I see no difference in commits, but a repository that is much lesser maintained than ours.

Is there a particular reason to use the fork of our repository, if it contains no new content?