### PR TITLE
Update python in lint-test from 3.7 to 3.11.2

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11.2
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1


### PR DESCRIPTION
Let's see if we can use a newer version over one from 2018.