### PR TITLE
Fix typo in 'controller'

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The change log until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.3.14
+
+
+Update various GH actions, typo fixes, and miscellaneous chores.
+
 ## 4.3.13
 
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.3.13
+version: 4.3.14
 appVersion: 2.387.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -617,7 +617,7 @@ controller:
 agent:
   enabled: true
   defaultsProviderTemplate: ""
-  # URL for connecting to the Jenkins contoller
+  # URL for connecting to the Jenkins controller
   jenkinsUrl:
   # connect to the specified host and port, instead of connecting directly to the Jenkins controller
   jenkinsTunnel:


### PR DESCRIPTION
I cherry-picked this commit from the other PR because I can't rebase it.

GH actions expect a chart update for that one:
>  ✖︎ jenkins => (version: "4.3.13", path: "charts/jenkins") > Chart version not ok. Needs a version bump!

Closes https://github.com/jenkinsci/helm-charts/pull/782