### PR TITLE
Slow down LTS sync schedule

### DIFF
--- a/.github/workflows/sync-lts.yaml
+++ b/.github/workflows/sync-lts.yaml
@@ -3,7 +3,7 @@ name: Sync LTS Version
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "0 * * * 3"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Instead of running every 15 minutes all day long, the change proposed slows it down to run hourly on Wednesday's, the only day of the week LTS releases are published.

Possible typo issues are covered by https://github.com/jenkinsci/helm-charts/pull/843