### PR TITLE
Bump chart version

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.3.22
+
+
+Bump chart version.
+
 ## 4.3.21
 
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.3.21
+version: 4.3.22
 appVersion: 2.387.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/helm-charts/issues/852 by releasing a newer version.

I tried to replay the GH workflow, but all it did was re-uploading the archive. Bumping the charts to skip 4.2.21 silently seems to be the easiest solution.