### PR TITLE
Fix spelling mistakes in charts/jenkins/README.md.

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -18,7 +18,6 @@ Fix various typos in the chart documentation.
 
 ## 4.3.25
 
-=======
 | plugin                | old version          | new version           |
 |-----------------------|----------------------|-----------------------|
 | kubernetes            | 3900.va_dce992317b_4 | 3937.vd7b_82db_e347b_ |

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.3.25
+
+Fix various typos in the chart documentation.
+
 ## 4.3.24
 
 Update Jenkins image and appVersion to jenkins lts release version 2.401.1

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.3.24
+version: 4.3.25
 appVersion: 2.401.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -222,8 +222,8 @@ Further JCasC examples can be found [here](https://github.com/jenkinsci/configur
 
 #### Breaking out large Config as Code scripts
 
-Jenkins Config as Code scripts can become quite large, and maintaining all of your scripts within one yaml file can be difficult.  The Config as Code plugin itself suggests updating the `CASC_JENKINS_CONFIG` environment variable to be a comma seperated list of paths for the plugin to traverse, picking up the yaml files as needed.  
-However, under the Jenkins helm chart, this `CASC_JENKINS_CONFIG` value is maintained through the templates.  A better solution is to split your `controller.JCasC.configScripts` into seperate values files, and provide each file during the helm install.
+Jenkins Config as Code scripts can become quite large, and maintaining all of your scripts within one yaml file can be difficult.  The Config as Code plugin itself suggests updating the `CASC_JENKINS_CONFIG` environment variable to be a comma separated list of paths for the plugin to traverse, picking up the yaml files as needed.  
+However, under the Jenkins helm chart, this `CASC_JENKINS_CONFIG` value is maintained through the templates.  A better solution is to split your `controller.JCasC.configScripts` into separate values files, and provide each file during the helm install.
 
 For example, you can have a values file (e.g values_main.yaml) that defines the values described in the `VALUES_SUMMARY.md` for your Jenkins configuration:
 


### PR DESCRIPTION
These changes resolve spelling mistakes found within `charts/jenkins/README.md`.
* A misspelled word, `seperated`, has been corrected to `separated` following [the Merriam-Webster spelling of the word](https://www.merriam-webster.com/dictionary/separated).
* A misspelled word, `seperate`, has been corrected to `separate` following [the Merriam-Webster spelling of the word](https://www.merriam-webster.com/dictionary/separate).