### PR TITLE
Outline how to bump charts in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,11 @@
 
 ### What does this PR do?
 
-<!-- Describe the purpose of this PR, and any background context. -->
+<!-- Describe the purpose of this PR, and any background context.
+*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
+-->
+
+- Fixes #
 
 If you modified files in the `./charts/jenkins/` directory, please also include the following:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,42 +1,18 @@
-<!--
-Thank you for contributing!
-Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:
-
-* https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
-* https://helm.sh/docs/chart_best_practices/
-
-For a quick overview across what we will look at reviewing your PR, please read our review guidelines:
-
-* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md
-
-Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.
-
-When updates to your PR are requested, please add new commits and do not squash the history.
-This will make it easier to identify new changes.
-The PR will be squashed anyways when it is merged.
-Thanks.
-
-For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
-
-Please make sure you test your changes before you push them.
-Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
-These checks run very quickly.
-Please check the results.
-We would like these checks to pass before we even continue reviewing your changes.
--->
 <!-- markdownlint-disable MD041 -->
 
-### What this PR does / why we need it
+### What does this PR do?
 
-### Which issue this PR fixes
+<!-- Describe the purpose of this PR, and any background context. -->
 
-*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
+If you modified files in the `./charts/jenkins/` directory, please also include the following:
 
-- fixes #
+```[tasklist]
+### Submitter checklist
+- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
+- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
+- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
+```
 
 ### Special notes for your reviewer
 
-### Checklist
-<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
-- [ ] Chart Version bumped
-- [ ] CHANGELOG.md was updated
+<!-- Leave blank if none -->


### PR DESCRIPTION
A small change, simplifying the PR template and removing the outdated helm/charts default text, that hopefully helps contributors to bump charts and add changelog entries, when modifying files guarded by GH actions.

# Real world demo below:

<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context. -->

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

<!-- Leave blank if none -->
