### PR TITLE
Update bundled plugins

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -15,10 +15,11 @@ Those entries include a reference to the git commit to be able to get more detai
 ## 4.3.25
 
 | plugin                | old version          | new version           |
-| --------------------- |----------------------|-----------------------|
+|-----------------------|----------------------|-----------------------|
 | kubernetes            | 3900.va_dce992317b_4 | 3937.vd7b_82db_e347b_ |
 | configuration-as-code | 1625.v27444588cc3d   | 1647.ve39ca_b_829b_42 |
 | git                   | 5.0.0                | 5.1.0                 |
+| ldap                  | 671.v2a_9192a_7419d  | 682.v7b_544c9d1512    |
 
 ## 4.3.24
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,14 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.3.25
+
+| plugin                | old version          | new version           |
+| --------------------- |----------------------|-----------------------|
+| kubernetes            | 3900.va_dce992317b_4 | 3937.vd7b_82db_e347b_ |
+| configuration-as-code | 1625.v27444588cc3d   | 1647.ve39ca_b_829b_42 |
+| git                   | 5.0.0                | 5.1.0                 |
+
 ## 4.3.24
 
 Update Jenkins image and appVersion to jenkins lts release version 2.401.1

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.3.24
+version: 4.3.25
 appVersion: 2.401.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/ci/other-values.yaml
+++ b/charts/jenkins/ci/other-values.yaml
@@ -18,7 +18,7 @@ controller:
               fromUserRecord:
                 attributeName: "memberOf"
   additionalPlugins:
-    - ldap:671.v2a_9192a_7419d
+    - ldap:682.v7b_544c9d1512
   scriptApproval:
     - "method groovy.json.JsonSlurperClassic parseText java.lang.String"
     - "new groovy.json.JsonSlurperClassic"

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -1,5 +1,5 @@
 render pod annotations:
   1: |
-    checksum/config: 572b6e6e44f82aa907092e9fcd7e4070830217a6bdca52f224d0c82dea885b9a
+    checksum/config: e9c390a2ecfa538ee038b07834bd56ac20fee77706eb3a112fdaa2d177185ede
     fixed-annotation: some-fixed-annotation
     templated-annotations: my-release

--- a/charts/jenkins/unittests/config-test.yaml
+++ b/charts/jenkins/unittests/config-test.yaml
@@ -40,10 +40,10 @@ tests:
       - equal:
           path: data.plugins\.txt
           value: |-
-            kubernetes:3900.va_dce992317b_4
+            kubernetes:3937.vd7b_82db_e347b_
             workflow-aggregator:596.v8c21c963d92d
-            git:5.0.0
-            configuration-as-code:1625.v27444588cc3d
+            git:5.1.0
+            configuration-as-code:1647.ve39ca_b_829b_42
   - it: no plugins
     set:
       controller.installPlugins: []
@@ -69,10 +69,10 @@ tests:
       - equal:
           path: data.plugins\.txt
           value: |-
-            kubernetes:3900.va_dce992317b_4
+            kubernetes:3937.vd7b_82db_e347b_
             workflow-aggregator:596.v8c21c963d92d
-            git:5.0.0
-            configuration-as-code:1625.v27444588cc3d
+            git:5.1.0
+            configuration-as-code:1647.ve39ca_b_829b_42
             kubernetes-credentials-provider
   - it: install latest plugins
     set:

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -46,7 +46,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: 572b6e6e44f82aa907092e9fcd7e4070830217a6bdca52f224d0c82dea885b9a
+                  checksum/config: e9c390a2ecfa538ee038b07834bd56ac20fee77706eb3a112fdaa2d177185ede
                 labels:
                   app.kubernetes.io/component: jenkins-controller
                   app.kubernetes.io/instance: my-release

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -241,10 +241,10 @@ controller:
 
   # List of plugins to be install during Jenkins controller start
   installPlugins:
-    - kubernetes:3900.va_dce992317b_4
+    - kubernetes:3937.vd7b_82db_e347b_
     - workflow-aggregator:596.v8c21c963d92d
-    - git:5.0.0
-    - configuration-as-code:1625.v27444588cc3d
+    - git:5.1.0
+    - configuration-as-code:1647.ve39ca_b_829b_42
 
   # Set to false to download the minimum required version of all dependencies.
   installLatestPlugins: true


### PR DESCRIPTION
Resolves a conflict with the pipeline plugin and git:
```
Plugin workflow-aggregator:596.v8c21c963d92d (via workflow-cps:3691.v28b_14c465a_b_b_) depends on git:5.1.0, but there is an older version defined on the top level - git:5.0.0,
```
I chose to bump all plugins to the version defined in the bom to prevent further conflicts.