### PR TITLE
feat: Make the k8s API server URL configurable

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.3.28
+
+Allow the kubernetes API server URL to be configurable.
+
 ## 4.3.27
 
 Bump kiwigrid/k8s-sidecar from 1.23.1 to 1.24.4 and jenkins/inbound-agent from 3107.v665000b_51092-5 to 3107.v665000b_51092-15.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.3.27
+version: 4.3.28
 appVersion: 2.401.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -10,6 +10,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 |---------------------------------------------|--------------------------------------------------------------------------|----------------------------------------------------------------------|
 | `checkDeprecation`                          | Checks for deprecated values used                                        | `true`                                                               |
 | `clusterZone`                               | Override the cluster name for FQDN resolving                             | `cluster.local`                                                      |
+| `kubernetesURL`                             | Override the Kubernetes API server URL                                   | `https://kubernetes.default`                                         |
 | `nameOverride`                              | Override the resource name prefix                                        | `jenkins`                                                            |
 | `renderHelmLabels`                          | Enables rendering of the helm.sh/chart label to the annotations          | `true`                                                               |
 | `fullnameOverride`                          | Override the full resource names                                         | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`) |

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -164,7 +164,7 @@ jenkins:
       maxRequestsPerHostStr: {{ .Values.agent.maxRequestsPerHostStr | quote }}
       name: "{{ .Values.controller.cloudName }}"
       namespace: "{{ template "jenkins.agent.namespace" . }}"
-      serverUrl: "https://kubernetes.default"
+      serverUrl: "{{ .Values.kubernetesURL }}"
       {{- if .Values.agent.enabled }}
       podLabels:
       - key: "jenkins/{{ .Release.Name }}-{{ .Values.agent.componentName }}"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -13,6 +13,9 @@
 # ref: https://github.com/kubernetes/dns/blob/master/docs/specification.md
 clusterZone: "cluster.local"
 
+# The URL of the Kubernetes API server
+kubernetesURL: "https://kubernetes.default"
+
 renderHelmLabels: true
 
 controller:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

This PR allows the kubernetes API server URL to be configurable via `kubernetesURL` in the chart values.

Previously it was hard coded to `https://kubernetes.default` which is now the default value.

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

