### PR TITLE
feat: allow cloning home-pvc from custom dataSource

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.5.0
+
+Added `.Values.persistence.dataSource` to allow cloning home PVC from existing dataSource.
+
 ## 4.4.2
 
 Update Jenkins image and appVersion to jenkins lts release version 2.401.3

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.4.2
+version: 4.5.0
 appVersion: 2.401.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -358,18 +358,19 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 ### Persistence
 
-| Parameter                   | Description                     | Default         |
-| --------------------------- | ------------------------------- | --------------- |
-| `persistence.enabled`       | Enable the use of a Jenkins PVC | `true`          |
-| `persistence.existingClaim` | Provide the name of a PVC       | `nil`           |
-| `persistence.storageClass`  | Storage class for the PVC       | `nil`           |
-| `persistence.annotations`   | Annotations for the PVC         | `{}`            |
-| `persistence.labels`        | Labels for the PVC              | `{}`            |
-| `persistence.accessMode`    | The PVC access mode             | `ReadWriteOnce` |
-| `persistence.size`          | The size of the PVC             | `8Gi`           |
-| `persistence.subPath`       | SubPath for jenkins-home mount  | `nil`           |
-| `persistence.volumes`       | Additional volumes              | `nil`           |
-| `persistence.mounts`        | Additional mounts               | `nil`           |
+| Parameter                   | Description                            | Default         |
+| --------------------------- | -------------------------------------- | --------------- |
+| `persistence.enabled`       | Enable the use of a Jenkins PVC        | `true`          |
+| `persistence.existingClaim` | Provide the name of a PVC              | `nil`           |
+| `persistence.storageClass`  | Storage class for the PVC              | `nil`           |
+| `persistence.annotations`   | Annotations for the PVC                | `{}`            |
+| `persistence.labels`        | Labels for the PVC                     | `{}`            |
+| `persistence.accessMode`    | The PVC access mode                    | `ReadWriteOnce` |
+| `persistence.size`          | The size of the PVC                    | `8Gi`           |
+| `persistence.dataSource`    | Existing data source to clone PVC from | `nil`           |
+| `persistence.subPath`       | SubPath for jenkins-home mount         | `nil`           |
+| `persistence.volumes`       | Additional volumes                     | `nil`           |
+| `persistence.mounts`        | Additional mounts                      | `nil`           |
 
 ### Backup
 

--- a/charts/jenkins/templates/home-pvc.yaml
+++ b/charts/jenkins/templates/home-pvc.yaml
@@ -21,6 +21,10 @@ metadata:
 {{ toYaml .Values.persistence.labels | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.persistence.dataSource }}
+  dataSource:
+{{ toYaml .Values.persistence.dataSource | indent 4 }}
+{{- end }}
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
   resources:

--- a/charts/jenkins/unittests/home-pvc-test.yaml
+++ b/charts/jenkins/unittests/home-pvc-test.yaml
@@ -31,6 +31,8 @@ tests:
           value:
             storage: 8Gi
       - isNull:
+          path: spec.dataSource
+      - isNull:
           path: spec.storageClassName
             
   - it: test different values
@@ -92,3 +94,18 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: jenkins
             test-label: test-value
+
+  - it: clone from dataSource
+    set:
+      persistence:
+        dataSource:
+          name: PVC-NAME
+          kind: PersistentVolumeClaim
+    asserts:
+      - equal:
+          path: spec.dataSource.name
+          value: PVC-NAME
+      - equal:
+          path: spec.dataSource.kind
+          value: PersistentVolumeClaim
+

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -850,6 +850,11 @@ persistence:
   labels: {}
   accessMode: "ReadWriteOnce"
   size: "8Gi"
+  # Existing data source to clone PVC from
+  # ref: https://kubernetes.io/docs/concepts/storage/volume-pvc-datasource/
+  dataSource:
+  #   name: PVC-NAME
+  #   kind: PersistentVolumeClaim
   volumes:
   #  - name: nothing
   #    emptyDir: {}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->
Add the ability to clone the home PVC from an existing volume, GCP snapshot, etc as described in [CSI Volume Cloning](https://kubernetes.io/docs/concepts/storage/volume-pvc-datasource/). Not only is this useful for CI/testing against the jenkins chart, this can also be used to restore from a backup or to facilitate a major jenkins version upgrade.


If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer
i added tests
<!-- Leave blank if none -->
