### PR TITLE
Update jcasc plugin

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -11,6 +11,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
+
+## 4.6.1
+
+Update `configuration-as-code` plugin to fix dependency issues with `azure-ad` plugin
+
 ## 4.6.0
 
 Added `.Values.controller.httpsKeyStore.jenkinsHttpsJksSecretKey` to allow overriding the default secret key containing the JKS file.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.6.0
+version: 4.6.1
 appVersion: 2.414.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -1,5 +1,5 @@
 render pod annotations:
   1: |
-    checksum/config: e9c390a2ecfa538ee038b07834bd56ac20fee77706eb3a112fdaa2d177185ede
+    checksum/config: e7e3e6a88c97b73fc5b8a1dea17f2586b5c2d05bc01628c963925c77fc3602b8
     fixed-annotation: some-fixed-annotation
     templated-annotations: my-release

--- a/charts/jenkins/unittests/config-test.yaml
+++ b/charts/jenkins/unittests/config-test.yaml
@@ -43,7 +43,7 @@ tests:
             kubernetes:3937.vd7b_82db_e347b_
             workflow-aggregator:596.v8c21c963d92d
             git:5.1.0
-            configuration-as-code:1647.ve39ca_b_829b_42
+            configuration-as-code:1670.v564dc8b_982d0
   - it: no plugins
     set:
       controller.installPlugins: []
@@ -72,7 +72,7 @@ tests:
             kubernetes:3937.vd7b_82db_e347b_
             workflow-aggregator:596.v8c21c963d92d
             git:5.1.0
-            configuration-as-code:1647.ve39ca_b_829b_42
+            configuration-as-code:1670.v564dc8b_982d0
             kubernetes-credentials-provider
   - it: install latest plugins
     set:

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -46,7 +46,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: e9c390a2ecfa538ee038b07834bd56ac20fee77706eb3a112fdaa2d177185ede
+                  checksum/config: e7e3e6a88c97b73fc5b8a1dea17f2586b5c2d05bc01628c963925c77fc3602b8
                 labels:
                   app.kubernetes.io/component: jenkins-controller
                   app.kubernetes.io/instance: my-release

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -247,7 +247,7 @@ controller:
     - kubernetes:3937.vd7b_82db_e347b_
     - workflow-aggregator:596.v8c21c963d92d
     - git:5.1.0
-    - configuration-as-code:1647.ve39ca_b_829b_42
+    - configuration-as-code:1670.v564dc8b_982d0
 
   # Set to false to download the minimum required version of all dependencies.
   installLatestPlugins: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

We had plugin dependency issues with `azure-ad` plugin after updating to the latest jenkins helm chart version (4.6.0)

```
...
io.jenkins.tools.pluginmanager.impl.AggregatePluginPrerequisitesNotMetException: Multiple plugin prerequisites not met:
Plugin azure-ad:385.v5d9f88612dd2 depends on configuration-as-code:1670.v564dc8b_982d0, but there is an older version defined on the top level - configuration-as-code:1647.ve39ca_b_829b_42,
Plugin azure-ad:385.v5d9f88612dd2 (via matrix-auth:3.2) depends on configuration-as-code:1670.v564dc8b_982d0, but there is an older version defined on the top level - configuration-as-code:1647.ve39ca_b_829b_42
...
```
- Fixes plugin dependency issues with `azure-ad:385.v5d9f88612dd2`

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

I was able to successfully install the latest jenkins helm chart version with the following override:

```
installPlugins:
  - configuration-as-code:1670.v564dc8b_982d0
```