### PR TITLE
Improving DRY principle support on Jenkins Controller Ingress host name

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.6.2
+
+Introducing TPL function on variables related to hostname in `./charts/jenkins/templates/jenkins-controller-ingress.yaml`
+
 ## 4.6.1
 
 Update `configuration-as-code` plugin to fix dependency issues with `azure-ad` plugin

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,10 +12,13 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.6.4
+
+Introducing TPL function on variables related to hostname in `./charts/jenkins/templates/jenkins-controller-ingress.yaml`
+
 ## 4.6.3
 
-* Add values to documentation
-* Introducing TPL function on variables related to hostname in `./charts/jenkins/templates/jenkins-controller-ingress.yaml`
+Add values to documentation
 
 ## 4.6.2
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,8 +14,8 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 4.6.3
 
-Add values to documentation
-Introducing TPL function on variables related to hostname in `./charts/jenkins/templates/jenkins-controller-ingress.yaml`
+* Add values to documentation
+* Introducing TPL function on variables related to hostname in `./charts/jenkins/templates/jenkins-controller-ingress.yaml`
 
 ## 4.6.2
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
 version: 4.6.2
-appVersion: 2.414.2
+appVersion: 2.414.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.6.3
+version: 4.6.4
 appVersion: 2.414.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.6.1
-appVersion: 2.414.1
+version: 4.6.2
+appVersion: 2.414.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/charts/jenkins/templates/jenkins-controller-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-ingress.yaml
@@ -52,7 +52,7 @@ spec:
 {{ tpl (toYaml .Values.controller.ingress.paths | indent 6) . }}
 {{- end -}}
 {{- if .Values.controller.ingress.hostName }}
-    host: {{ .Values.controller.ingress.hostName | quote }}
+    host: {{ tpl .Values.controller.ingress.hostName . | quote }}
 {{- end }}
 {{- if .Values.controller.ingress.resourceRootUrl }}
   - http:
@@ -68,10 +68,10 @@ spec:
           serviceName: {{ template "jenkins.fullname" . }}
           servicePort: {{ .Values.controller.servicePort }}
 {{- end }}
-    host: {{ .Values.controller.ingress.resourceRootUrl | quote }}
+    host: {{ tpl .Values.controller.ingress.resourceRootUrl . | quote }}
 {{- end }}
 {{- if .Values.controller.ingress.tls }}
   tls:
-{{ toYaml .Values.controller.ingress.tls | indent 4 }}
+{{ tpl (toYaml .Values.controller.ingress.tls ) . | indent 4 }}
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

Improving DRY principle support on Jenkins Controller Ingress host name

- Fixes #

### Submitter checklist
- [ ] Introducing TPL function on variables related to hostname in `./charts/jenkins/templates/jenkins-controller-ingress.yaml`


### Special notes for your reviewer

The change is intending to support the following syntax in a _values.yaml_ such as:
```
global:
  jenkinsHostname: "jenkins.my-org.com"

controller:
  ingress:
    enabled: true
    hostName: "{{ .Values.global.jenkinsHostname }}"
    resourceRootUrl: "{{ .Values.global.jenkinsHostname }}"
    tls:
      - hosts:
        - "{{ .Values.global.jenkinsHostname }}"
```
