### PR TITLE
Update jenkinsciinfra/jv from 0.4.4 to 0.4.6

### DIFF
--- a/.github/workflows/sync-lts.yaml
+++ b/.github/workflows/sync-lts.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Jenkins LTS version
         id: lts
-        uses: jenkins-infra/jenkins-version@0.4.4
+        uses: jenkins-infra/jenkins-version@0.4.6
         with:
           version-identifier: lts
 


### PR DESCRIPTION
0.4.4 vanished from https://hub.docker.com/r/jenkinsciinfra/jv/tags causing a failure in this workflow.