### PR TITLE
Upgrade kubernetes plugin version

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.6.5
+version: 4.6.6
 appVersion: 2.414.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -1,5 +1,5 @@
 render pod annotations:
   1: |
-    checksum/config: e7e3e6a88c97b73fc5b8a1dea17f2586b5c2d05bc01628c963925c77fc3602b8
+    checksum/config: ce69b63eb27efd6e89b22eeaf52dbe7fe3a319b4178f4de5a66077e50ccf50df
     fixed-annotation: some-fixed-annotation
     templated-annotations: my-release

--- a/charts/jenkins/unittests/config-test.yaml
+++ b/charts/jenkins/unittests/config-test.yaml
@@ -40,7 +40,7 @@ tests:
       - equal:
           path: data.plugins\.txt
           value: |-
-            kubernetes:3937.vd7b_82db_e347b_
+            kubernetes:4029.v5712230ccb_f8
             workflow-aggregator:596.v8c21c963d92d
             git:5.1.0
             configuration-as-code:1670.v564dc8b_982d0
@@ -69,7 +69,7 @@ tests:
       - equal:
           path: data.plugins\.txt
           value: |-
-            kubernetes:3937.vd7b_82db_e347b_
+            kubernetes:4029.v5712230ccb_f8
             workflow-aggregator:596.v8c21c963d92d
             git:5.1.0
             configuration-as-code:1670.v564dc8b_982d0

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -46,7 +46,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: e7e3e6a88c97b73fc5b8a1dea17f2586b5c2d05bc01628c963925c77fc3602b8
+                  checksum/config: ce69b63eb27efd6e89b22eeaf52dbe7fe3a319b4178f4de5a66077e50ccf50df
                 labels:
                   app.kubernetes.io/component: jenkins-controller
                   app.kubernetes.io/instance: my-release

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -244,7 +244,7 @@ controller:
 
   # List of plugins to be install during Jenkins controller start
   installPlugins:
-    - kubernetes:3937.vd7b_82db_e347b_
+    - kubernetes:4029.v5712230ccb_f8
     - workflow-aggregator:596.v8c21c963d92d
     - git:5.1.0
     - configuration-as-code:1670.v564dc8b_982d0


### PR DESCRIPTION
currently when installing jenkins with helm chart on a new kubernetes cluster the kubernetes plugin requires an upgrade in order to function

<!-- markdownlint-disable MD041 -->

### What does this PR do?
upgrading the kubernetes plugin to it's latest version. 
also suggested here: https://community.jenkins.io/t/error-while-launching-agent/9385/5
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- I bumped the "version" for kubernetes plugin key in `./charts/jenkins/values.yml`.
```
<!-- Leave blank if none -->
