### PR TITLE
Use config-reload container as an init container

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.7.0
+
+Runs `config-reload` as an init container, in addition to the sidecar container, to ensure that JCasC YAMLS are present before the main Jenkins container starts. This should fix some race conditions and crashes on startup.
+
 ## 4.6.5
 
 Update Jenkins image and appVersion to jenkins lts release version 2.414.2

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.6.6
+version: 4.7.0
 appVersion: 2.414.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -22,20 +22,21 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 #### Jenkins Configuration as Code (JCasC)
 
-| Parameter                         | Description                          | Default                                                           |
-| --------------------------------- | ------------------------------------ |-------------------------------------------------------------------|
-| `controller.JCasC.defaultConfig`      | Enables default Jenkins configuration via configuration as code plugin | `true`                                                            |
-| `controller.JCasC.configScripts`      | List of Jenkins Config as Code scripts | `{}`                                                              |
-| `controller.JCasC.security`      | Jenkins Config as Code for Security section | `legacy`                                                          |
-| `controller.JCasC.securityRealm`      | Jenkins Config as Code for Security Realm | `legacy`                                                          |
-| `controller.JCasC.authorizationStrategy` | Jenkins Config as Code for Authorization Strategy | `loggedInUsersCanDoAnything`                                      |
-| `controller.sidecars.configAutoReload` | Jenkins Config as Code auto-reload settings |                                                                   |
-| `controller.sidecars.configAutoReload.enabled` | Jenkins Config as Code auto-reload settings (Attention: rbac needs to be enabled otherwise the sidecar can't read the config map) | `true`                                                            |
-| `controller.sidecars.configAutoReload.image` | Image which triggers the reload | `kiwigrid/k8s-sidecar:1.24.4`                                     |
-| `controller.sidecars.configAutoReload.reqRetryConnect` | How many connection-related errors to retry on  | `10`                                                              |
-| `controller.sidecars.configAutoReload.envFrom` | Environment variable sources for the Jenkins Config as Code auto-reload container | Not set                                                           |
-| `controller.sidecars.configAutoReload.env` | Environment variables for the Jenkins Config as Code auto-reload container  | Not set                                                           |
-| `controller.sidecars.configAutoReload.containerSecurityContext` | Enable container security context | `{readOnlyRootFilesystem: true, allowPrivilegeEscalation: false}` |
+| Parameter                                                       | Description                                                                                                                       | Default                                                           |
+|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `controller.JCasC.defaultConfig`                                | Enables default Jenkins configuration via configuration as code plugin                                                            | `true`                                                            |
+| `controller.JCasC.configScripts`                                | List of Jenkins Config as Code scripts                                                                                            | `{}`                                                              |
+| `controller.JCasC.security`                                     | Jenkins Config as Code for Security section                                                                                       | `legacy`                                                          |
+| `controller.JCasC.securityRealm`                                | Jenkins Config as Code for Security Realm                                                                                         | `legacy`                                                          |
+| `controller.JCasC.authorizationStrategy`                        | Jenkins Config as Code for Authorization Strategy                                                                                 | `loggedInUsersCanDoAnything`                                      |
+| `controller.sidecars.configAutoReload`                          | Jenkins Config as Code auto-reload settings                                                                                       |                                                                   |
+| `controller.sidecars.configAutoReload.enabled`                  | Jenkins Config as Code auto-reload settings (Attention: rbac needs to be enabled otherwise the sidecar can't read the config map) | `true`                                                            |
+| `controller.sidecars.configAutoReload.image`                    | Image which triggers the reload                                                                                                   | `kiwigrid/k8s-sidecar:1.24.4`                                     |
+| `controller.sidecars.configAutoReload.reqRetryConnect`          | How many connection-related errors to retry on                                                                                    | `10`                                                              |
+| `controller.sidecars.configAutoReload.sleepTime`                | How many seconds to wait before updating config-maps/secrets (sets METHOD=SLEEP on the sidecar)                                   | Not set                                                           |
+| `controller.sidecars.configAutoReload.envFrom`                  | Environment variable sources for the Jenkins Config as Code auto-reload container                                                 | Not set                                                           |
+| `controller.sidecars.configAutoReload.env`                      | Environment variables for the Jenkins Config as Code auto-reload container                                                        | Not set                                                           |
+| `controller.sidecars.configAutoReload.containerSecurityContext` | Enable container security context                                                                                                 | `{readOnlyRootFilesystem: true, allowPrivilegeEscalation: false}` |
 
 #### Jenkins Configuration Files & Scripts
 

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -509,8 +509,7 @@ Create the HTTP port for interacting with the controller
 {{- if $method }}
     - name: METHOD
       value: "{{ $method }}"
-{{- end }}
-{{- if $root.Values.controller.sidecars.configAutoReload.sleepTime }}
+{{- else if $root.Values.controller.sidecars.configAutoReload.sleepTime }}
     - name: METHOD
       value: "SLEEP"
     - name: SLEEP_TIME

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -484,6 +484,7 @@ Create the HTTP port for interacting with the controller
 {{- define "jenkins.configReloadContainer" -}}
 {{- $root := index . 0 -}}
 {{- $containerName := index . 1 -}}
+{{- $method := index . 2 -}}
 - name: {{ $containerName }}
   image: "{{ $root.Values.controller.sidecars.configAutoReload.image }}"
   imagePullPolicy: {{ $root.Values.controller.sidecars.configAutoReload.imagePullPolicy }}
@@ -505,6 +506,10 @@ Create the HTTP port for interacting with the controller
       value: "{{ $root.Values.controller.sidecars.configAutoReload.folder }}"
     - name: NAMESPACE
       value: '{{ $root.Values.controller.sidecars.configAutoReload.searchNamespace | default (include "jenkins.namespace" $root) }}'
+{{- if $method }}
+    - name: METHOD
+      value: "{{ $method }}"
+{{- end }}
     - name: REQ_URL
       value: "http://localhost:{{- include "controller.httpPort" $root -}}{{- $root.Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
     - name: REQ_METHOD

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -482,15 +482,17 @@ Create the HTTP port for interacting with the controller
 {{- end -}}
 
 {{- define "jenkins.configReloadContainer" -}}
-- name: config-reload
-  image: "{{ .Values.controller.sidecars.configAutoReload.image }}"
-  imagePullPolicy: {{ .Values.controller.sidecars.configAutoReload.imagePullPolicy }}
-  {{- if .Values.controller.sidecars.configAutoReload.containerSecurityContext }}
-  securityContext: {{- toYaml .Values.controller.sidecars.configAutoReload.containerSecurityContext | nindent 4 }}
+{{- $root := index . 0 -}}
+{{- $containerName := index . 1 -}}
+- name: {{ $containerName }}
+  image: "{{ $root.Values.controller.sidecars.configAutoReload.image }}"
+  imagePullPolicy: {{ $root.Values.controller.sidecars.configAutoReload.imagePullPolicy }}
+  {{- if $root.Values.controller.sidecars.configAutoReload.containerSecurityContext }}
+  securityContext: {{- toYaml $root.Values.controller.sidecars.configAutoReload.containerSecurityContext | nindent 4 }}
   {{- end }}
-  {{- if .Values.controller.sidecars.configAutoReload.envFrom }}
+  {{- if $root.Values.controller.sidecars.configAutoReload.envFrom }}
   envFrom:
-{{ (tpl (toYaml .Values.controller.sidecars.configAutoReload.envFrom) .) | indent 4 }}
+{{ (tpl (toYaml $root.Values.controller.sidecars.configAutoReload.envFrom) $root) | indent 4 }}
   {{- end }}
   env:
     - name: POD_NAME
@@ -498,29 +500,29 @@ Create the HTTP port for interacting with the controller
         fieldRef:
           fieldPath: metadata.name
     - name: LABEL
-      value: "{{ template "jenkins.fullname" . }}-jenkins-config"
+      value: "{{ template "jenkins.fullname" $root }}-jenkins-config"
     - name: FOLDER
-      value: "{{ .Values.controller.sidecars.configAutoReload.folder }}"
+      value: "{{ $root.Values.controller.sidecars.configAutoReload.folder }}"
     - name: NAMESPACE
-      value: '{{ .Values.controller.sidecars.configAutoReload.searchNamespace | default (include "jenkins.namespace" .) }}'
+      value: '{{ $root.Values.controller.sidecars.configAutoReload.searchNamespace | default (include "jenkins.namespace" $root) }}'
     - name: REQ_URL
-      value: "http://localhost:{{- include "controller.httpPort" . -}}{{- .Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
+      value: "http://localhost:{{- include "controller.httpPort" $root -}}{{- $root.Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
     - name: REQ_METHOD
       value: "POST"
     - name: REQ_RETRY_CONNECT
-      value: "{{ .Values.controller.sidecars.configAutoReload.reqRetryConnect }}"
-    {{- if .Values.controller.sidecars.configAutoReload.env }}
-{{ (tpl (toYaml .Values.controller.sidecars.configAutoReload.env) .) | indent 4 }}
+      value: "{{ $root.Values.controller.sidecars.configAutoReload.reqRetryConnect }}"
+    {{- if $root.Values.controller.sidecars.configAutoReload.env }}
+{{ (tpl (toYaml $root.Values.controller.sidecars.configAutoReload.env) $root) | indent 4 }}
     {{- end }}
   resources:
-{{ toYaml .Values.controller.sidecars.configAutoReload.resources | indent 4 }}
+{{ toYaml $root.Values.controller.sidecars.configAutoReload.resources | indent 4 }}
   volumeMounts:
     - name: sc-config-volume
-      mountPath: {{ .Values.controller.sidecars.configAutoReload.folder | quote }}
+      mountPath: {{ $root.Values.controller.sidecars.configAutoReload.folder | quote }}
     - name: jenkins-home
-      mountPath: {{ .Values.controller.jenkinsHome }}
-      {{- if .Values.persistence.subPath }}
-      subPath: {{ .Values.persistence.subPath }}
+      mountPath: {{ $root.Values.controller.jenkinsHome }}
+      {{- if $root.Values.persistence.subPath }}
+      subPath: {{ $root.Values.persistence.subPath }}
       {{- end }}
 
 {{- end -}}

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -510,6 +510,12 @@ Create the HTTP port for interacting with the controller
     - name: METHOD
       value: "{{ $method }}"
 {{- end }}
+{{- if $root.Values.controller.sidecars.configAutoReload.sleepTime }}
+    - name: METHOD
+      value: "SLEEP"
+    - name: SLEEP_TIME
+      value: "{{ $root.Values.controller.sidecars.configAutoReload.sleepTime }}"
+{{- end }}
     - name: REQ_URL
       value: "http://localhost:{{- include "controller.httpPort" $root -}}{{- $root.Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
     - name: REQ_METHOD

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -109,6 +109,11 @@ spec:
 {{- if .Values.controller.customInitContainers }}
 {{ tpl (toYaml .Values.controller.customInitContainers) . | indent 8 }}
 {{- end }}
+
+{{- if .Values.controller.sidecars.configAutoReload.enabled }}
+{{- include "jenkins.configReloadContainer" (list $ "config-reload-init" "LIST") | nindent 8 }}
+{{- end}}
+
         - name: "init"
           image: "{{ .Values.controller.image }}:{{- include "controller.tag" . -}}"
           imagePullPolicy: "{{ .Values.controller.imagePullPolicy }}"
@@ -301,7 +306,7 @@ spec:
               name: tmp-volume
 
 {{- if .Values.controller.sidecars.configAutoReload.enabled }}
-{{- include "jenkins.configReloadContainer" (list $ "config-reload") | nindent 8 }}
+{{- include "jenkins.configReloadContainer" (list $ "config-reload" nil) | nindent 8 }}
 {{- end}}
 
 

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -301,7 +301,7 @@ spec:
               name: tmp-volume
 
 {{- if .Values.controller.sidecars.configAutoReload.enabled }}
-{{- include "jenkins.configReloadContainer" . | nindent 8 }}
+{{- include "jenkins.configReloadContainer" (list $ "config-reload") | nindent 8 }}
 {{- end}}
 
 

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -301,46 +301,7 @@ spec:
               name: tmp-volume
 
 {{- if .Values.controller.sidecars.configAutoReload.enabled }}
-        - name: config-reload
-          image: "{{ .Values.controller.sidecars.configAutoReload.image }}"
-          imagePullPolicy: {{ .Values.controller.sidecars.configAutoReload.imagePullPolicy }}
-          {{- if .Values.controller.sidecars.configAutoReload.containerSecurityContext }}
-          securityContext: {{- toYaml .Values.controller.sidecars.configAutoReload.containerSecurityContext | nindent 12 }}
-          {{- end }}
-          {{- if .Values.controller.sidecars.configAutoReload.envFrom }}
-          envFrom:
-{{ (tpl (toYaml .Values.controller.sidecars.configAutoReload.envFrom) .) | indent 12 }}
-          {{- end }}
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: LABEL
-              value: "{{ template "jenkins.fullname" . }}-jenkins-config"
-            - name: FOLDER
-              value: "{{ .Values.controller.sidecars.configAutoReload.folder }}"
-            - name: NAMESPACE
-              value: '{{ .Values.controller.sidecars.configAutoReload.searchNamespace | default (include "jenkins.namespace" .) }}'
-            - name: REQ_URL
-              value: "http://localhost:{{- include "controller.httpPort" . -}}{{- .Values.controller.jenkinsUriPrefix -}}/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
-            - name: REQ_METHOD
-              value: "POST"
-            - name: REQ_RETRY_CONNECT
-              value: "{{ .Values.controller.sidecars.configAutoReload.reqRetryConnect }}"
-            {{- if .Values.controller.sidecars.configAutoReload.env }}
-{{ (tpl (toYaml .Values.controller.sidecars.configAutoReload.env) .) | indent 12 }}
-            {{- end }}
-          resources:
-{{ toYaml .Values.controller.sidecars.configAutoReload.resources | indent 12 }}
-          volumeMounts:
-            - name: sc-config-volume
-              mountPath: {{ .Values.controller.sidecars.configAutoReload.folder | quote }}
-            - name: jenkins-home
-              mountPath: {{ .Values.controller.jenkinsHome }}
-              {{- if .Values.persistence.subPath }}
-              subPath: {{ .Values.persistence.subPath }}
-              {{- end }}
+{{- include "jenkins.configReloadContainer" . | nindent 8 }}
 {{- end}}
 
 

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -161,7 +161,39 @@ tests:
                       - mountPath: /var/jenkins_home
                         name: jenkins-home
                 initContainers:
-                  - command:
+                  - name: config-reload-init
+                    env:
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: LABEL
+                      value: my-release-jenkins-jenkins-config
+                    - name: FOLDER
+                      value: /var/jenkins_home/casc_configs
+                    - name: NAMESPACE
+                      value: my-namespace
+                    - name: METHOD
+                      value: LIST
+                    - name: REQ_URL
+                      value: http://localhost:8080/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)
+                    - name: REQ_METHOD
+                      value: POST
+                    - name: REQ_RETRY_CONNECT
+                      value: "10"
+                    image: kiwigrid/k8s-sidecar:1.24.4
+                    imagePullPolicy: IfNotPresent
+                    resources: {}
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                    volumeMounts:
+                    - mountPath: /var/jenkins_home/casc_configs
+                      name: sc-config-volume
+                    - mountPath: /var/jenkins_home
+                      name: jenkins-home
+                  - name: init
+                    command:
                       - sh
                       - /var/jenkins_config/apply_config.sh
                     image: jenkins/jenkins:2.414.2-jdk11
@@ -171,7 +203,6 @@ tests:
                       runAsGroup: 1000
                       readOnlyRootFilesystem: true
                       allowPrivilegeEscalation: false
-                    name: init
                     resources:
                       limits:
                         cpu: 2000m
@@ -564,12 +595,12 @@ tests:
             name: special-config
     asserts:
       - contains:
-          path: spec.template.spec.initContainers[0].env
+          path: spec.template.spec.initContainers[1].env
           content:
             name: "TEST_ENV_VAR_INIT"
             value: "test-env-var-init"
       - contains:
-          path: spec.template.spec.initContainers[0].env
+          path: spec.template.spec.initContainers[1].env
           content:
             name: "TEST_ENV_VAR_INIT_TEMPLATED"
             value: "some-value"
@@ -594,7 +625,7 @@ tests:
             name: "TEST_ENV_VAR__CONTAINER_TEMPLATED"
             value: "some-value"
       - contains:
-          path: spec.template.spec.initContainers[0].envFrom
+          path: spec.template.spec.initContainers[1].envFrom
           content:
             configMapRef:
               name: special-config
@@ -682,7 +713,7 @@ tests:
             mountPath: /some/path
             name: jenkins-https-keystore
       - notContains:
-          path: spec.template.spec.initContainers[0].volumeMounts
+          path: spec.template.spec.initContainers[1].volumeMounts
           content:
             mountPath: /some/path
             name: jenkins-https-keystore
@@ -721,7 +752,7 @@ tests:
             mountPath: /some/path
             name: jenkins-https-keystore
       - contains:
-          path: spec.template.spec.initContainers[0].volumeMounts
+          path: spec.template.spec.initContainers[1].volumeMounts
           content:
             mountPath: /some/path
             name: jenkins-https-keystore
@@ -788,7 +819,7 @@ tests:
             name: plugins
             emptyDir: {}
       - notContains:
-          path: spec.template.spec.initContainers[0].volumeMounts
+          path: spec.template.spec.initContainers[1].volumeMounts
           content:
             name: plugins
   - it:

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -589,11 +589,21 @@ tests:
             name: special-config
       controller.sidecars.configAutoReload.envFrom:
         - configMapRef:
-            name: special-config
+            name: special-config-auto-reload
       controller.containerEnvFrom:
         - configMapRef:
             name: special-config
     asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: "TEST_ENV_VAR_CONFIG"
+            value: "test-env-var-config"
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: "TEST_ENV_VAR_CONFIG_TEMPLATED"
+            value: "some-value"
       - contains:
           path: spec.template.spec.initContainers[1].env
           content:
@@ -625,6 +635,11 @@ tests:
             name: "TEST_ENV_VAR__CONTAINER_TEMPLATED"
             value: "some-value"
       - contains:
+          path: spec.template.spec.initContainers[0].envFrom
+          content:
+            configMapRef:
+              name: special-config-auto-reload
+      - contains:
           path: spec.template.spec.initContainers[1].envFrom
           content:
             configMapRef:
@@ -638,7 +653,7 @@ tests:
           path: spec.template.spec.containers[1].envFrom
           content:
             configMapRef:
-              name: special-config
+              name: special-config-auto-reload
   - it: overrides container args
     template: jenkins-controller-statefulset.yaml
     set:

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -654,6 +654,27 @@ tests:
           content:
             configMapRef:
               name: special-config-auto-reload
+  - it: test sleep time for config-reload
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller.sidecars.configAutoReload.sleepTime: 60
+    asserts:
+      - contains:
+          # METHOD remains LIST on the config-reload init container
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: "METHOD"
+            value: "LIST"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "METHOD"
+            value: "SLEEP"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "SLEEP_TIME"
+            value: "60"
   - it: overrides container args
     template: jenkins-controller-statefulset.yaml
     set:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

- Fixes #868 

This should make the startup routine of Jenkins more stable and have fewer race conditions. When the existing implementation of the sidecar detects configmap/secret changes, it calls an endpoint on Jenkins to reload CasC, however since the sidecar and the Jenkins begin booting up at the same time, this introduces several potential race conditions:

- the endpoint to reload CasC may be called before Jenkins has started up and result in various errors (e.g. CSRF problems)
- the endpoint to reload CasC may be called while Jenkins is initializing original CasC (unverified, but in theory possible - there is some evidence that this might have happened, although not concrete proof)
- the config-reload sidecar might be rewriting files while Jenkins is reading them, resulting in partial, inconsistent configuration which in turn results in a crash (we have definitely experienced something that can be explained by this)

Introducing an init container with METHOD=LIST copies the necessary files into place before Jenkins has started booting up, preventing the above race conditions.

I verified this approach in practice, and whereby Jenkins used to crash 3-4 times (at least) before finally starting up, it does now start up consistently without crashes.

There still is scope for certain race conditions due to the fact that Helm applies changes all at once, however they should be unlikely, as various delays in StatefulSet restarting the Pod and the cluster taking time to start up the Pod.

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

- It might be easier to review this commit-by-commit.
- Should I hide the init container behind a flag and disable it by default? I feel like that should not be necessary, but at the same time - I don't know how large the user base is for this and what kinds of configurations they might have - some might consider this a breaking change?
