### PR TITLE
Add checksum for config-init-script into statefullset annotations

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.7.3
+
+Add the config-init-script checksum into the controller statefullset pod annotations to trigger restart of the pod in case of updated init scripts.
+
 ## 4.7.1
 
 Changes in 4.7.0 were reverted.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.7.2
+version: 4.7.3
 appVersion: 2.414.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -45,6 +45,9 @@ spec:
         {{- end}}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.controller.initScripts }}
+        checksum/config-init-scripts: {{ include (print $.Template.BasePath "/config-init-scripts.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.controller.podAnnotations }}
 {{ tpl (toYaml .Values.controller.podAnnotations | indent 8) . }}
         {{- end }}

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -5,6 +5,7 @@ release:
 templates:
   - jenkins-controller-statefulset.yaml
   - config.yaml
+  - config-init-scripts.yaml
 tests:
   - it: default values
     template: jenkins-controller-statefulset.yaml
@@ -832,3 +833,16 @@ tests:
           content:
             name: "CASC_JENKINS_CONFIG"
             value: "/var/jenkins_home/casc_configs"
+
+  - it: test checksum for config-init-script
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        initScripts:
+          test: |-
+            This is a test script
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            checksum/config-init-scripts: 2ee2c03a600a50a55cf62cbed3f1d558d5322eda7544b4047beeb4df66e8ec11


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

Add the config-init-script checksum into the controller statefullset pod annotations to trigger restart of the pod in case of updated init scripts.

- Fixes #678

```[tasklist]
### Submitter checklist
- [X] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [X] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [X] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

<!-- Leave blank if none -->
