### PR TITLE
add jcasc auto reload sidecar resources

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.7.3
+
+Clarify documentation of configAutoReload sidecar resources
+
 ## 4.7.1
 
 Changes in 4.7.0 were reverted.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.7.2
+version: 4.7.3
 appVersion: 2.414.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -32,6 +32,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.sidecars.configAutoReload` | Jenkins Config as Code auto-reload settings |                                                                   |
 | `controller.sidecars.configAutoReload.enabled` | Jenkins Config as Code auto-reload settings (Attention: rbac needs to be enabled otherwise the sidecar can't read the config map) | `true`                                                            |
 | `controller.sidecars.configAutoReload.image` | Image which triggers the reload | `kiwigrid/k8s-sidecar:1.24.4`                                     |
+| `controller.sidecars.configAutoReload.resources` | Resources allocation (Requests and Limits) | Not set                                     |
 | `controller.sidecars.configAutoReload.reqRetryConnect` | How many connection-related errors to retry on  | `10`                                                              |
 | `controller.sidecars.configAutoReload.envFrom` | Environment variable sources for the Jenkins Config as Code auto-reload container | Not set                                                           |
 | `controller.sidecars.configAutoReload.env` | Environment variables for the Jenkins Config as Code auto-reload container  | Not set                                                           |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

This PR updates the values summary documentation to include a reference to how to set resource requests and limits for the configAutoReload. Exposing the resource limits and requests for the sidecar allows them to be set to the same value, which allows the whole Pod to be granted a "Guaranteed" QoS class. The helmchart already supports this, though it wasn't reflected in the docs already.

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

<!-- Leave blank if none -->
