### PR TITLE
chore: add `artifacthub.io/changes` changelog annotation to the released chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,34 +24,20 @@ jobs:
         with:
           version: v3.12.0
 
-      - name: Run chart-releaser
-        id: chart_releaser
-        uses: helm/chart-releaser-action@v1.6.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-      # Retrieve last tag pushed by cr
-      - name: Checkout
-        if: steps.chart_releaser.outputs.changed_charts != ''
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get Last Tag
-        id: last_tag
-        if: steps.chart_releaser.outputs.changed_charts != ''
-        run: echo "tag=$(git describe --abbrev=0 --tags)" >> "${GITHUB_OUTPUT}"
-
-      - name: Extract last tag changelog
-        id: last_tag_changelog
-        if: steps.chart_releaser.outputs.changed_charts != ''
-        env:
-          LAST_TAG: ${{ steps.last_tag.outputs.tag }}
+      - name: Retrieve version from Chart.yaml
+        id: chart_version
         run: |
-          changelog=$(awk -v tag="${LAST_TAG#jenkins-}" '
+          echo "version=$(yq '.version' charts/jenkins/Chart.yaml)" >> "${GITHUB_OUTPUT}"
+
+      - name: Extract version changelog
+        id: version_changelog
+        env:
+          VERSION: ${{ steps.chart_version.outputs.version }}
+        run: |
+          changelog=$(awk -v version="${VERSION}" '
           /^(##|###) [0-9]+.[0-9]+.[0-9]+/ {
               if (p) { exit };
-              if ($2 == tag) {
+              if ($2 == version) {
                   p = 1; next
               }
           } p
@@ -63,11 +49,34 @@ jobs:
           echo "${changelog}" >> "${GITHUB_OUTPUT}"
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
+      - name: Annotate Chart.yaml with version changelog
+        if: steps.version_changelog.outputs.changelog != ''
+        env:
+          CHANGELOG: ${{steps.version_changelog.outputs.changelog}}
+        run: |
+          # Remove first line if empty and replace emojis by spaces (issue with yq/chart-releaser which break multiline)
+          stripped_changelog=$(echo "$CHANGELOG" | sed -e '2,$b' -e '/^$/d' | iconv -c -f utf8 -t ascii)
+          # Remove leading spaces
+          stripped_changelog="${stripped_changelog#"${stripped_changelog%%[![:space:]]*}"}"
+
+          # Update chart annotations
+          yq --inplace ".annotations.\"artifacthub.io/changes\" = \"${stripped_changelog}\"" charts/jenkins/Chart.yaml
+
+      - name: Show updated Chart.yaml
+        run: |
+          yq charts/jenkins/Chart.yaml
+
+      - name: Run chart-releaser
+        id: chart_releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Retrieve release info
         id: release_info
         if: steps.chart_releaser.outputs.changed_charts != ''
         env:
-          LAST_TAG: ${{ steps.last_tag.outputs.tag }}
+          LAST_TAG: "jenkins-${{ steps.chart_version.outputs.version }}"
           REPOSITORY: ${{ github.repository }}
         run: |
           release=$(curl -L "https://api.github.com/repos/${REPOSITORY}/releases/tags/${LAST_TAG}")
@@ -87,7 +96,7 @@ jobs:
         env:
           ID: ${{ steps.release_info.outputs.id }}
           BODY: ${{steps.release_info.outputs.body}}
-          CHANGELOG: ${{steps.last_tag_changelog.outputs.changelog}}
+          CHANGELOG: ${{steps.version_changelog.outputs.changelog}}
         with:
           script: |
             try {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,7 @@ jobs:
           CHANGELOG: ${{steps.version_changelog.outputs.changelog}}
         run: |
           # Remove first line if empty and replace emojis by spaces (issue with yq/chart-releaser which break multiline)
+          # shellcheck disable=SC2016
           stripped_changelog=$(echo "$CHANGELOG" | sed -e '2,$b' -e '/^$/d' | iconv -c -f utf8 -t ascii)
           # Remove leading spaces
           stripped_changelog="${stripped_changelog#"${stripped_changelog%%[![:space:]]*}"}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
           delimiter="$(openssl rand -hex 8)"
           # shellcheck disable=SC2129
           echo "body<<${delimiter}" >> "${GITHUB_OUTPUT}"
-          echo "${release}" | jq '.body' >> "${GITHUB_OUTPUT}"
+          echo "${release}" | jq --raw-output '.body' >> "${GITHUB_OUTPUT}"
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - name: Update release description
@@ -105,7 +105,7 @@ jobs:
                 release_id: process.env.ID,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: process.env.BODY.slice(1, -1) + "\r\n\r\n## Changelog" + process.env.CHANGELOG,
+                body: process.env.BODY + "\r\n\r\n## Changelog" + process.env.CHANGELOG,
               });
             } catch (error) {
               core.setFailed(error.message);

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,10 +12,13 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.8.4
+
+Add `artifacthub.io/changes` changelog annotation to the released chart.
+
 ## 4.8.3
 
 Update Jenkins image and appVersion to jenkins lts release version 2.426.1
-
 
 ## 4.8.2
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.8.3
+version: 4.8.4
 appVersion: 2.426.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:


### PR DESCRIPTION
This PR adds Artifact Hub annotation in the released chart so it can renders its integrated changelog: https://blog.artifacthub.io/blog/changelogs/

#### Notes:
- Only the current version changes have to be included, not the full changelog.
- It's the simple form of Artifact Hub changes. Looking at the existing changelog, I'm not sure the more complete form will ever be needed.
- I had to strip emojis to avoid having the scalar value broke as single string and failing chart-releaser step:
  <details>
  
  ```
  📦 Add `artifacthub.io/changes` changelog annotation to the released chart.
  
  Table example:
  | plugin                | old version          | new version           |
  |-----------------------|----------------------|-----------------------|
  | kubernetes            | 3900.va_dce992317b_4 | 3937.vd7b_82db_e347b_ |
  | configuration-as-code | 1625.v27444588cc3d   | 1647.ve39ca_b_829b_42 |
  ```
  replaced by
  ```
  artifacthub.io/changes: "\U0001F4E6 Add `artifacthub.io/changes` changelog annotation to the released chart.\n\nTable example:\n| plugin                | old version          | new version           |\n|-----------------------|----------------------|-----------------------|\n| kubernetes            | 3900.va_dce992317b_4 | 3937.vd7b_82db_e347b_ |\n| configuration-as-code | 1625.v27444588cc3d   | 1647.ve39ca_b_829b_42 |"
  ```
  </details>
- I'm using `yq` to retrieve the version directly from Chart.yaml, easier than the previous method requiring two steps.

#### Tested on a fork:
- Entry in CHANGELOG.md starting with an emoji and including a table: https://github.com/lemeurherve/jenkinsci-helm-charts/blob/862770b35ef457f3ffc20b6286e227ee74fef91f/charts/jenkins/CHANGELOG.md?plain=1
- Release: https://github.com/lemeurherve/jenkinsci-helm-charts/releases/tag/jenkins-4.8.4
- <details><summary>Released Chart.yaml content</summary>

  ```yaml
  annotations:
    artifacthub.io/category: integration-delivery
    artifacthub.io/changes: |-
      Add `artifacthub.io/changes` changelog annotation to the released chart.
  
      Table example:
      | plugin                | old version          | new version           |
      |-----------------------|----------------------|-----------------------|
      | kubernetes            | 3900.va_dce992317b_4 | 3937.vd7b_82db_e347b_ |
      | configuration-as-code | 1625.v27444588cc3d   | 1647.ve39ca_b_829b_42 |
    artifacthub.io/images: |
      - name: jenkins
        image: jenkins/jenkins:2.426.1-jdk11
      - name: k8s-sidecar
        image: kiwigrid/k8s-sidecar:1.24.4
      - name: inbound-agent
        image: jenkins/inbound-agent:3107.v665000b_51092-15
      - name: backup
        image: maorfr/kube-tasks:0.2.0
    artifacthub.io/license: Apache-2.0
    artifacthub.io/links: |
      - name: Chart Source
        url: https://github.com/jenkinsci/helm-charts/tree/main/charts/jenkins
      - name: Jenkins
        url: https://www.jenkins.io/
      - name: support
        url: https://github.com/jenkinsci/helm-charts/issues
  apiVersion: v2
  appVersion: 2.426.1
  description: Jenkins - Build great things at any scale! The leading open source automation
    server, Jenkins provides over 1800 plugins to support building, deploying and automating
    any project.
  home: https://jenkins.io/
  icon: https://get.jenkins.io/art/jenkins-logo/logo.svg
  keywords:
  - jenkins
  - ci
  - devops
  maintainers:
  - email: maor.friedman@redhat.com
    name: maorfr
  - email: mail@torstenwalter.de
    name: torstenwalter
  - email: garridomota@gmail.com
    name: mogaal
  - email: wmcdona89@gmail.com
    name: wmcdona89
  - email: timjacomb1@gmail.com
    name: timja
  name: jenkins
  sources:
  - https://github.com/jenkinsci/jenkins
  - https://github.com/jenkinsci/docker-inbound-agent
  - https://github.com/maorfr/kube-tasks
  - https://github.com/jenkinsci/configuration-as-code-plugin
  version: 4.8.4
  
  ```
  
  </details>

#### Follow-up of:
- https://github.com/jenkinsci/helm-charts/pull/946#pullrequestreview-1737958569

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

<!-- Leave blank if none -->
