### PR TITLE
fix: proper `artifacthub.io/changes` annotation preprocessing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,19 +49,22 @@ jobs:
           echo "${changelog}" >> "${GITHUB_OUTPUT}"
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
-      - name: Annotate Chart.yaml with version changelog
+      - name: Annotate Chart.yaml with current version changelog
         if: steps.version_changelog.outputs.changelog != ''
         env:
-          CHANGELOG: ${{steps.version_changelog.outputs.changelog}}
+          CHANGELOG: ${{ steps.version_changelog.outputs.changelog }}
         run: |
-          # Remove first line if empty and replace emojis by spaces (issue with yq/chart-releaser which break multiline)
+          # Changelog sanitation
           # shellcheck disable=SC2016
-          stripped_changelog=$(echo "${CHANGELOG}" | sed -e '2,$b' -e '/^$/d' | iconv -c -f utf8 -t ascii)
-          # Remove leading spaces
-          stripped_changelog="${stripped_changelog#"${stripped_changelog%%[![:space:]]*}"}"
+          proper_changelog=$(echo "${CHANGELOG}" \
+          | grep -v '^$' `# remove empty lines` \
+          | grep -v '^|' `# remove table lines` \
+          | iconv -c -f utf8 -t ascii `# remove non ascii characters like emoji` \
+          | sed 's/^/- /' `# add a dash in front of every line` \
+          | sed 's/  / /') # double spaces
 
           # Add new line to ensure scalar value in Chart.yaml
-          printf -v change '%s\n' "${stripped_changelog}"
+          printf -v change '%s\n' "${proper_changelog}"
 
           # Update chart annotations using strenv operator (https://mikefarah.gitbook.io/yq/operators/string-operators#string-blocks-bash-and-newlines)
           CHANGE="${change}" yq --inplace ".annotations.\"artifacthub.io/changes\" = strenv(CHANGE)" charts/jenkins/Chart.yaml

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,19 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+<!--
+Artifact Hub changes annotations processing:
+- Remove empty lines
+- Keep only ASCII characters (no emojis)
+- One change per line
+- Remove table(s) (lines starting by "|")
+- Backticks aren't rendered on artifactthub.io changelog
+-->
+
+## 4.8.6
+
+Proper `artifacthub.io/changes` changelog annotation preprocessing.
+
 ## 4.8.5
 
 Fix `artifacthub.io/changes` changelog annotation added to the released chart.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.8.5
+version: 4.8.6
 appVersion: 2.426.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:


### PR DESCRIPTION
### What does this PR do?

This PR fixes Artifact Hub changes annotation by properly preprocessing the version changes from CHANGELOG.md:
- Remove empty lines
- Keep only ASCII characters (no emojis)
- One change per line
- Remove table(s) (lines starting by `|`)

Note that backticks aren't rendered on artifactthub.io changelog.

Fixup of:
- #949 
- #950 

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

Tested on a fork and on an Artifact Hub account I've setup for testing:
- Commit: https://github.com/lemeurherve/testchart/commit/b395c641ee25e71dee5d86d1564542f25606c9d2
- GitHub Release: https://github.com/lemeurherve/testchart/releases/tag/jenkins-0.1.9
- Artifact Hub changelog: https://artifacthub.io/packages/helm/testchart/jenkins?modal=changelog