### PR TITLE
Update base images from JDK 11 to JDK 17

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.9.0
+
+Update base images from JDK 11 to JDK 17.
+
 ## 4.8.5
 
 Fix `artifacthub.io/changes` changelog annotation added to the released chart.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.8.5
+version: 4.9.0
 appVersion: 2.426.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:
@@ -35,7 +35,7 @@ annotations:
       url: https://github.com/jenkinsci/helm-charts/issues
   artifacthub.io/images: |
     - name: jenkins
-      image: jenkins/jenkins:2.426.1-jdk11
+      image: jenkins/jenkins:2.426.1-jdk17
     - name: k8s-sidecar
       image: kiwigrid/k8s-sidecar:1.24.4
     - name: inbound-agent

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -110,7 +110,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `controller.image`                    | Controller image name                     | `jenkins/jenkins`                         |
-| `controller.tagLabel`                 | Controller image tag label                | `jdk11`                                   |
+| `controller.tagLabel`                 | Controller image tag label                | `jdk17`                                   |
 | `controller.tag`                      | Controller image tag override             | Not set                                   |
 | `controller.imagePullPolicy`          | Controller image pull policy              | `Always`                                  |
 | `controller.imagePullSecretName`      | Controller image pull secret              | Not set                                   |

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -72,7 +72,7 @@ tests:
                         value: "50000"
                       - name: CASC_JENKINS_CONFIG
                         value: /var/jenkins_home/casc_configs
-                    image: jenkins/jenkins:2.426.1-jdk11
+                    image: jenkins/jenkins:2.426.1-jdk17
                     imagePullPolicy: Always
                     securityContext:
                       runAsUser: 1000
@@ -191,7 +191,7 @@ tests:
                     command:
                       - sh
                       - /var/jenkins_config/apply_config.sh
-                    image: jenkins/jenkins:2.426.1-jdk11
+                    image: jenkins/jenkins:2.426.1-jdk17
                     imagePullPolicy: Always
                     securityContext:
                       runAsUser: 1000

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -22,8 +22,8 @@ controller:
   # Used for label app.kubernetes.io/component
   componentName: "jenkins-controller"
   image: "jenkins/jenkins"
-  # tag: "2.426.1-jdk11"
-  tagLabel: jdk11
+  # tag: "2.426.1-jdk17"
+  tagLabel: jdk17
   imagePullPolicy: "Always"
   imagePullSecretName:
   # Optionally configure lifetime for controller-container


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

Starting with 2.426.1, we support 11, 17 and 21. I think that's a good time to move on to defaulting and testing with the jdk17 images. Not to forget, we already have an admin monitor warning about Java 11 EOL in Jenkins.
