### PR TITLE
chore: run `release` GitHub Action only if there is a chart change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'charts/**'
 
 jobs:
   release:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

This PR runs run `release` GitHub Action only if there is at least a change in `./charts/**`.

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

Same setting as the one we're using in https://github.com/jenkins-infra/helm-charts/blob/86569747e16096bcd20ea217db697f44dc2ae398/.github/workflows/release.yml#L6-L7
