### PR TITLE
chore: restore Artifact Hub notes location in CHANGELOG.md

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,19 +12,20 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
-## 4.9.0
-
-Update base images from JDK 11 to JDK 17.
-
-
-<!--
-Artifact Hub changes annotations processing:
+Notes about [Artifact Hub](https://artifacthub.io/packages/helm/jenkinsci/jenkins?modal=changelog) changes annotations automatic processing:
 - Remove empty lines
 - Keep only ASCII characters (no emojis)
 - One change per line
 - Remove table(s) (lines starting by "|")
 - Backticks aren't rendered on artifacthub.io changelog
--->
+
+## 4.9.1
+
+Restore artifact hub notes location in CHANGELOG.md
+
+## 4.9.0
+
+Update base images from JDK 11 to JDK 17.
 
 ## 4.8.6
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,7 +12,7 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
-Notes about [Artifact Hub](https://artifacthub.io/packages/helm/jenkinsci/jenkins?modal=changelog) changes annotations automatic processing:
+Notes about [Artifact Hub](https://artifacthub.io/packages/helm/jenkinsci/jenkins?modal=changelog) changelog processing:
 - Remove empty lines
 - Keep only ASCII characters (no emojis)
 - One change per line

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.9.0
+version: 4.9.1
 appVersion: 2.426.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:


### PR DESCRIPTION
### What does this PR do?

This PR restore the Artifact Hub notes location to avoid incorrect artifacthub.io changes annotations due to the move of the comment in CHANGELOG.md as noted in https://github.com/jenkinsci/helm-charts/pull/952#discussion_r1405484420

Corresponding GHA logs with wrong Chart.yaml annotations: https://github.com/jenkinsci/helm-charts/actions/runs/6998244499/job/19036090425

```yaml
  artifacthub.io/changes: |
    - Update base images from JDK 11 to JDK 17.
    - <!--
    - Artifact Hub changes annotations processing:
    - - Remove empty lines
    - - Keep only ASCII characters (no emojis)
    - - One change per line
    - - Remove table(s) (lines starting by "|")
    - - Backticks aren't rendered on artifacthub.io changelog
    - -->
```

Fixup of:
- #952 

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

<!-- Leave blank if none -->
