### PR TITLE
fix: prometheus docs mentioning master as config field that has been …

### DIFF
--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -918,10 +918,10 @@ controller:
 If you want to expose Prometheus metrics you need to install the [Jenkins Prometheus Metrics Plugin](https://github.com/jenkinsci/prometheus-plugin).
 It will expose an endpoint (default `/prometheus`) with metrics where a Prometheus Server can scrape.
 
-If you have implemented [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), you can set `master.prometheus.enabled` to `true` to configure a `ServiceMonitor` and `PrometheusRule`.
-If you want to further adjust alerting rules you can do so by configuring `master.prometheus.alertingrules`
+If you have implemented [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), you can set `controller.prometheus.enabled` to `true` to configure a `ServiceMonitor` and `PrometheusRule`.
+If you want to further adjust alerting rules you can do so by configuring `controller.prometheus.alertingrules`
 
-If you have implemented Prometheus without using the operator, you can leave `master.prometheus.enabled` set to `false`.
+If you have implemented Prometheus without using the operator, you can leave `controller.prometheus.enabled` set to `false`.
 
 ### Running Behind a Forward Proxy
 


### PR DESCRIPTION
…renamed to controller

<!-- markdownlint-disable MD041 -->

### What does this PR do?

- Fixes the documentation of the fields mentioned in the prometheus montitor

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

I think none of the above tasks is required by that config documentation change