### PR TITLE
Add multi-cloud support (#634)

### DIFF
--- a/.github/workflows/sync-lts.yaml
+++ b/.github/workflows/sync-lts.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Jenkins LTS version
         id: lts
-        uses: jenkins-infra/jenkins-version@0.4.7
+        uses: jenkins-infra/jenkins-version@0.5.0
         with:
           version-identifier: lts
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.11.0
+
+Add multi-cloud support.
+
 ## 4.10.0
 
 Bumped Jenkins inbound agent from 3107.v665000b_51092-15 to 3192.v713e3b_039fb_e-5.

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,14 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.1.10
+
+Add multi-cloud support.
+
+## 4.10.0
+
+Bumped Jenkins inbound agent from 3107.v665000b_51092-15 to 3192.v713e3b_039fb_e-5.
+
 ## 4.9.2
 
 Update Jenkins image and appVersion to jenkins lts release version 2.426.2

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
 version: 4.9.2
-appVersion: 2.426.1
+appVersion: 2.426.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
 version: 4.9.2
-appVersion: 2.426.2
+appVersion: 2.426.1
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.10.0
+version: 4.11.0
 appVersion: 2.426.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.9.2
+version: 4.10.0
 appVersion: 2.426.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -170,6 +170,7 @@ jenkins:
       name: "{{ .Values.controller.cloudName }}"
       namespace: "{{ template "jenkins.agent.namespace" . }}"
       serverUrl: "{{ .Values.kubernetesURL }}"
+      credentialsId: "{{ .Values.credentialsId }}"
       {{- if .Values.agent.enabled }}
       podLabels:
       - key: "jenkins/{{ .Release.Name }}-{{ .Values.agent.componentName }}"
@@ -206,6 +207,94 @@ jenkins:
         {{- end }}
       {{- end }}
       {{- end }}
+    {{- if .Values.additionalClouds }}
+    {{- /* save root */}}
+    {{- $oldRoot := deepCopy $ }}
+      {{- range $name, $additionalCloud := .Values.additionalClouds }}
+      {{- $newRoot := deepCopy $ }}
+      {{- /* clear additionalAgents from the copy if override set to `true` */}}
+      {{- if .additionalAgentsOverride }}
+      {{- $_ := set $newRoot.Values "additionalAgents" list}}
+      {{- end}}
+      {{- $newValues := merge $additionalCloud $newRoot.Values }}
+      {{- $_ := set $newRoot "Values" $newValues }}
+      {{- /* clear additionalClouds from the copy */}}
+      {{- $_ := set $newRoot.Values "additionalClouds" list }}
+      {{- with $newRoot}}
+  - kubernetes:
+     containerCapStr: "{{ .Values.agent.containerCap }}"
+     {{- if .Values.agent.jnlpregistry }}
+     jnlpregistry: "{{ .Values.agent.jnlpregistry }}"
+     {{- end }}
+     defaultsProviderTemplate: "{{ .Values.agent.defaultsProviderTemplate }}"
+     connectTimeout: "{{ .Values.agent.kubernetesConnectTimeout }}"
+     readTimeout: "{{ .Values.agent.kubernetesReadTimeout }}"
+     {{- if .Values.agent.directConnection }}
+     directConnection: true
+     {{- else }}
+     {{- if .Values.agent.jenkinsUrl }}
+     jenkinsUrl: "{{ tpl .Values.agent.jenkinsUrl . }}"
+     {{- else }}
+     jenkinsUrl: "http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.controller.servicePort}}{{ default "" .Values.controller.jenkinsUriPrefix }}"
+     {{- end }}
+     {{- if not .Values.agent.websocket }}
+     {{- if .Values.agent.jenkinsTunnel }}
+     jenkinsTunnel: "{{ tpl .Values.agent.jenkinsTunnel . }}"
+     {{- else }}
+     jenkinsTunnel: "{{ template "jenkins.fullname" . }}-agent.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{ .Values.controller.agentListenerPort }}"
+     {{- end }}
+     {{- else }}
+     webSocket: true
+     {{- end }}
+     {{- end }}
+     maxRequestsPerHostStr: {{ .Values.agent.maxRequestsPerHostStr | quote }}
+     retentionTimeout: {{ .Values.agent.retentionTimeout | quote }}
+     waitForPodSec: {{ .Values.agent.waitForPodSec | quote }}
+     name: {{ $name | quote }}
+     namespace: "{{ template "jenkins.agent.namespace" . }}"
+     serverUrl: "{{ .Values.kubernetesURL }}"
+     credentialsId: "{{ .Values.credentialsId }}"
+     {{- if .Values.agent.enabled }}
+     podLabels:
+     - key: "jenkins/{{ .Release.Name }}-{{ .Values.agent.componentName }}"
+       value: "true"
+     {{- range $key, $val := .Values.agent.podLabels }}
+     - key: {{ $key | quote }}
+       value: {{ $val | quote }}
+     {{- end }}
+     templates:
+    {{- if not .Values.agent.disableDefaultAgent }}
+      {{- include "jenkins.casc.podTemplate" . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.additionalAgents }}
+      {{- /* save .Values.agent */}}
+      {{- $agent := .Values.agent }}
+      {{- range $name, $additionalAgent := .Values.additionalAgents }}
+        {{- $additionalContainersEmpty := and (hasKey $additionalAgent "additionalContainers") (empty $additionalAgent.additionalContainers)  }}
+        {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
+        {{- $additionalAgent := merge $additionalAgent $agent }}
+        {{- /* clear list of additional containers in case it is configured empty for this agent (merge might have overwritten that) */}}
+        {{- if $additionalContainersEmpty }}
+        {{- $_ := set $additionalAgent "additionalContainers" list }}
+        {{- end }}
+        {{- /* set .Values.agent to $additionalAgent */}}
+        {{- $_ := set $.Values "agent" $additionalAgent }}
+        {{- include "jenkins.casc.podTemplate" $ | nindent 8 }}
+      {{- end }}
+      {{- /* restore .Values.agent */}}
+      {{- $_ := set .Values "agent" $agent }}
+    {{- end }}
+      {{- if .Values.agent.podTemplates }}
+        {{- range $key, $val := .Values.agent.podTemplates }}
+          {{- tpl $val $ | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- /* restore root */}}
+  {{- $_ := set $ "Values" $oldRoot.Values }}
+  {{- end }}
   {{- if .Values.controller.csrf.defaultCrumbIssuer.enabled }}
   crumbIssuer:
     standard:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -222,76 +222,76 @@ jenkins:
       {{- $_ := set $newRoot.Values "additionalClouds" list }}
       {{- with $newRoot}}
   - kubernetes:
-     containerCapStr: "{{ .Values.agent.containerCap }}"
-     {{- if .Values.agent.jnlpregistry }}
-     jnlpregistry: "{{ .Values.agent.jnlpregistry }}"
-     {{- end }}
-     defaultsProviderTemplate: "{{ .Values.agent.defaultsProviderTemplate }}"
-     connectTimeout: "{{ .Values.agent.kubernetesConnectTimeout }}"
-     readTimeout: "{{ .Values.agent.kubernetesReadTimeout }}"
-     {{- if .Values.agent.directConnection }}
-     directConnection: true
-     {{- else }}
-     {{- if .Values.agent.jenkinsUrl }}
-     jenkinsUrl: "{{ tpl .Values.agent.jenkinsUrl . }}"
-     {{- else }}
-     jenkinsUrl: "http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.controller.servicePort}}{{ default "" .Values.controller.jenkinsUriPrefix }}"
-     {{- end }}
-     {{- if not .Values.agent.websocket }}
-     {{- if .Values.agent.jenkinsTunnel }}
-     jenkinsTunnel: "{{ tpl .Values.agent.jenkinsTunnel . }}"
-     {{- else }}
-     jenkinsTunnel: "{{ template "jenkins.fullname" . }}-agent.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{ .Values.controller.agentListenerPort }}"
-     {{- end }}
-     {{- else }}
-     webSocket: true
-     {{- end }}
-     {{- end }}
-     maxRequestsPerHostStr: {{ .Values.agent.maxRequestsPerHostStr | quote }}
-     retentionTimeout: {{ .Values.agent.retentionTimeout | quote }}
-     waitForPodSec: {{ .Values.agent.waitForPodSec | quote }}
-     name: {{ $name | quote }}
-     namespace: "{{ template "jenkins.agent.namespace" . }}"
-     serverUrl: "{{ .Values.kubernetesURL }}"
-     credentialsId: "{{ .Values.credentialsId }}"
-     {{- if .Values.agent.enabled }}
-     podLabels:
-     - key: "jenkins/{{ .Release.Name }}-{{ .Values.agent.componentName }}"
-       value: "true"
-     {{- range $key, $val := .Values.agent.podLabels }}
-     - key: {{ $key | quote }}
-       value: {{ $val | quote }}
-     {{- end }}
-     templates:
-    {{- if not .Values.agent.disableDefaultAgent }}
-      {{- include "jenkins.casc.podTemplate" . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.additionalAgents }}
-      {{- /* save .Values.agent */}}
-      {{- $agent := .Values.agent }}
-      {{- range $name, $additionalAgent := .Values.additionalAgents }}
-        {{- $additionalContainersEmpty := and (hasKey $additionalAgent "additionalContainers") (empty $additionalAgent.additionalContainers)  }}
-        {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
-        {{- $additionalAgent := merge $additionalAgent $agent }}
-        {{- /* clear list of additional containers in case it is configured empty for this agent (merge might have overwritten that) */}}
-        {{- if $additionalContainersEmpty }}
-        {{- $_ := set $additionalAgent "additionalContainers" list }}
-        {{- end }}
-        {{- /* set .Values.agent to $additionalAgent */}}
-        {{- $_ := set $.Values "agent" $additionalAgent }}
-        {{- include "jenkins.casc.podTemplate" $ | nindent 8 }}
+      containerCapStr: "{{ .Values.agent.containerCap }}"
+      {{- if .Values.agent.jnlpregistry }}
+      jnlpregistry: "{{ .Values.agent.jnlpregistry }}"
       {{- end }}
-      {{- /* restore .Values.agent */}}
-      {{- $_ := set .Values "agent" $agent }}
-    {{- end }}
-      {{- if .Values.agent.podTemplates }}
-        {{- range $key, $val := .Values.agent.podTemplates }}
-          {{- tpl $val $ | nindent 8 }}
-        {{- end }}
+      defaultsProviderTemplate: "{{ .Values.agent.defaultsProviderTemplate }}"
+      connectTimeout: "{{ .Values.agent.kubernetesConnectTimeout }}"
+      readTimeout: "{{ .Values.agent.kubernetesReadTimeout }}"
+      {{- if .Values.agent.directConnection }}
+      directConnection: true
+      {{- else }}
+      {{- if .Values.agent.jenkinsUrl }}
+      jenkinsUrl: "{{ tpl .Values.agent.jenkinsUrl . }}"
+      {{- else }}
+      jenkinsUrl: "http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.controller.servicePort}}{{ default "" .Values.controller.jenkinsUriPrefix }}"
+      {{- end }}
+      {{- if not .Values.agent.websocket }}
+      {{- if .Values.agent.jenkinsTunnel }}
+      jenkinsTunnel: "{{ tpl .Values.agent.jenkinsTunnel . }}"
+      {{- else }}
+      jenkinsTunnel: "{{ template "jenkins.fullname" . }}-agent.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{ .Values.controller.agentListenerPort }}"
+      {{- end }}
+      {{- else }}
+      webSocket: true
       {{- end }}
       {{- end }}
-    {{- end }}
-    {{- end }}
+      maxRequestsPerHostStr: {{ .Values.agent.maxRequestsPerHostStr | quote }}
+      retentionTimeout: {{ .Values.agent.retentionTimeout | quote }}
+      waitForPodSec: {{ .Values.agent.waitForPodSec | quote }}
+      name: {{ $name | quote }}
+      namespace: "{{ template "jenkins.agent.namespace" . }}"
+      serverUrl: "{{ .Values.kubernetesURL }}"
+      credentialsId: "{{ .Values.credentialsId }}"
+      {{- if .Values.agent.enabled }}
+      podLabels:
+      - key: "jenkins/{{ .Release.Name }}-{{ .Values.agent.componentName }}"
+        value: "true"
+      {{- range $key, $val := .Values.agent.podLabels }}
+      - key: {{ $key | quote }}
+        value: {{ $val | quote }}
+      {{- end }}
+      templates:
+     {{- if not .Values.agent.disableDefaultAgent }}
+       {{- include "jenkins.casc.podTemplate" . | nindent 8 }}
+     {{- end }}
+     {{- if .Values.additionalAgents }}
+       {{- /* save .Values.agent */}}
+       {{- $agent := .Values.agent }}
+       {{- range $name, $additionalAgent := .Values.additionalAgents }}
+         {{- $additionalContainersEmpty := and (hasKey $additionalAgent "additionalContainers") (empty $additionalAgent.additionalContainers)  }}
+         {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
+         {{- $additionalAgent := merge $additionalAgent $agent }}
+         {{- /* clear list of additional containers in case it is configured empty for this agent (merge might have overwritten that) */}}
+         {{- if $additionalContainersEmpty }}
+         {{- $_ := set $additionalAgent "additionalContainers" list }}
+         {{- end }}
+         {{- /* set .Values.agent to $additionalAgent */}}
+         {{- $_ := set $.Values "agent" $additionalAgent }}
+         {{- include "jenkins.casc.podTemplate" $ | nindent 8 }}
+       {{- end }}
+       {{- /* restore .Values.agent */}}
+       {{- $_ := set .Values "agent" $agent }}
+     {{- end }}
+       {{- if .Values.agent.podTemplates }}
+         {{- range $key, $val := .Values.agent.podTemplates }}
+           {{- tpl $val $ | nindent 8 }}
+         {{- end }}
+       {{- end }}
+       {{- end }}
+     {{- end }}
+     {{- end }}
   {{- /* restore root */}}
   {{- $_ := set $ "Values" $oldRoot.Values }}
   {{- end }}

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -3063,3 +3063,566 @@ tests:
               location:
                 adminAddress:
                 url: http://RELEASE-NAME-jenkins:8080
+  - it: additional clouds
+    set:
+      additionalClouds:
+        remote-cloud-1:
+          kubernetesURL: https://api.remote-cloud.com
+          credentialsId: "remote-cloud-token"
+    release:
+      namespace: default
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - hasDocuments:
+         count: 1
+      - isNotEmpty:
+          path: data.jcasc-default-config\.yaml
+      - matchRegex:
+          path: metadata.labels.helm\.sh/chart
+          pattern: ^jenkins-
+      - equal:
+          path: data.jcasc-default-config\.yaml
+          value: |-
+            jenkins:
+              authorizationStrategy:
+                loggedInUsersCanDoAnything:
+                  allowAnonymousRead: false
+              securityRealm:
+                local:
+                  allowsSignup: false
+                  enableCaptcha: false
+                  users:
+                  - id: "${chart-admin-username}"
+                    name: "Jenkins Admin"
+                    password: "${chart-admin-password}"
+              disableRememberMe: false
+              mode: NORMAL
+              numExecutors: 0
+              labelString: ""
+              projectNamingStrategy: "standard"
+              markupFormatter:
+                plainText
+              clouds:
+              - kubernetes:
+                  containerCapStr: "10"
+                  defaultsProviderTemplate: ""
+                  connectTimeout: "5"
+                  readTimeout: "15"
+                  jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+                  jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                  maxRequestsPerHostStr: "32"
+                  retentionTimeout: "5"
+                  waitForPodSec: "600"
+                  name: "kubernetes"
+                  namespace: "default"
+                  serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
+                  podLabels:
+                  - key: "jenkins/RELEASE-NAME-jenkins-agent"
+                    value: "true"
+                  templates:
+                    - name: "default"
+                      namespace: "default"
+                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent "
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      yamlMergeStrategy: override
+              - kubernetes:
+                  containerCapStr: "10"
+                  defaultsProviderTemplate: ""
+                  connectTimeout: "5"
+                  readTimeout: "15"
+                  jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+                  jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                  maxRequestsPerHostStr: "32"
+                  retentionTimeout: "5"
+                  waitForPodSec: "600"
+                  name: "remote-cloud-1"
+                  namespace: "default"
+                  serverUrl: "https://api.remote-cloud.com"
+                  credentialsId: "remote-cloud-token"
+                  podLabels:
+                  - key: "jenkins/RELEASE-NAME-jenkins-agent"
+                    value: "true"
+                  templates:
+                    - name: "default"
+                      namespace: "default"
+                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent "
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      yamlMergeStrategy: override
+              crumbIssuer:
+                standard:
+                  excludeClientIPFromCrumb: true
+            security:
+              apiToken:
+                creationOfLegacyTokenEnabled: false
+                tokenGenerationOnCreationEnabled: false
+                usageStatisticsEnabled: true
+            unclassified:
+              location:
+                adminAddress:
+                url: http://RELEASE-NAME-jenkins:8080
+  - it: additional clouds inheriting additional agents
+    set:
+      additionalAgents:
+        maven:
+          namespace: maven
+          podName: maven
+          customJenkinsLabels: maven
+          image: jenkins/jnlp-agent-maven
+          tag: latest
+      additionalClouds:
+        remote-cloud-1:
+          kubernetesURL: https://api.remote-cloud.com
+          credentialsId: "remote-cloud-token"
+    release:
+      namespace: default
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - hasDocuments:
+         count: 1
+      - isNotEmpty:
+          path: data.jcasc-default-config\.yaml
+      - matchRegex:
+          path: metadata.labels.helm\.sh/chart
+          pattern: ^jenkins-
+      - equal:
+          path: data.jcasc-default-config\.yaml
+          value: |-
+            jenkins:
+              authorizationStrategy:
+                loggedInUsersCanDoAnything:
+                  allowAnonymousRead: false
+              securityRealm:
+                local:
+                  allowsSignup: false
+                  enableCaptcha: false
+                  users:
+                  - id: "${chart-admin-username}"
+                    name: "Jenkins Admin"
+                    password: "${chart-admin-password}"
+              disableRememberMe: false
+              mode: NORMAL
+              numExecutors: 0
+              labelString: ""
+              projectNamingStrategy: "standard"
+              markupFormatter:
+                plainText
+              clouds:
+              - kubernetes:
+                  containerCapStr: "10"
+                  defaultsProviderTemplate: ""
+                  connectTimeout: "5"
+                  readTimeout: "15"
+                  jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+                  jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                  maxRequestsPerHostStr: "32"
+                  retentionTimeout: "5"
+                  waitForPodSec: "600"
+                  name: "kubernetes"
+                  namespace: "default"
+                  serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
+                  podLabels:
+                  - key: "jenkins/RELEASE-NAME-jenkins-agent"
+                    value: "true"
+                  templates:
+                    - name: "default"
+                      namespace: "default"
+                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent "
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      yamlMergeStrategy: override
+                    - name: "maven"
+                      namespace: "maven"
+                      id: 77265108d78497ecf62874facf837d929a471b1d26e578bdf8cdf15bdea2403a
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/jnlp-agent-maven:latest"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent maven"
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      yamlMergeStrategy: override
+              - kubernetes:
+                  containerCapStr: "10"
+                  defaultsProviderTemplate: ""
+                  connectTimeout: "5"
+                  readTimeout: "15"
+                  jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+                  jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                  maxRequestsPerHostStr: "32"
+                  retentionTimeout: "5"
+                  waitForPodSec: "600"
+                  name: "remote-cloud-1"
+                  namespace: "default"
+                  serverUrl: "https://api.remote-cloud.com"
+                  credentialsId: "remote-cloud-token"
+                  podLabels:
+                  - key: "jenkins/RELEASE-NAME-jenkins-agent"
+                    value: "true"
+                  templates:
+                    - name: "default"
+                      namespace: "default"
+                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent "
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      yamlMergeStrategy: override
+                    - name: "maven"
+                      namespace: "maven"
+                      id: 77265108d78497ecf62874facf837d929a471b1d26e578bdf8cdf15bdea2403a
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/jnlp-agent-maven:latest"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent maven"
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      yamlMergeStrategy: override
+              crumbIssuer:
+                standard:
+                  excludeClientIPFromCrumb: true
+            security:
+              apiToken:
+                creationOfLegacyTokenEnabled: false
+                tokenGenerationOnCreationEnabled: false
+                usageStatisticsEnabled: true
+            unclassified:
+              location:
+                adminAddress:
+                url: http://RELEASE-NAME-jenkins:8080
+
+  - it: additional clouds overriding additional agents
+    set:
+      additionalAgents:
+        maven:
+          namespace: maven
+          podName: maven
+          customJenkinsLabels: maven
+          image: jenkins/jnlp-agent-maven
+          tag: latest
+      additionalClouds:
+        remote-cloud-1:
+          kubernetesURL: https://api.remote-cloud.com
+          credentialsId: "remote-cloud-token"
+          additionalAgentsOverride: true
+    release:
+      namespace: default
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - hasDocuments:
+         count: 1
+      - isNotEmpty:
+          path: data.jcasc-default-config\.yaml
+      - matchRegex:
+          path: metadata.labels.helm\.sh/chart
+          pattern: ^jenkins-
+      - equal:
+          path: data.jcasc-default-config\.yaml
+          value: |-
+            jenkins:
+              authorizationStrategy:
+                loggedInUsersCanDoAnything:
+                  allowAnonymousRead: false
+              securityRealm:
+                local:
+                  allowsSignup: false
+                  enableCaptcha: false
+                  users:
+                  - id: "${chart-admin-username}"
+                    name: "Jenkins Admin"
+                    password: "${chart-admin-password}"
+              disableRememberMe: false
+              mode: NORMAL
+              numExecutors: 0
+              labelString: ""
+              projectNamingStrategy: "standard"
+              markupFormatter:
+                plainText
+              clouds:
+              - kubernetes:
+                  containerCapStr: "10"
+                  defaultsProviderTemplate: ""
+                  connectTimeout: "5"
+                  readTimeout: "15"
+                  jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+                  jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                  maxRequestsPerHostStr: "32"
+                  retentionTimeout: "5"
+                  waitForPodSec: "600"
+                  name: "kubernetes"
+                  namespace: "default"
+                  serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
+                  podLabels:
+                  - key: "jenkins/RELEASE-NAME-jenkins-agent"
+                    value: "true"
+                  templates:
+                    - name: "default"
+                      namespace: "default"
+                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent "
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      yamlMergeStrategy: override
+                    - name: "maven"
+                      namespace: "maven"
+                      id: 77265108d78497ecf62874facf837d929a471b1d26e578bdf8cdf15bdea2403a
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/jnlp-agent-maven:latest"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent maven"
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      yamlMergeStrategy: override
+              - kubernetes:
+                  containerCapStr: "10"
+                  defaultsProviderTemplate: ""
+                  connectTimeout: "5"
+                  readTimeout: "15"
+                  jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+                  jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                  maxRequestsPerHostStr: "32"
+                  retentionTimeout: "5"
+                  waitForPodSec: "600"
+                  name: "remote-cloud-1"
+                  namespace: "default"
+                  serverUrl: "https://api.remote-cloud.com"
+                  credentialsId: "remote-cloud-token"
+                  podLabels:
+                  - key: "jenkins/RELEASE-NAME-jenkins-agent"
+                    value: "true"
+                  templates:
+                    - name: "default"
+                      namespace: "default"
+                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent "
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      yamlMergeStrategy: override
+              crumbIssuer:
+                standard:
+                  excludeClientIPFromCrumb: true
+            security:
+              apiToken:
+                creationOfLegacyTokenEnabled: false
+                tokenGenerationOnCreationEnabled: false
+                usageStatisticsEnabled: true
+            unclassified:
+              location:
+                adminAddress:
+                url: http://RELEASE-NAME-jenkins:8080
+

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -51,6 +51,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -176,6 +177,7 @@ tests:
                   name: "kubernetes"
                   namespace: "jenkins-agents"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -482,6 +484,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/my-release-jenkins-agent"
                     value: "true"
@@ -628,6 +631,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -734,6 +738,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -838,6 +843,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -944,6 +950,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -1051,6 +1058,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -1157,6 +1165,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -1262,6 +1271,7 @@ tests:
                   name: "kubernetes"
                   namespace: "controller-namespace"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
               crumbIssuer:
                 standard:
                   excludeClientIPFromCrumb: true
@@ -1332,6 +1342,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -1431,6 +1442,7 @@ tests:
                   name: "kubernetes"
                   namespace: "NAMESPACE"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -1534,6 +1546,7 @@ tests:
                 name: "kubernetes"
                 namespace: "default"
                 serverUrl: "https://kubernetes.default"
+                credentialsId: ""
                 podLabels:
                 - key: "jenkins/RELEASE-NAME-jenkins-agent"
                   value: "true"
@@ -1635,6 +1648,7 @@ tests:
                 name: "kubernetes"
                 namespace: "default"
                 serverUrl: "https://kubernetes.default"
+                credentialsId: ""
                 podLabels:
                 - key: "jenkins/RELEASE-NAME-jenkins-agent"
                   value: "true"
@@ -1724,6 +1738,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -1820,6 +1835,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -1913,6 +1929,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -2007,6 +2024,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -2100,6 +2118,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -2223,6 +2242,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -2390,6 +2410,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -2529,6 +2550,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -2635,6 +2657,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -2742,6 +2765,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -2847,6 +2871,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"
@@ -2965,6 +2990,7 @@ tests:
                   name: "kubernetes"
                   namespace: "default"
                   serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
                   podLabels:
                   - key: "jenkins/RELEASE-NAME-jenkins-agent"
                     value: "true"

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -3124,7 +3124,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      id: 923e6d6b3128baaa56764f4b69d4c62b61e55d00f8170e3428f011148767dc99
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -3134,7 +3134,7 @@ tests:
                           - envVar:
                               key: "JENKINS_URL"
                               value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
-                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        image: "jenkins/inbound-agent:3192.v713e3b_039fb_e-5"
                         privileged: "false"
                         resourceLimitCpu: 512m
                         resourceLimitMemory: 512Mi
@@ -3173,7 +3173,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      id: 923e6d6b3128baaa56764f4b69d4c62b61e55d00f8170e3428f011148767dc99
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -3183,7 +3183,7 @@ tests:
                           - envVar:
                               key: "JENKINS_URL"
                               value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
-                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        image: "jenkins/inbound-agent:3192.v713e3b_039fb_e-5"
                         privileged: "false"
                         resourceLimitCpu: 512m
                         resourceLimitMemory: 512Mi
@@ -3282,7 +3282,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      id: 923e6d6b3128baaa56764f4b69d4c62b61e55d00f8170e3428f011148767dc99
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -3292,7 +3292,7 @@ tests:
                           - envVar:
                               key: "JENKINS_URL"
                               value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
-                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        image: "jenkins/inbound-agent:3192.v713e3b_039fb_e-5"
                         privileged: "false"
                         resourceLimitCpu: 512m
                         resourceLimitMemory: 512Mi
@@ -3362,7 +3362,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      id: 923e6d6b3128baaa56764f4b69d4c62b61e55d00f8170e3428f011148767dc99
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -3372,7 +3372,7 @@ tests:
                           - envVar:
                               key: "JENKINS_URL"
                               value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
-                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        image: "jenkins/inbound-agent:3192.v713e3b_039fb_e-5"
                         privileged: "false"
                         resourceLimitCpu: 512m
                         resourceLimitMemory: 512Mi
@@ -3504,7 +3504,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      id: 923e6d6b3128baaa56764f4b69d4c62b61e55d00f8170e3428f011148767dc99
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -3514,7 +3514,7 @@ tests:
                           - envVar:
                               key: "JENKINS_URL"
                               value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
-                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        image: "jenkins/inbound-agent:3192.v713e3b_039fb_e-5"
                         privileged: "false"
                         resourceLimitCpu: 512m
                         resourceLimitMemory: 512Mi
@@ -3584,7 +3584,7 @@ tests:
                   templates:
                     - name: "default"
                       namespace: "default"
-                      id: e4c9c2dfb0f00a1c4759b687084b28e89b79bf351943087cc8afd93c45d8748f
+                      id: 923e6d6b3128baaa56764f4b69d4c62b61e55d00f8170e3428f011148767dc99
                       containers:
                       - name: "jnlp"
                         alwaysPullImage: false
@@ -3594,7 +3594,7 @@ tests:
                           - envVar:
                               key: "JENKINS_URL"
                               value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
-                        image: "jenkins/inbound-agent:3107.v665000b_51092-15"
+                        image: "jenkins/inbound-agent:3192.v713e3b_039fb_e-5"
                         privileged: "false"
                         resourceLimitCpu: 512m
                         resourceLimitMemory: 512Mi

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -845,7 +845,7 @@ additionalAgents: {}
 # Here you can add additional clouds
 # They inherit all values from the default cloud (including the main agent), so
 # you only need to specify values which differ. If you want to override
-# default additionalAgents with the additionalClouds.additionalAgents set 
+# default additionalAgents with the additionalClouds.additionalAgents set
 # additionalAgentsOverride to `true`.
 additionalClouds: {}
 #  remote-cloud-1:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -16,6 +16,9 @@ clusterZone: "cluster.local"
 # The URL of the Kubernetes API server
 kubernetesURL: "https://kubernetes.default"
 
+# The Jenkins credentials to access the Kubernetes API server. For the the default cluster it is not needed.
+credentialsId:
+
 renderHelmLabels: true
 
 controller:
@@ -838,6 +841,27 @@ additionalAgents: {}
 #    command: "/bin/sh -c"
 #    args: "cat"
 #    TTYEnabled: true
+
+# Here you can add additional clouds
+# They inherit all values from the default cloud (including the main agent), so
+# you only need to specify values which differ. If you want to override
+# default additionalAgents with the additionalClouds.additionalAgents set 
+# additionalAgentsOverride to `true`.
+additionalClouds: {}
+#  remote-cloud-1:
+#    kubernetesURL: https://api.remote-cloud.com
+#    additionalAgentsOverride: true
+#    additionalAgents:
+#      maven-2:
+#        podName: maven-2
+#        customJenkinsLabels: maven
+#        # An example of overriding the jnlp container
+#        # sideContainerName: jnlp
+#        image: jenkins/jnlp-agent-maven
+#        tag: latest
+#        namespace: my-other-maven-namespace
+#  remote-cloud-2:
+#    kubernetesURL: https://api.remote-cloud.com
 
 persistence:
   enabled: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #634
- Adds the option to set the `credentialsId` for the main cloud and the additional clouds.

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

I did not do the tasks in "Submitter checklist" because I want to gather feedback on my changes. If I'm going in the right direction I will be happy to do all those tasks!

I tried to do the `additionalClouds` feature the same way the `additionalAgents` feature was built in: by looping through the items and merging to the main template. I also stored the state before the loop and restored it after the loop ends.
