### PR TITLE
chore: Updated helm-unittest to 0.3.6 + made tests compatible

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -50,7 +50,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm env
-          helm plugin install https://github.com/quintush/helm-unittest --version 0.2.11
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.3.6
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,10 @@ Tests can be executed like this:
 
 ```console
 # install the unittest plugin
-$ helm plugin install https://github.com/quintush/helm-unittest --version 0.2.11
+$ helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.3.6
 
 # run the unittests
-$ helm unittest --helm3 --strict -f 'unittests/*.yaml' charts/jenkins
+$ helm unittest --strict -f 'unittests/*.yaml' charts/jenkins
 
 ### Chart [ jenkins ] charts/jenkins
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.11.1
+
+Updated helm-unittest and made unittests compatible.
+
 ## 4.11.0
 
 Add multi-cloud support.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.11.0
+version: 4.11.1
 appVersion: 2.426.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/unittests/config-init-scripts-test.yaml
+++ b/charts/jenkins/unittests/config-init-scripts-test.yaml
@@ -14,6 +14,6 @@ tests:
       - hasDocuments:
          count: 1
       - equal:
-          path: data.inittest\.groovy
+          path: data["inittest.groovy"]
           value: |-
             my script here val here

--- a/charts/jenkins/unittests/config-test.yaml
+++ b/charts/jenkins/unittests/config-test.yaml
@@ -16,7 +16,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: jenkins
       - equal:
-          path: data.apply_config\.sh
+          path: data["apply_config.sh"]
           value: |-
             set -e
             echo "disable Setup Wizard"
@@ -38,7 +38,7 @@ tests:
             yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
             echo "finished initialization"
       - equal:
-          path: data.plugins\.txt
+          path: data["plugins.txt"]
           value: |-
             kubernetes:4029.v5712230ccb_f8
             workflow-aggregator:596.v8c21c963d92d
@@ -49,7 +49,7 @@ tests:
       controller.installPlugins: []
     asserts:
       - equal:
-          path: data.apply_config\.sh
+          path: data["apply_config.sh"]
           value: |-
             set -e
             echo "disable Setup Wizard"
@@ -58,7 +58,7 @@ tests:
             echo $JENKINS_VERSION > /var/jenkins_home/jenkins.install.InstallUtil.lastExecVersion
             echo "finished initialization"
       - equal:
-          path: data.plugins\.txt
+          path: data["plugins.txt"]
           value: ""
   - it: additional plugins config
     set:
@@ -67,7 +67,7 @@ tests:
               - kubernetes-credentials-provider
     asserts:
       - equal:
-          path: data.plugins\.txt
+          path: data["plugins.txt"]
           value: |-
             kubernetes:4029.v5712230ccb_f8
             workflow-aggregator:596.v8c21c963d92d
@@ -79,7 +79,7 @@ tests:
       controller.installLatestPlugins: false
     asserts:
       - equal:
-          path: data.apply_config\.sh
+          path: data["apply_config.sh"]
           value: |-
             set -e
             echo "disable Setup Wizard"
@@ -105,7 +105,7 @@ tests:
       controller.installLatestSpecifiedPlugins: true
     asserts:
       - equal:
-          path: data.apply_config\.sh
+          path: data["apply_config.sh"]
           value: |-
             set -e
             echo "disable Setup Wizard"

--- a/charts/jenkins/unittests/home-pvc-test.yaml
+++ b/charts/jenkins/unittests/home-pvc-test.yaml
@@ -19,7 +19,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -11,12 +11,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -142,7 +142,7 @@ tests:
 
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -411,7 +411,7 @@ tests:
         isKind:
           of: ConfigMap
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - documentIndex: 0
         equal:
@@ -422,7 +422,7 @@ tests:
           path: metadata.namespace
           value: other
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - documentIndex: 1
         isKind:
@@ -452,7 +452,7 @@ tests:
                 systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.
       - documentIndex: 1
         equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -591,12 +591,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -698,12 +698,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -803,12 +803,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -910,12 +910,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -1018,12 +1018,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -1125,12 +1125,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -1236,7 +1236,7 @@ tests:
       agent.enabled: false
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -1302,12 +1302,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -1402,12 +1402,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -1506,12 +1506,12 @@ tests:
     - hasDocuments:
         count: 1
     - isNotEmpty:
-        path: data.jcasc-default-config\.yaml
+        path: data["jcasc-default-config.yaml"]
     - matchRegex:
-        path: metadata.labels.helm\.sh/chart
+        path: metadata.labels["helm.sh/chart"]
         pattern: ^jenkins-
     - equal:
-        path: data.jcasc-default-config\.yaml
+        path: data["jcasc-default-config.yaml"]
         value: |-
           jenkins:
             authorizationStrategy:
@@ -1606,12 +1606,12 @@ tests:
     - hasDocuments:
         count: 1
     - isNotEmpty:
-        path: data.jcasc-default-config\.yaml
+        path: data["jcasc-default-config.yaml"]
     - matchRegex:
-        path: metadata.labels.helm\.sh/chart
+        path: metadata.labels["helm.sh/chart"]
         pattern: ^jenkins-
     - equal:
-        path: data.jcasc-default-config\.yaml
+        path: data["jcasc-default-config.yaml"]
         value: |-
           jenkins:
             authorizationStrategy:
@@ -1704,7 +1704,7 @@ tests:
         projectNamingStrategy:
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -1797,7 +1797,7 @@ tests:
             mySetting2: something
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -1894,7 +1894,7 @@ tests:
               sshHostKeyVerificationStrategy: "acceptFirstConnectionStrategy"
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -1989,7 +1989,7 @@ tests:
             apiToken: overridden
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -2083,7 +2083,7 @@ tests:
             privileged: true
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -2207,7 +2207,7 @@ tests:
               args: arg1 arg2
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -2375,7 +2375,7 @@ tests:
           additionalContainers: []
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -2515,7 +2515,7 @@ tests:
         hostNetworking: true
     asserts:
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -2617,12 +2617,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -2726,12 +2726,12 @@ tests:
       - hasDocuments:
           count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -2831,12 +2831,12 @@ tests:
       - hasDocuments:
           count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -2950,12 +2950,12 @@ tests:
       - hasDocuments:
           count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -3077,12 +3077,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -3235,12 +3235,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:
@@ -3457,12 +3457,12 @@ tests:
       - hasDocuments:
          count: 1
       - isNotEmpty:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
-          path: data.jcasc-default-config\.yaml
+          path: data["jcasc-default-config.yaml"]
           value: |-
             jenkins:
               authorizationStrategy:

--- a/charts/jenkins/unittests/jenkins-agent-svc-test.yaml
+++ b/charts/jenkins/unittests/jenkins-agent-svc-test.yaml
@@ -19,7 +19,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jenkins-controller-alerting-rules-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-alerting-rules-test.yaml
@@ -33,13 +33,13 @@ tests:
           path: metadata.name
           value: my-release-jenkins
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
           path: spec

--- a/charts/jenkins/unittests/jenkins-controller-ingress-1.19-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-ingress-1.19-test.yaml
@@ -35,7 +35,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jenkins-controller-ingress-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-ingress-test.yaml
@@ -35,7 +35,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jenkins-controller-networkpolicy-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-networkpolicy-test.yaml
@@ -24,7 +24,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jenkins-controller-pdb-1.21-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-pdb-1.21-test.yaml
@@ -30,7 +30,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jenkins-controller-pdb-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-pdb-test.yaml
@@ -30,7 +30,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
@@ -37,7 +37,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jenkins-controller-secondary-ingress-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-secondary-ingress-test.yaml
@@ -14,7 +14,7 @@ tests:
         count: 0
   - it: enabled
     set:
-      controller.secondaryingress:
+      "controller.secondaryingress":
         enabled: true
         hostName: jenkins.example.com
         ingressClassName: nginx
@@ -37,7 +37,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jenkins-controller-servicemonitor_test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-servicemonitor_test.yaml
@@ -25,7 +25,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
           path: spec

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -22,7 +22,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/jenkins-controller-svc-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-svc-test.yaml
@@ -19,7 +19,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/rbac-test.yaml
+++ b/charts/jenkins/unittests/rbac-test.yaml
@@ -145,7 +145,7 @@ tests:
       - hasDocuments:
           count: 6
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
 
   - it: disable helm.sh label

--- a/charts/jenkins/unittests/secret-additional-test.yaml
+++ b/charts/jenkins/unittests/secret-additional-test.yaml
@@ -29,7 +29,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/secret-claims-test.yaml
+++ b/charts/jenkins/unittests/secret-claims-test.yaml
@@ -34,7 +34,7 @@ tests:
           value: my-release-jenkins-simple-secret
       - documentIndex: 0
         matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - documentIndex: 0
         isNull:
@@ -63,7 +63,7 @@ tests:
           value: my-release-jenkins-complex-secret
       - documentIndex: 1
         matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - documentIndex: 1
         isNull:

--- a/charts/jenkins/unittests/secret-test.yaml
+++ b/charts/jenkins/unittests/secret-test.yaml
@@ -19,7 +19,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations

--- a/charts/jenkins/unittests/service-account-agent-test.yaml
+++ b/charts/jenkins/unittests/service-account-agent-test.yaml
@@ -26,7 +26,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations
@@ -51,7 +51,7 @@ tests:
           path: metadata.namespace
           value: agents
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - equal:
           path: metadata.annotations
@@ -90,14 +90,14 @@ tests:
           "this.is.another.test.label": "with a different value"
     asserts:
       - equal:
-          path: metadata.labels.\app\.kubernetes\.io/name
+          path: metadata.labels["app.kubernetes.io/name"]
           value: "jenkins"
       - equal:
-          path: metadata.labels.app\.kubernetes\.io/managed-by
+          path: metadata.labels["app.kubernetes.io/managed-by"]
           value: "Helm"
       - equal:
-          path: metadata.labels.this\.\is\.a\.test\.label
+          path: metadata.labels["this.is.a.test.label"]
           value: "with a value"
       - equal:
-          path: metadata.labels.this\.is\.another\.test\.label
+          path: metadata.labels["this.is.another.test.label"]
           value: "with a different value"

--- a/charts/jenkins/unittests/service-account-test.yaml
+++ b/charts/jenkins/unittests/service-account-test.yaml
@@ -19,7 +19,7 @@ tests:
           path: metadata.namespace
           value: my-namespace
       - matchRegex:
-          path: metadata.labels.helm\.sh/chart
+          path: metadata.labels["helm.sh/chart"]
           pattern: ^jenkins-
       - isNull:
           path: metadata.annotations
@@ -64,14 +64,14 @@ tests:
           "this.is.another.test.label": "with a different value"
     asserts:
       - equal:
-          path: metadata.labels.\app\.kubernetes\.io/name
+          path: metadata.labels["app.kubernetes.io/name"]
           value: "jenkins"
       - equal:
-          path: metadata.labels.app\.kubernetes\.io/managed-by
+          path: metadata.labels["app.kubernetes.io/managed-by"]
           value: "Helm"
       - equal:
-          path: metadata.labels.this\.\is\.a\.test\.label
+          path: metadata.labels["this.is.a.test.label"]
           value: "with a value"
       - equal:
-          path: metadata.labels.this\.is\.another\.test\.label
+          path: metadata.labels["this.is.another.test.label"]
           value: "with a different value"

--- a/ct.yaml
+++ b/ct.yaml
@@ -5,4 +5,4 @@ chart-dirs:
   - charts
 helm-extra-args: --timeout 600s
 additional-commands:
-  - helm unittest --helm3 --strict -f 'unittests/*.yaml' {{ .Path }}
+  - helm unittest --strict -f 'unittests/*.yaml' {{ .Path }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
This PR updates helm-unittest to 0.3.6 and makes the existing unit tests compatible. There have been earlier PRs that tried to achieve this but those didn't include the changes I had to make to the unittests.
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #956

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

<!-- Leave blank if none -->
