### PR TITLE
Add support for generic ephemeral storage

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,12 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 4.12.0
+
+| plugin     | old version         | new version        |
+|------------|---------------------|--------------------|
+| kubernetes | 4029.v5712230ccb_f8 | 4174.v4230d0ccd951 |
+
 ## 4.11.2
 
 Fixed documentation for controller.initScripts.

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,6 +14,8 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 4.12.0
 
+Add support for setting [generic ephemeral storage](https://github.com/jenkinsci/kubernetes-plugin/pull/1489) in `agent.volumes`.
+
 | plugin     | old version         | new version        |
 |------------|---------------------|--------------------|
 | kubernetes | 4029.v5712230ccb_f8 | 4174.v4230d0ccd951 |

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 4.12.0
 
-Add support for setting [generic ephemeral storage](https://github.com/jenkinsci/kubernetes-plugin/pull/1489) in `agent.volumes`.
+Add support for [generic ephemeral storage](https://github.com/jenkinsci/kubernetes-plugin/pull/1489) in `agent.volumes` and `agents.workspaceVolume`.
 
 | plugin     | old version         | new version        |
 |------------|---------------------|--------------------|

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 4.11.2
+version: 4.12.0
 appVersion: 2.426.2
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -482,6 +482,8 @@ Returns kubernetes pod template configuration as code
     dynamicPVC:
     {{- else if (eq .Values.agent.workspaceVolume.type "EmptyDir") }}
     emptyDirWorkspaceVolume:
+    {{- else if (eq .Values.agent.workspaceVolume.type "EphemeralVolume") }}
+    genericEphemeralVolume:
     {{- else if (eq .Values.agent.workspaceVolume.type "HostPath") }}
     hostPathWorkspaceVolume:
     {{- else if (eq .Values.agent.workspaceVolume.type "Nfs") }}

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -462,6 +462,7 @@ Returns kubernetes pod template configuration as code
   {{- range $index, $volume := .Values.agent.volumes }}
     -{{- if (eq $volume.type "ConfigMap") }} configMapVolume:
      {{- else if (eq $volume.type "EmptyDir") }} emptyDirVolume:
+     {{- else if (eq $volume.type "EphemeralVolume") }} genericEphemeralVolume:
      {{- else if (eq $volume.type "HostPath") }} hostPathVolume:
      {{- else if (eq $volume.type "Nfs") }} nfsVolume:
      {{- else if (eq $volume.type "PVC") }} persistentVolumeClaim:

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -1,5 +1,5 @@
 render pod annotations:
   1: |
-    checksum/config: ce69b63eb27efd6e89b22eeaf52dbe7fe3a319b4178f4de5a66077e50ccf50df
+    checksum/config: d07ed80fe87695afb403730897369275917d5984231041cbd3b8960d6b230aa2
     fixed-annotation: some-fixed-annotation
     templated-annotations: my-release

--- a/charts/jenkins/unittests/config-test.yaml
+++ b/charts/jenkins/unittests/config-test.yaml
@@ -40,7 +40,7 @@ tests:
       - equal:
           path: data["plugins.txt"]
           value: |-
-            kubernetes:4029.v5712230ccb_f8
+            kubernetes:4174.v4230d0ccd951
             workflow-aggregator:596.v8c21c963d92d
             git:5.1.0
             configuration-as-code:1670.v564dc8b_982d0
@@ -69,7 +69,7 @@ tests:
       - equal:
           path: data["plugins.txt"]
           value: |-
-            kubernetes:4029.v5712230ccb_f8
+            kubernetes:4174.v4230d0ccd951
             workflow-aggregator:596.v8c21c963d92d
             git:5.1.0
             configuration-as-code:1670.v564dc8b_982d0

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -585,6 +585,115 @@ tests:
               location:
                 adminAddress: admin@example.org
                 url: https://jenkins.example.com
+  - it: custom ephemeral storage workspace volume
+    set:
+      agent:
+        workspaceVolume:
+          type: "EphemeralVolume"
+          accessModes: "ReadWriteOnce"
+          requestsSize: "2Gi"
+          storageClassName: "test-storageclass"
+    release:
+      namespace: default
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - hasDocuments:
+         count: 1
+      - isNotEmpty:
+          path: data["jcasc-default-config.yaml"]
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^jenkins-
+      - equal:
+          path: data["jcasc-default-config.yaml"]
+          value: |-
+            jenkins:
+              authorizationStrategy:
+                loggedInUsersCanDoAnything:
+                  allowAnonymousRead: false
+              securityRealm:
+                local:
+                  allowsSignup: false
+                  enableCaptcha: false
+                  users:
+                  - id: "${chart-admin-username}"
+                    name: "Jenkins Admin"
+                    password: "${chart-admin-password}"
+              disableRememberMe: false
+              mode: NORMAL
+              numExecutors: 0
+              labelString: ""
+              projectNamingStrategy: "standard"
+              markupFormatter:
+                plainText
+              clouds:
+              - kubernetes:
+                  containerCapStr: "10"
+                  defaultsProviderTemplate: ""
+                  connectTimeout: "5"
+                  readTimeout: "15"
+                  jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+                  jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+                  maxRequestsPerHostStr: "32"
+                  retentionTimeout: "5"
+                  waitForPodSec: "600"
+                  name: "kubernetes"
+                  namespace: "default"
+                  serverUrl: "https://kubernetes.default"
+                  credentialsId: ""
+                  podLabels:
+                  - key: "jenkins/RELEASE-NAME-jenkins-agent"
+                    value: "true"
+                  templates:
+                    - name: "default"
+                      namespace: "default"
+                      id: ea5eb73a5f6e8914d92a87ba9567e3253aa768f60ec4cddb6a7d4c9189ba0889
+                      containers:
+                      - name: "jnlp"
+                        alwaysPullImage: false
+                        args: "^${computer.jnlpmac} ^${computer.name}"
+                        command:
+                        envVars:
+                          - envVar:
+                              key: "JENKINS_URL"
+                              value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                        image: "jenkins/inbound-agent:3192.v713e3b_039fb_e-5"
+                        privileged: "false"
+                        resourceLimitCpu: 512m
+                        resourceLimitMemory: 512Mi
+                        resourceRequestCpu: 512m
+                        resourceRequestMemory: 512Mi
+                        runAsUser:
+                        runAsGroup:
+                        ttyEnabled: false
+                        workingDir: /home/jenkins/agent
+                      idleMinutes: 0
+                      instanceCap: 2147483647
+                      label: "RELEASE-NAME-jenkins-agent "
+                      nodeUsageMode: "NORMAL"
+                      podRetention: Never
+                      showRawYaml: true
+                      serviceAccount: "default"
+                      slaveConnectTimeoutStr: "100"
+                      workspaceVolume:
+                        genericEphemeralVolume:
+                          accessModes: "ReadWriteOnce"
+                          requestsSize: "2Gi"
+                          storageClassName: "test-storageclass"
+                      yamlMergeStrategy: override
+              crumbIssuer:
+                standard:
+                  excludeClientIPFromCrumb: true
+            security:
+              apiToken:
+                creationOfLegacyTokenEnabled: false
+                tokenGenerationOnCreationEnabled: false
+                usageStatisticsEnabled: true
+            unclassified:
+              location:
+                adminAddress:
+                url: http://RELEASE-NAME-jenkins:8080
   - it: custom dynamic pvc workspace volume
     set:
       agent:

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -388,6 +388,11 @@ tests:
           defaultMode: "600"
           mountPath: /var/myapp/mysecret
           secretName: mysecret
+        - type: EphemeralVolume
+          mountPath: /var/myapp/myephemeralvolume
+          accessModes: ReadWriteOnce
+          requestsSize: 2Gi
+          storageClassName: test-storageclass
         annotations:
           ci.jenkins-agent/test: "custom"
         yamlTemplate: |-
@@ -494,7 +499,7 @@ tests:
                       annotations:
                       - key: ci.jenkins-agent/test
                         value: "custom"
-                      id: 6de9914dfb9678a4f580464e046eea7dabd8ade25357bdbe43447cf3be2264ae
+                      id: 8d8b353b1f27b74148ea53bdafaa66c35d1f18a4d1f9bf7eb119fbcc3d0ae4f4
                       containers:
                       - name: "sideContainer"
                         alwaysPullImage: true
@@ -554,6 +559,11 @@ tests:
                             defaultMode: "600"
                             mountPath: "/var/myapp/mysecret"
                             secretName: "mysecret"
+                        - genericEphemeralVolume:
+                            accessModes: "ReadWriteOnce"
+                            mountPath: "/var/myapp/myephemeralvolume"
+                            requestsSize: "2Gi"
+                            storageClassName: "test-storageclass"
                       yaml: |-
                         apiVersion: v1
                         kind: Pod

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -47,7 +47,7 @@ tests:
             template:
               metadata:
                 annotations:
-                  checksum/config: ce69b63eb27efd6e89b22eeaf52dbe7fe3a319b4178f4de5a66077e50ccf50df
+                  checksum/config: d07ed80fe87695afb403730897369275917d5984231041cbd3b8960d6b230aa2
                 labels:
                   app.kubernetes.io/component: jenkins-controller
                   app.kubernetes.io/instance: my-release

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -678,7 +678,7 @@ agent:
   # or simply to clean up the output to make it easier to read.
   showRawYaml: true
   # You can define the volumes that you want to mount for this container
-  # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, PVC, Secret
+  # Allowed types are: ConfigMap, EmptyDir, EphemeralVolume, HostPath, Nfs, PVC, Secret
   # Configure the attributes as they appear in the corresponding Java class for that type
   # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
   volumes: []
@@ -688,6 +688,11 @@ agent:
   # - type: EmptyDir
   #   mountPath: /var/myapp/myemptydir
   #   memory: false
+  # - type: EphemeralVolume
+  #   mountPath: /var/myapp/myephemeralvolume
+  #   accessModes: ReadWriteOnce
+  #   requestsSize: 10Gi
+  #   storageClassName: mystorageclass
   # - type: HostPath
   #   hostPath: /var/lib/containers
   #   mountPath: /var/myapp/myhostpath

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -247,7 +247,7 @@ controller:
 
   # List of plugins to be install during Jenkins controller start
   installPlugins:
-    - kubernetes:4029.v5712230ccb_f8
+    - kubernetes:4174.v4230d0ccd951
     - workflow-aggregator:596.v8c21c963d92d
     - git:5.1.0
     - configuration-as-code:1670.v564dc8b_982d0

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -712,7 +712,7 @@ agent:
   # Pod-wide environment, these vars are visible to any container in the agent pod
 
   # You can define the workspaceVolume that you want to mount for this container
-  # Allowed types are: DynamicPVC, EmptyDir, HostPath, Nfs, PVC
+  # Allowed types are: DynamicPVC, EmptyDir, EphemeralVolume, HostPath, Nfs, PVC
   # Configure the attributes as they appear in the corresponding Java class for that type
   # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace
   workspaceVolume: {}
@@ -722,6 +722,11 @@ agent:
   ## EmptyDir example
   # type: EmptyDir
   # memory: false
+  ## EphemeralVolume example
+  # type: EphemeralVolume
+  # accessModes: ReadWriteOnce
+  # requestsSize: 10Gi
+  # storageClassName: mystorageclass
   ## HostPath example
   # type: HostPath
   # hostPath: /var/lib/containers


### PR DESCRIPTION
### What does this PR do?

https://github.com/jenkinsci/kubernetes-plugin/pull/1489 introduces the possibility to use ephemeral storage volumes in the Build pod specification. This change makes it explicit that this volume type is supported by the Helm Chart.

- Fixes #982

### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).

### Special notes for your reviewer

During implementation I realized that there is a fallback/default behavior for when the desired type is not listed/implemented. Since the `kubernetes` plugin had to be updated anyways to allow that type, I continued implementing this PR.