### PR TITLE
chore: Prefixed artifacthub.io/images with docker.io

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.0.3
+
+Prefixed artifacthub.io/images with `docker.io`
+
 ## 5.0.2
 
 Update `git` to version `5.2.1`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 5.0.2
+version: 5.0.3
 appVersion: 2.426.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:
@@ -35,10 +35,10 @@ annotations:
       url: https://github.com/jenkinsci/helm-charts/issues
   artifacthub.io/images: |
     - name: jenkins
-      image: jenkins/jenkins:2.426.3-jdk17
+      image: docker.io/jenkins/jenkins:2.426.3-jdk17
     - name: k8s-sidecar
-      image: kiwigrid/k8s-sidecar:1.24.4
+      image: docker.io/kiwigrid/k8s-sidecar:1.24.4
     - name: inbound-agent
-      image: jenkins/inbound-agent:3192.v713e3b_039fb_e-5
+      image: docker.io/jenkins/inbound-agent:3192.v713e3b_039fb_e-5
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "Apache-2.0"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
This will merge #991 and #992. Also, this makes the artifacthub.io/images annotation more explicit
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

<!-- Leave blank if none -->
