### PR TITLE
chore: Remove docker.io prefix for inbound-agent

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.0.6
+
+Removed `docker.io` prefix from inbound-agent image
+
 ## 5.0.5
 
 Prefixed artifacthub.io/images with `docker.io`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 5.0.5
+version: 5.0.6
 appVersion: 2.426.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:
@@ -39,6 +39,6 @@ annotations:
     - name: k8s-sidecar
       image: docker.io/kiwigrid/k8s-sidecar:1.24.4
     - name: inbound-agent
-      image: docker.io/jenkins/inbound-agent:3192.v713e3b_039fb_e-5
+      image: jenkins/inbound-agent:3192.v713e3b_039fb_e-5
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "Apache-2.0"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
This should merge #996 and #998
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer
I'll make some changes to the Renovate config at a later moment that should allow for the jenkins-inbound-agent image to be prefixed with docker.io
<!-- Leave blank if none -->
