### PR TITLE
Update jenkins-controller-statefulset.yaml to match the recent parame…

### DIFF
--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -313,8 +313,8 @@ spec:
 {{- end}}
 
 
-{{- if .Values.controller.sidecars.other}}
-{{ tpl (toYaml .Values.controller.sidecars.other | indent 8) .}}
+{{- if .Values.controller.sidecars.customInitContainers}}
+{{ tpl (toYaml .Values.controller.sidecars.customInitContainers | indent 8) .}}
 {{- end }}
 
       volumes:


### PR DESCRIPTION
…ter changes

`controller.sidecars.other` has been renamed to `controller.sidecars.additionalSidecarContainers`.

But the actual template has not been updated.

### What does this PR do?

Update the template to match recent parameter deprecations

### Special notes for your reviewer
