### PR TITLE
fix: controller.sidecars.additionalSidecarContainers renaming and add tests

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,7 +1,0 @@
-/github/workspace/charts/jenkins/README.md:hashicorp-tf-password:664
-/github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:635
-/github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:636
-/github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:665
-/github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:666
-/github/workspace/charts/jenkins/values.yaml:hashicorp-tf-password:584
-/github/workspace/charts/jenkins/values.yaml:hashicorp-tf-password:590

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,5 +1,7 @@
 /github/workspace/charts/jenkins/README.md:hashicorp-tf-password:664
 /github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:635
 /github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:636
+/github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:665
+/github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:666
 /github/workspace/charts/jenkins/values.yaml:hashicorp-tf-password:584
 /github/workspace/charts/jenkins/values.yaml:hashicorp-tf-password:590

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.0.12
+
+* Fix controller.sidecars.additionalSidecarContainers renaming and add tests
+
 ## 5.0.11
 
 * Add controller.sidecars.configAutoReload.scheme to specify protocol scheme when connecting Jenkins configuration-as-code reload endpoint

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 5.0.12
 
-* Fix controller.sidecars.additionalSidecarContainers renaming and add tests
+Fix controller.sidecars.additionalSidecarContainers renaming and add tests
 
 ## 5.0.11
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: jenkins
 home: https://jenkins.io/
-version: 5.0.11
+version: 5.0.12
 appVersion: 2.426.3
 description: Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.
 sources:

--- a/charts/jenkins/VALUES_SUMMARY.md
+++ b/charts/jenkins/VALUES_SUMMARY.md
@@ -160,7 +160,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `controller.admin.userKey`                 | The key in the existing admin secret containing the username.                                                                | `jenkins-admin-user`                                                                                 |
 | `controller.admin.passwordKey`             | The key in the existing admin secret containing the password.                                                                | `jenkins-admin-password`                                                                             |
 | `controller.customInitContainers`          | Custom init-container specification in raw-yaml format                                                                       | Not set                                                                                              |
-| `controller.sidecars.other`                | Configures additional sidecar container(s) for Jenkins controller                                                            | `[]`                                                                                                 |
+| `controller.sidecars.additionalSidecarContainers`| Configures additional sidecar container(s) for Jenkins controller                                                            | `[]`                                                                                                 |
 
 #### Kubernetes Pod Disruption Budget
 

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -313,8 +313,8 @@ spec:
 {{- end}}
 
 
-{{- if .Values.controller.sidecars.other}}
-{{ tpl (toYaml .Values.controller.sidecars.other | indent 8) .}}
+{{- if .Values.controller.sidecars.additionalSidecarContainers}}
+{{ tpl (toYaml .Values.controller.sidecars.additionalSidecarContainers | indent 8) .}}
 {{- end }}
 
       volumes:

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -251,6 +251,36 @@ tests:
             runAsUser: 4444
             supplementalGroups:
               - 5555
+  - it: test controller.sidecars.additionalSidecarContainers
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        sidecars:
+          additionalSidecarContainers:
+            - name: otel-collector
+              image: opentelemetry-collector:0.93.0
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2]
+          value:
+            name: otel-collector
+            image: opentelemetry-collector:0.93.0
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 200m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
   - it: test 2 additional secrets
     template: jenkins-controller-statefulset.yaml
     set:


### PR DESCRIPTION
Fix controller.sidecars.additionalSidecarContainers 

subsume https://github.com/jenkinsci/helm-charts/pull/1001

Missing unit test didn't catch this regression so adding one

<!-- markdownlint-disable MD041 -->

### What does this PR do?

Fix controller.sidecars.additionalSidecarContainers renaming and add tests

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

<!-- Leave blank if none -->
