### PR TITLE
chore: Disabled GitLeaks linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,6 +19,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_KUBERNETES_KUBECONFORM: false
+          VALIDATE_GITLEAKS: false
           VALIDATE_YAML: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,5 +1,0 @@
-/github/workspace/charts/jenkins/README.md:hashicorp-tf-password:664
-/github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:635
-/github/workspace/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml:hashicorp-tf-password:636
-/github/workspace/charts/jenkins/values.yaml:hashicorp-tf-password:584
-/github/workspace/charts/jenkins/values.yaml:hashicorp-tf-password:590


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
Disables the new GitLeaks linter included in super-linter, as it keeps popping up with new false-positives.
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer

<!-- Leave blank if none -->
