### PR TITLE
chore: Fixed Renovate changelog entry

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -5,7 +5,7 @@
   platform: "github",
   repositories: ["jenkinsci/helm-charts"],
   // eslint-disable-next-line
-  allowedPostUpgradeCommands: ["^\.github\/renovate-postupgrade\.sh {{{depName}}} {{{newVersion}}}$"],
+  allowedPostUpgradeCommands: ['^\.github\/renovate-postupgrade\.sh "{{{depName}}}" "{{{newVersion}}}"$'],
   prConcurrentLimit: 0,
   prHourlyLimit: 5,
   semanticCommits: "enabled",
@@ -27,7 +27,7 @@
       matchFileNames: ["charts/jenkins/**"],
       postUpgradeTasks: {
         commands: [
-          ".github/renovate-postupgrade.sh {{{depName}}} {{{newVersion}}}",
+          '.github/renovate-postupgrade.sh "{{{depName}}}" "{{{newVersion}}}"',
         ],
         fileFilters: ["charts/jenkins/**"],
         executionMode: "branch",

--- a/.github/renovate-postupgrade.sh
+++ b/.github/renovate-postupgrade.sh
@@ -2,7 +2,8 @@
 
 CHARTVERSION="$(jx-release-version -previous-version=from-file:charts/jenkins/Chart.yaml)"
 export CHARTVERSION
-export DEPNAME="$1"
+depName=$(echo "$1" | tr ' ' '\n' | sort | uniq)
+export DEPNAME="$depName"
 export NEWVERSION="$2"
 
 helm unittest --strict -f 'unittests/*.yaml' charts/jenkins -u


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
Fixed the Renovate changelog entry by handling the depName that is supplied twice.
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #1028 

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer
The solution is a bit hacky, but it works and seems robust, since the script should never be called with multiple unique dependency names.
<!-- Leave blank if none -->
