### PR TITLE
fix(renovate): Fix Renovate configuration for Jenkins LTS

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -82,6 +82,7 @@
       ],
       datasourceTemplate: "docker",
       versioningTemplate: "regex:^(?<major>\\d+)?\\.(?<minor>\\w+?)?(_|\\.)(?<patch>\\w+)?(-(?<build>\\d+))?.*",
+      depNameTemplate: "{{#if (equals depName 'docker.io/jenkins/jenkins')}}jenkins/jenkins{{else}}{{{depName}}}{{/if}}"
     },
   ],
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
Fixes the Renovate configuration for Jenkins LTS updates
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #1030 

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
```

### Special notes for your reviewer
I had a package rule for `jenkins/jenkins` to specify a more strict versioning than is default for Renovate. This didn't get applied to `docker.io/jenkins/jenkins`
<!-- Leave blank if none -->
