### PR TITLE
chore: improved renovate config for detecting python updates

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -39,6 +39,14 @@
       minimumReleaseAge: "12 hours",
     },
   ],
+  customDatasources: {
+    "python_actions": {
+      defaultRegistryUrlTemplate: "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json",
+      transformTemplates: [
+        "{\"releases\": $$[stable=true].files[arch=\"x64\" and platform=\"linux\"].{\"version\":%.version,\"changelogUrl\":\"https://docs.python.org/whatsnew/index.html\"},\"homepage\":\"https://python.org/\",\"changelogUrl\":\"https://docs.python.org/whatsnew/index.html\"}",
+      ],
+    },
+  },
   customManagers: [
     {
       customType: "regex",
@@ -82,7 +90,7 @@
       ],
       datasourceTemplate: "docker",
       versioningTemplate: "regex:^(?<major>\\d+)?\\.(?<minor>\\w+?)?(_|\\.)(?<patch>\\w+)?(-(?<build>\\d+))?.*",
-      depNameTemplate: "{{#if (equals depName 'docker.io/jenkins/jenkins')}}jenkins/jenkins{{else}}{{{depName}}}{{/if}}"
+      depNameTemplate: "{{#if (equals depName 'docker.io/jenkins/jenkins')}}jenkins/jenkins{{else}}{{{depName}}}{{/if}}",
     },
   ],
 }

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          # renovate: datasource=docker depName=python
+          # renovate: datasource=custom.python_actions depName=python
           python-version: 3.12.2
 
       - name: Set up chart-testing


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
Improves Renovate's version detection for Python versions for GitHub Actions
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes the problem seen in #1067

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
- [x] Checked the new Renovate configuration locally by running `RENOVATE_CONFIG_FILE=.github/renovate-config.json5 LOG_LEVEL=debug RENOVATE_TOKEN=$(gh auth token) renovate --platform=local`
```

### Special notes for your reviewer
@timja this will prevent Renovate from opening these types of PRs until the Python version is supported by actions/setup-python.
<!-- Leave blank if none -->
