### PR TITLE
feat: Configure inherit yaml merge strategy

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.2.0
+
+Add `agent.inheritYamlMergeStrategy` to allow configuring this setting on the default agent pod template.
+
 ## 5.1.30
 
 Add `controller.JCasC.configMapAnnotations` to allow setting annotations on the JCasC ConfigMaps.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.1.30
+version: 5.2.0
 appVersion: 2.452.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -8,21 +8,21 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Key | Type | Description | Default |
 |:----|:-----|:---------|:------------|
-| [additionalAgents](./values.yaml#L1142) | object | Configure additional | `{}` |
-| [additionalClouds](./values.yaml#L1167) | object |  | `{}` |
+| [additionalAgents](./values.yaml#L1144) | object | Configure additional | `{}` |
+| [additionalClouds](./values.yaml#L1169) | object |  | `{}` |
 | [agent.TTYEnabled](./values.yaml#L1062) | bool | Allocate pseudo tty to the side container | `false` |
-| [agent.additionalContainers](./values.yaml#L1095) | list | Add additional containers to the agents | `[]` |
+| [agent.additionalContainers](./values.yaml#L1097) | list | Add additional containers to the agents | `[]` |
 | [agent.alwaysPullImage](./values.yaml#L955) | bool | Always pull agent container image before build | `false` |
-| [agent.annotations](./values.yaml#L1091) | object | Annotations to apply to the pod | `{}` |
+| [agent.annotations](./values.yaml#L1093) | object | Annotations to apply to the pod | `{}` |
 | [agent.args](./values.yaml#L1056) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
 | [agent.command](./values.yaml#L1054) | string | Command to execute when side container starts | `nil` |
 | [agent.componentName](./values.yaml#L923) | string |  | `"jenkins-agent"` |
-| [agent.connectTimeout](./values.yaml#L1089) | int | Timeout in seconds for an agent to be online | `100` |
+| [agent.connectTimeout](./values.yaml#L1091) | int | Timeout in seconds for an agent to be online | `100` |
 | [agent.containerCap](./values.yaml#L1064) | int | Max number of agents to launch | `10` |
 | [agent.customJenkinsLabels](./values.yaml#L920) | list | Append Jenkins labels to the agent | `[]` |
 | [agent.defaultsProviderTemplate](./values.yaml#L886) | string | The name of the pod template to use for providing default values | `""` |
 | [agent.directConnection](./values.yaml#L926) | bool |  | `false` |
-| [agent.disableDefaultAgent](./values.yaml#L1113) | bool | Disable the default Jenkins Agent configuration | `false` |
+| [agent.disableDefaultAgent](./values.yaml#L1115) | bool | Disable the default Jenkins Agent configuration | `false` |
 | [agent.enabled](./values.yaml#L884) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
 | [agent.envVars](./values.yaml#L1037) | list | Environment variables for the agent Pod | `[]` |
 | [agent.hostNetworking](./values.yaml#L934) | bool | Enables the agent to use the host network | `false` |
@@ -30,6 +30,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [agent.image.repository](./values.yaml#L913) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
 | [agent.image.tag](./values.yaml#L915) | string | Tag of the image to pull | `"3248.v65ecb_254c298-1"` |
 | [agent.imagePullSecretName](./values.yaml#L922) | string | Name of the secret to be used to pull the image | `nil` |
+| [agent.inheritYamlMergeStrategy](./values.yaml#L1089) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one  | `false` |
 | [agent.jenkinsTunnel](./values.yaml#L894) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
 | [agent.jenkinsUrl](./values.yaml#L890) | string | Overrides the Kubernetes Jenkins URL | `nil` |
 | [agent.jnlpregistry](./values.yaml#L910) | string | Custom registry used to pull the agent jnlp image from | `nil` |
@@ -43,7 +44,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [agent.podLabels](./values.yaml#L908) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
 | [agent.podName](./values.yaml#L1066) | string | Agent Pod base name | `"default"` |
 | [agent.podRetention](./values.yaml#L964) | string |  | `"Never"` |
-| [agent.podTemplates](./values.yaml#L1123) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
+| [agent.podTemplates](./values.yaml#L1125) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
 | [agent.privileged](./values.yaml#L928) | bool | Agent privileged container | `false` |
 | [agent.resources](./values.yaml#L936) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
 | [agent.restrictedPssSecurityContext](./values.yaml#L961) | bool | Set a restricted securityContext on jnlp containers | `false` |
@@ -60,11 +61,11 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [agent.workspaceVolume](./values.yaml#L1010) | object | Workspace volume (defaults to EmptyDir) | `{}` |
 | [agent.yamlMergeStrategy](./values.yaml#L1087) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
 | [agent.yamlTemplate](./values.yaml#L1076) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1293) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1295) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1297) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1296) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1290) | bool | Checks if any deprecated values are used | `true` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1295) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1297) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1299) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1298) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1292) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L533) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L538) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -265,40 +266,40 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.usePodSecurityContext](./values.yaml#L176) | bool | Enable pod security context (must be `true` if podSecurityContextOverride, runAsUser or fsGroup are set) | `true` |
 | [credentialsId](./values.yaml#L27) | string | The Jenkins credentials to access the Kubernetes API server. For the default cluster it is not needed. | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1306) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1308) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1310) | string | Tag of the image to test the framework | `"1.11.0"` |
+| [helmtest.bats.image.registry](./values.yaml#L1308) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1310) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1312) | string | Tag of the image to test the framework | `"1.11.0"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
-| [networkPolicy.apiVersion](./values.yaml#L1236) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
-| [networkPolicy.enabled](./values.yaml#L1231) | bool | Enable the creation of NetworkPolicy resources | `false` |
-| [networkPolicy.externalAgents.except](./values.yaml#L1250) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
-| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1248) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
-| [networkPolicy.internalAgents.allowed](./values.yaml#L1240) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
-| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1244) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
-| [networkPolicy.internalAgents.podLabels](./values.yaml#L1242) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
-| [persistence.accessMode](./values.yaml#L1206) | string | The PVC access mode | `"ReadWriteOnce"` |
-| [persistence.annotations](./values.yaml#L1202) | object | Annotations for the PVC | `{}` |
-| [persistence.dataSource](./values.yaml#L1212) | object | Existing data source to clone PVC from | `{}` |
-| [persistence.enabled](./values.yaml#L1186) | bool | Enable the use of a Jenkins PVC | `true` |
-| [persistence.existingClaim](./values.yaml#L1192) | string | Provide the name of a PVC | `nil` |
-| [persistence.labels](./values.yaml#L1204) | object | Labels for the PVC | `{}` |
-| [persistence.mounts](./values.yaml#L1224) | list | Additional mounts | `[]` |
-| [persistence.size](./values.yaml#L1208) | string | The size of the PVC | `"8Gi"` |
-| [persistence.storageClass](./values.yaml#L1200) | string | Storage class for the PVC | `nil` |
-| [persistence.subPath](./values.yaml#L1217) | string | SubPath for jenkins-home mount | `nil` |
-| [persistence.volumes](./values.yaml#L1219) | list | Additional volumes | `[]` |
-| [rbac.create](./values.yaml#L1256) | bool | Whether RBAC resources are created | `true` |
-| [rbac.readSecrets](./values.yaml#L1258) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
+| [networkPolicy.apiVersion](./values.yaml#L1238) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
+| [networkPolicy.enabled](./values.yaml#L1233) | bool | Enable the creation of NetworkPolicy resources | `false` |
+| [networkPolicy.externalAgents.except](./values.yaml#L1252) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
+| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1250) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
+| [networkPolicy.internalAgents.allowed](./values.yaml#L1242) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
+| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1246) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
+| [networkPolicy.internalAgents.podLabels](./values.yaml#L1244) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
+| [persistence.accessMode](./values.yaml#L1208) | string | The PVC access mode | `"ReadWriteOnce"` |
+| [persistence.annotations](./values.yaml#L1204) | object | Annotations for the PVC | `{}` |
+| [persistence.dataSource](./values.yaml#L1214) | object | Existing data source to clone PVC from | `{}` |
+| [persistence.enabled](./values.yaml#L1188) | bool | Enable the use of a Jenkins PVC | `true` |
+| [persistence.existingClaim](./values.yaml#L1194) | string | Provide the name of a PVC | `nil` |
+| [persistence.labels](./values.yaml#L1206) | object | Labels for the PVC | `{}` |
+| [persistence.mounts](./values.yaml#L1226) | list | Additional mounts | `[]` |
+| [persistence.size](./values.yaml#L1210) | string | The size of the PVC | `"8Gi"` |
+| [persistence.storageClass](./values.yaml#L1202) | string | Storage class for the PVC | `nil` |
+| [persistence.subPath](./values.yaml#L1219) | string | SubPath for jenkins-home mount | `nil` |
+| [persistence.volumes](./values.yaml#L1221) | list | Additional volumes | `[]` |
+| [rbac.create](./values.yaml#L1258) | bool | Whether RBAC resources are created | `true` |
+| [rbac.readSecrets](./values.yaml#L1260) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
-| [serviceAccount.annotations](./values.yaml#L1268) | object | Configures annotations for the ServiceAccount | `{}` |
-| [serviceAccount.create](./values.yaml#L1262) | bool | Configures if a ServiceAccount with this name should be created | `true` |
-| [serviceAccount.extraLabels](./values.yaml#L1270) | object | Configures extra labels for the ServiceAccount | `{}` |
-| [serviceAccount.imagePullSecretName](./values.yaml#L1272) | string | Controller ServiceAccount image pull secret | `nil` |
-| [serviceAccount.name](./values.yaml#L1266) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1283) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.create](./values.yaml#L1277) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1285) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1287) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1281) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccount.annotations](./values.yaml#L1270) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.create](./values.yaml#L1264) | bool | Configures if a ServiceAccount with this name should be created | `true` |
+| [serviceAccount.extraLabels](./values.yaml#L1272) | object | Configures extra labels for the ServiceAccount | `{}` |
+| [serviceAccount.imagePullSecretName](./values.yaml#L1274) | string | Controller ServiceAccount image pull secret | `nil` |
+| [serviceAccount.name](./values.yaml#L1268) | string |  | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1285) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.create](./values.yaml#L1279) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1287) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1289) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1283) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -30,7 +30,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [agent.image.repository](./values.yaml#L913) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
 | [agent.image.tag](./values.yaml#L915) | string | Tag of the image to pull | `"3248.v65ecb_254c298-1"` |
 | [agent.imagePullSecretName](./values.yaml#L922) | string | Name of the secret to be used to pull the image | `nil` |
-| [agent.inheritYamlMergeStrategy](./values.yaml#L1089) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one  | `false` |
+| [agent.inheritYamlMergeStrategy](./values.yaml#L1089) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
 | [agent.jenkinsTunnel](./values.yaml#L894) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
 | [agent.jenkinsUrl](./values.yaml#L890) | string | Overrides the Kubernetes Jenkins URL | `nil` |
 | [agent.jnlpregistry](./values.yaml#L910) | string | Custom registry used to pull the agent jnlp image from | `nil` |

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -520,6 +520,7 @@ Returns kubernetes pod template configuration as code
     {{- tpl (trim .Values.agent.yamlTemplate) . | nindent 4 }}
 {{- end }}
   yamlMergeStrategy: {{ .Values.agent.yamlMergeStrategy }}
+  inheritYamlMergeStrategy: {{ .Values.agent.inheritYamlMergeStrategy }}
 {{- end -}}
 
 {{- define "jenkins.kubernetes-version" -}}

--- a/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
@@ -68,6 +68,7 @@ additional clouds:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         - kubernetes:
             containerCapStr: "10"
             defaultsProviderTemplate: ""
@@ -115,6 +116,7 @@ additional clouds:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -196,6 +198,7 @@ additional clouds inheriting additional agents:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
                 id: c55bbaa8d121ac9b4d750ebf3a7a6959cae6bd7a3761cfeae267dd95572161e6
@@ -224,6 +227,7 @@ additional clouds inheriting additional agents:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         - kubernetes:
             containerCapStr: "10"
             defaultsProviderTemplate: ""
@@ -271,6 +275,7 @@ additional clouds inheriting additional agents:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
                 id: c55bbaa8d121ac9b4d750ebf3a7a6959cae6bd7a3761cfeae267dd95572161e6
@@ -299,6 +304,7 @@ additional clouds inheriting additional agents:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -380,6 +386,7 @@ additional clouds overriding additional agents:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
                 id: c55bbaa8d121ac9b4d750ebf3a7a6959cae6bd7a3761cfeae267dd95572161e6
@@ -408,6 +415,7 @@ additional clouds overriding additional agents:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         - kubernetes:
             containerCapStr: "10"
             defaultsProviderTemplate: ""
@@ -455,6 +463,7 @@ additional clouds overriding additional agents:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -540,6 +549,7 @@ adds custom labels on agent pods:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -621,6 +631,7 @@ agent namespace and templates:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
                 id: 31452256c3147d4e880a3f254271bc958177b62440912e24d33ac4bbce3368ce
@@ -649,6 +660,7 @@ agent namespace and templates:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
               - name: "python"
                 namespace: "jenkins-agents"
                 id: 19d3d9a9feaa55daa63e6d28f716c725b03e7b11ac663caaf25ac9cb312e1a82
@@ -678,6 +690,7 @@ agent namespace and templates:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
               - name: python3
                 label: jenkins-python3
                 serviceAccount: jenkins
@@ -782,6 +795,7 @@ agent with liveness probe:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -885,6 +899,7 @@ agents with liveness probe:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -967,6 +982,7 @@ configure hostnetworking to agent:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1053,6 +1069,7 @@ custom dynamic pvc workspace volume:
                     requestsSize: "2Gi"
                     storageClassName: "gp2"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1137,6 +1154,7 @@ custom emptyDir workspace volume:
                   emptyDirWorkspaceVolume:
                     memory: true
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1221,6 +1239,7 @@ custom hostPath workspace volume:
                   hostPathWorkspaceVolume:
                     hostPath: "/data"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1302,6 +1321,7 @@ custom jenkins label:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1388,6 +1408,7 @@ custom nfs workspace volume:
                     serverAddress: "1.1.1.1"
                     serverPath: "/data"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1473,6 +1494,7 @@ custom other workspace volume:
                     claimName: "my-claim"
                     readOnly: false
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1558,6 +1580,7 @@ custom pvc workspace volume:
                     claimName: "my-claim"
                     readOnly: false
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1769,6 +1792,7 @@ default config:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1898,6 +1922,7 @@ empty projectNamingStrategy:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1979,6 +2004,7 @@ legacyRemotingSecurityEnabled = false:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2062,6 +2088,7 @@ legacyRemotingSecurityEnabled = true:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2146,6 +2173,7 @@ non-string projectNamingStrategy:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2226,6 +2254,7 @@ set directConnection:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2307,6 +2336,7 @@ set restrictedPssSecurityContext:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2397,6 +2427,7 @@ set secretEnvVars:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2494,6 +2525,7 @@ specify additional container:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2591,6 +2623,7 @@ specify additional container and clear in additional agent:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
                 id: c078dfa2d6d61ac696bae8d72eabe89baa3cd1aec30d75fe6b1aaacf31a95edd
@@ -2619,6 +2652,7 @@ specify additional container and clear in additional agent:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2716,6 +2750,7 @@ specify additional container and overwrite in additional agent:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
                 id: c53ea2695edf71fe73a0bdcf0daba85e433094671c1c152f8e183ffc9ab05855
@@ -2760,6 +2795,7 @@ specify additional container and overwrite in additional agent:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2841,6 +2877,7 @@ specify security settings with apiToken override:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2919,6 +2956,7 @@ specify security settings without apiToken override:
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true

--- a/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
@@ -42,7 +42,7 @@ additional clouds:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -90,7 +90,7 @@ additional clouds:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -172,7 +172,7 @@ additional clouds inheriting additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -201,7 +201,7 @@ additional clouds inheriting additional agents:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: c55bbaa8d121ac9b4d750ebf3a7a6959cae6bd7a3761cfeae267dd95572161e6
+                id: 9fa611fe5dfbb34bf1dffd17b510353212f493117275c2a1425a991d4fdeffa0
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -249,7 +249,7 @@ additional clouds inheriting additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -278,7 +278,7 @@ additional clouds inheriting additional agents:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: c55bbaa8d121ac9b4d750ebf3a7a6959cae6bd7a3761cfeae267dd95572161e6
+                id: 9fa611fe5dfbb34bf1dffd17b510353212f493117275c2a1425a991d4fdeffa0
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -360,7 +360,7 @@ additional clouds overriding additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -389,7 +389,7 @@ additional clouds overriding additional agents:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: c55bbaa8d121ac9b4d750ebf3a7a6959cae6bd7a3761cfeae267dd95572161e6
+                id: 9fa611fe5dfbb34bf1dffd17b510353212f493117275c2a1425a991d4fdeffa0
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -437,7 +437,7 @@ additional clouds overriding additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -523,7 +523,7 @@ adds custom labels on agent pods:
             templates:
               - name: "default"
                 namespace: "NAMESPACE"
-                id: 8f53ffd4799720c9cc886f4ec4bbef03bf164f8cad77c576f5653614efbeae2c
+                id: e1e3b0f333bde2739f7cbfc816c3e372377bc88f20c405f074c68d60170a8ea6
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -605,7 +605,7 @@ agent namespace and templates:
             templates:
               - name: "default"
                 namespace: "jenkins-agents"
-                id: c88a1905b24da70371d2778077a858e731955bd229f25b82331adfcc0a345d8e
+                id: 316bc79edd5f50e122fe5f1c362b27fdc804a8a79b6305462cc6e01d49c87270
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -634,7 +634,7 @@ agent namespace and templates:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 31452256c3147d4e880a3f254271bc958177b62440912e24d33ac4bbce3368ce
+                id: 535ab7168c785305f08312c3f09c8f7003a9ed4b95b062c0e33f2891d73ae2c5
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -663,7 +663,7 @@ agent namespace and templates:
                 inheritYamlMergeStrategy: false
               - name: "python"
                 namespace: "jenkins-agents"
-                id: 19d3d9a9feaa55daa63e6d28f716c725b03e7b11ac663caaf25ac9cb312e1a82
+                id: a51f0cf2998bfe44971344c255751aa03af9c4803295b1863f33a43cffd41f33
                 containers:
                 - name: "python"
                   alwaysPullImage: false
@@ -762,7 +762,7 @@ agent with liveness probe:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 9bd32deb5516e0003e93e906a57d412394f77f524326f98d7ff51a8e19d8589f
+                id: dba61b4e2e83c10e93744ea246fe7afa8c8d0ba4864a9ea66a9512eedd79749d
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -851,7 +851,7 @@ agents with liveness probe:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 8c2fa3140aae8357133e9c018ba35e731cd3ac87b3e2d03e8a916b139ccd7993
+                id: 2d4b01160b896b7e53070d8d0eb9ecbfb6217b8d691656eae2aed418b3769721
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -955,7 +955,7 @@ configure hostnetworking to agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 514d425a646a090a052906977d0b7725cb4984c5979acacbc1648f0c76614f85
+                id: 1f79e8d2a15eda318bc72d57887984fc76f5b2d46f182a96bfcc87c704fb4ae7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1038,7 +1038,7 @@ custom dynamic pvc workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: d2068cbc1d7d92cfb7a331667229ba6de76ce2387878fa2844a1601cb50414dc
+                id: 750b80b72067c32087eed32463fcf8805aabb491c2868b9ba910d6f1448fcd3f
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1125,7 +1125,7 @@ custom emptyDir workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 64830c23c018be5a08265247a9cc747ee71d7dac9698fa3a277390e64a4677d9
+                id: 6002ae8741564e37782ee72931fcfbbbcd71577749b6ae2e4a277560af6a712d
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1210,7 +1210,7 @@ custom hostPath workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: c0b8fe5b5155458b8958c9d675477e4d36959ee2b4dbd3f178cf4dc440465482
+                id: 05052d0d7a5bc9d233335a2c9f45208a6e1b4aa3fa888aba49f5d79e1ccf2771
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1295,7 +1295,7 @@ custom jenkins label:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1377,7 +1377,7 @@ custom nfs workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 6e7e3558f3aef50338678454bd2ff88b0849841b05a1b5654af0eb4d0fecce7d
+                id: de53177c7c7e46cfa0cd415e2746143699102ab1429edd40131277ec4e66a88b
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1464,7 +1464,7 @@ custom other workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 82b333a55c24b468c1247d9c0997e1b5d124f999f01521b4d80d5c2d9aeac20f
+                id: e1fd0f0d4a5b688ff3a7831573cc2cae84421e4a446c8cc895b2e886c3fd9018
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1550,7 +1550,7 @@ custom pvc workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: d251dde4e84f6a6431ce0ed47a688ad8c4f034353830cef70105ea0ec01b7ef3
+                id: 77241c1f9dfb28b90a20b9b07bd5ab61950857a8969f6e29592ff51a5ef34661
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1636,7 +1636,7 @@ customized config:
                 annotations:
                 - key: ci.jenkins-agent/test
                   value: "custom"
-                id: a7cd0cca1d5f06a7330de7aad512bdc3363a2e1841995cef1a446f1705efdcbb
+                id: dba455f7c62e2d39ff8d439a7189051d0398b6a79f20550498d55ce89b9e0e30
                 containers:
                 - name: "sideContainer"
                   alwaysPullImage: true
@@ -1710,6 +1710,7 @@ customized config:
                       operator: "Equal"
                       value: "value"
                 yamlMergeStrategy: merge
+                inheritYamlMergeStrategy: false
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1766,7 +1767,7 @@ default config:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1896,7 +1897,7 @@ empty projectNamingStrategy:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1978,7 +1979,7 @@ legacyRemotingSecurityEnabled = false:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2062,7 +2063,7 @@ legacyRemotingSecurityEnabled = true:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2147,7 +2148,7 @@ non-string projectNamingStrategy:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2228,7 +2229,7 @@ set directConnection:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 94ccfec218605a444ab56569da89ad1f05cf448677594b14f2c6511dd599ae60
+                id: 3673e9a95f8b487e656984afe9b5f6ea38d1928bfe799d7fa1b003cd734e668d
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2310,7 +2311,7 @@ set restrictedPssSecurityContext:
             templates:
               - name: "default"
                 namespace: "default"
-                id: bcc32856f5ae9025af118a0ab806aac13c9842d3c5dbdeb96cb90fd84d51ab49
+                id: fd958758a8afd9576d3d4cb608fff934aa593c851d9c28e113a8dd129c1442bf
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2392,7 +2393,7 @@ set secretEnvVars:
             templates:
               - name: "default"
                 namespace: "default"
-                id: ece91f962c9315968e77775820f5ffd834f410642767961fe4537c982b578cf3
+                id: a0f9498c9556f5c357ad0307258678d95fa17b55b3bf381391afc2568c034388
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2483,7 +2484,7 @@ specify additional container:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 744bcfc57335409f78a8b4d2844a5a91d1e5d0f871f7baf2e98d85bad659a6fa
+                id: f7971cc512b8a43ccf96e5c38c2a7eab589840478499fe082df149956dcd8903
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2581,7 +2582,7 @@ specify additional container and clear in additional agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 744bcfc57335409f78a8b4d2844a5a91d1e5d0f871f7baf2e98d85bad659a6fa
+                id: f7971cc512b8a43ccf96e5c38c2a7eab589840478499fe082df149956dcd8903
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2626,7 +2627,7 @@ specify additional container and clear in additional agent:
                 inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
-                id: c078dfa2d6d61ac696bae8d72eabe89baa3cd1aec30d75fe6b1aaacf31a95edd
+                id: 2ad3f4fa1fc8c134f4e9a3503a8834c688b1d3d78bc48f4879525e23acf758c8
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2708,7 +2709,7 @@ specify additional container and overwrite in additional agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 744bcfc57335409f78a8b4d2844a5a91d1e5d0f871f7baf2e98d85bad659a6fa
+                id: f7971cc512b8a43ccf96e5c38c2a7eab589840478499fe082df149956dcd8903
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2753,7 +2754,7 @@ specify additional container and overwrite in additional agent:
                 inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
-                id: c53ea2695edf71fe73a0bdcf0daba85e433094671c1c152f8e183ffc9ab05855
+                id: aa754edd6a296eff9bad25ac8acead9e17f98a24df025185a388afde458455f8
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2851,7 +2852,7 @@ specify security settings with apiToken override:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2930,7 +2931,7 @@ specify security settings without apiToken override:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 98d73d53e16a7cb91a7b32c4919957504f5605e430e5ca4da5878e8d7a0092ff
+                id: be2d42706452f6e88c95b5ea71d54a3ed6c7ce0918e743ae20e15bfd79331645
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -1085,6 +1085,8 @@ agent:
 
   # -- Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override"
   yamlMergeStrategy: "override"
+  # -- Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one 
+  inheritYamlMergeStrategy: false
   # -- Timeout in seconds for an agent to be online
   connectTimeout: 100
   # -- Annotations to apply to the pod

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -1085,7 +1085,7 @@ agent:
 
   # -- Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override"
   yamlMergeStrategy: "override"
-  # -- Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one 
+  # -- Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one
   inheritYamlMergeStrategy: false
   # -- Timeout in seconds for an agent to be online
   connectTimeout: 100


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

This pr exposes the configuration of `inheritYamlMergeStrategy` on the default agent via the chart values. The default value for this is set to `false` to match the default behaviour of the JCasC plugin.

The changes have been tested against a live jenkins deployment and the configuration is applied and behaves as expected. Tested with both the default value and overridden to `true`.




If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
