### PR TITLE
feat: add controller.topologySpreadConstraints

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.3.0
+
+Add controller.topologySpreadConstraints
+
 ## 5.2.2
 
 Update `kubernetes` to version `4246.v5a_12b_1fe120e`

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 5.3.0
 
-Add controller.topologySpreadConstraints
+Add `controller.topologySpreadConstraints`
 
 ## 5.2.2
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.2.2
+version: 5.3.0
 appVersion: 2.452.2
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -8,64 +8,64 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Key | Type | Description | Default |
 |:----|:-----|:---------|:------------|
-| [additionalAgents](./values.yaml#L1144) | object | Configure additional | `{}` |
-| [additionalClouds](./values.yaml#L1169) | object |  | `{}` |
-| [agent.TTYEnabled](./values.yaml#L1062) | bool | Allocate pseudo tty to the side container | `false` |
-| [agent.additionalContainers](./values.yaml#L1097) | list | Add additional containers to the agents | `[]` |
-| [agent.alwaysPullImage](./values.yaml#L955) | bool | Always pull agent container image before build | `false` |
-| [agent.annotations](./values.yaml#L1093) | object | Annotations to apply to the pod | `{}` |
-| [agent.args](./values.yaml#L1056) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
-| [agent.command](./values.yaml#L1054) | string | Command to execute when side container starts | `nil` |
-| [agent.componentName](./values.yaml#L923) | string |  | `"jenkins-agent"` |
-| [agent.connectTimeout](./values.yaml#L1091) | int | Timeout in seconds for an agent to be online | `100` |
-| [agent.containerCap](./values.yaml#L1064) | int | Max number of agents to launch | `10` |
-| [agent.customJenkinsLabels](./values.yaml#L920) | list | Append Jenkins labels to the agent | `[]` |
-| [agent.defaultsProviderTemplate](./values.yaml#L886) | string | The name of the pod template to use for providing default values | `""` |
-| [agent.directConnection](./values.yaml#L926) | bool |  | `false` |
-| [agent.disableDefaultAgent](./values.yaml#L1115) | bool | Disable the default Jenkins Agent configuration | `false` |
-| [agent.enabled](./values.yaml#L884) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
-| [agent.envVars](./values.yaml#L1037) | list | Environment variables for the agent Pod | `[]` |
-| [agent.hostNetworking](./values.yaml#L934) | bool | Enables the agent to use the host network | `false` |
-| [agent.idleMinutes](./values.yaml#L1069) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
-| [agent.image.repository](./values.yaml#L913) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
-| [agent.image.tag](./values.yaml#L915) | string | Tag of the image to pull | `"3248.v65ecb_254c298-1"` |
-| [agent.imagePullSecretName](./values.yaml#L922) | string | Name of the secret to be used to pull the image | `nil` |
-| [agent.inheritYamlMergeStrategy](./values.yaml#L1089) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
-| [agent.jenkinsTunnel](./values.yaml#L894) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
-| [agent.jenkinsUrl](./values.yaml#L890) | string | Overrides the Kubernetes Jenkins URL | `nil` |
-| [agent.jnlpregistry](./values.yaml#L910) | string | Custom registry used to pull the agent jnlp image from | `nil` |
-| [agent.kubernetesConnectTimeout](./values.yaml#L896) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
-| [agent.kubernetesReadTimeout](./values.yaml#L898) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
-| [agent.livenessProbe](./values.yaml#L945) | object |  | `{}` |
-| [agent.maxRequestsPerHostStr](./values.yaml#L900) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
-| [agent.namespace](./values.yaml#L906) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
-| [agent.nodeSelector](./values.yaml#L1048) | object | Node labels for pod assignment | `{}` |
-| [agent.nodeUsageMode](./values.yaml#L918) | string |  | `"NORMAL"` |
-| [agent.podLabels](./values.yaml#L908) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
-| [agent.podName](./values.yaml#L1066) | string | Agent Pod base name | `"default"` |
-| [agent.podRetention](./values.yaml#L964) | string |  | `"Never"` |
-| [agent.podTemplates](./values.yaml#L1125) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
-| [agent.privileged](./values.yaml#L928) | bool | Agent privileged container | `false` |
-| [agent.resources](./values.yaml#L936) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
-| [agent.restrictedPssSecurityContext](./values.yaml#L961) | bool | Set a restricted securityContext on jnlp containers | `false` |
-| [agent.retentionTimeout](./values.yaml#L902) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
-| [agent.runAsGroup](./values.yaml#L932) | string | Configure container group | `nil` |
-| [agent.runAsUser](./values.yaml#L930) | string | Configure container user | `nil` |
-| [agent.secretEnvVars](./values.yaml#L1041) | list | Mount a secret as environment variable | `[]` |
-| [agent.showRawYaml](./values.yaml#L968) | bool |  | `true` |
-| [agent.sideContainerName](./values.yaml#L1058) | string | Side container name | `"jnlp"` |
-| [agent.volumes](./values.yaml#L975) | list | Additional volumes | `[]` |
-| [agent.waitForPodSec](./values.yaml#L904) | int | Seconds to wait for pod to be running | `600` |
-| [agent.websocket](./values.yaml#L925) | bool | Enables agent communication via websockets | `false` |
-| [agent.workingDir](./values.yaml#L917) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
-| [agent.workspaceVolume](./values.yaml#L1010) | object | Workspace volume (defaults to EmptyDir) | `{}` |
-| [agent.yamlMergeStrategy](./values.yaml#L1087) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
-| [agent.yamlTemplate](./values.yaml#L1076) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1295) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1297) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1299) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1298) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1292) | bool | Checks if any deprecated values are used | `true` |
+| [additionalAgents](./values.yaml#L1147) | object | Configure additional | `{}` |
+| [additionalClouds](./values.yaml#L1172) | object |  | `{}` |
+| [agent.TTYEnabled](./values.yaml#L1065) | bool | Allocate pseudo tty to the side container | `false` |
+| [agent.additionalContainers](./values.yaml#L1100) | list | Add additional containers to the agents | `[]` |
+| [agent.alwaysPullImage](./values.yaml#L958) | bool | Always pull agent container image before build | `false` |
+| [agent.annotations](./values.yaml#L1096) | object | Annotations to apply to the pod | `{}` |
+| [agent.args](./values.yaml#L1059) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
+| [agent.command](./values.yaml#L1057) | string | Command to execute when side container starts | `nil` |
+| [agent.componentName](./values.yaml#L926) | string |  | `"jenkins-agent"` |
+| [agent.connectTimeout](./values.yaml#L1094) | int | Timeout in seconds for an agent to be online | `100` |
+| [agent.containerCap](./values.yaml#L1067) | int | Max number of agents to launch | `10` |
+| [agent.customJenkinsLabels](./values.yaml#L923) | list | Append Jenkins labels to the agent | `[]` |
+| [agent.defaultsProviderTemplate](./values.yaml#L889) | string | The name of the pod template to use for providing default values | `""` |
+| [agent.directConnection](./values.yaml#L929) | bool |  | `false` |
+| [agent.disableDefaultAgent](./values.yaml#L1118) | bool | Disable the default Jenkins Agent configuration | `false` |
+| [agent.enabled](./values.yaml#L887) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
+| [agent.envVars](./values.yaml#L1040) | list | Environment variables for the agent Pod | `[]` |
+| [agent.hostNetworking](./values.yaml#L937) | bool | Enables the agent to use the host network | `false` |
+| [agent.idleMinutes](./values.yaml#L1072) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
+| [agent.image.repository](./values.yaml#L916) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
+| [agent.image.tag](./values.yaml#L918) | string | Tag of the image to pull | `"3248.v65ecb_254c298-1"` |
+| [agent.imagePullSecretName](./values.yaml#L925) | string | Name of the secret to be used to pull the image | `nil` |
+| [agent.inheritYamlMergeStrategy](./values.yaml#L1092) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
+| [agent.jenkinsTunnel](./values.yaml#L897) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
+| [agent.jenkinsUrl](./values.yaml#L893) | string | Overrides the Kubernetes Jenkins URL | `nil` |
+| [agent.jnlpregistry](./values.yaml#L913) | string | Custom registry used to pull the agent jnlp image from | `nil` |
+| [agent.kubernetesConnectTimeout](./values.yaml#L899) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
+| [agent.kubernetesReadTimeout](./values.yaml#L901) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
+| [agent.livenessProbe](./values.yaml#L948) | object |  | `{}` |
+| [agent.maxRequestsPerHostStr](./values.yaml#L903) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
+| [agent.namespace](./values.yaml#L909) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
+| [agent.nodeSelector](./values.yaml#L1051) | object | Node labels for pod assignment | `{}` |
+| [agent.nodeUsageMode](./values.yaml#L921) | string |  | `"NORMAL"` |
+| [agent.podLabels](./values.yaml#L911) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
+| [agent.podName](./values.yaml#L1069) | string | Agent Pod base name | `"default"` |
+| [agent.podRetention](./values.yaml#L967) | string |  | `"Never"` |
+| [agent.podTemplates](./values.yaml#L1128) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
+| [agent.privileged](./values.yaml#L931) | bool | Agent privileged container | `false` |
+| [agent.resources](./values.yaml#L939) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
+| [agent.restrictedPssSecurityContext](./values.yaml#L964) | bool | Set a restricted securityContext on jnlp containers | `false` |
+| [agent.retentionTimeout](./values.yaml#L905) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
+| [agent.runAsGroup](./values.yaml#L935) | string | Configure container group | `nil` |
+| [agent.runAsUser](./values.yaml#L933) | string | Configure container user | `nil` |
+| [agent.secretEnvVars](./values.yaml#L1044) | list | Mount a secret as environment variable | `[]` |
+| [agent.showRawYaml](./values.yaml#L971) | bool |  | `true` |
+| [agent.sideContainerName](./values.yaml#L1061) | string | Side container name | `"jnlp"` |
+| [agent.volumes](./values.yaml#L978) | list | Additional volumes | `[]` |
+| [agent.waitForPodSec](./values.yaml#L907) | int | Seconds to wait for pod to be running | `600` |
+| [agent.websocket](./values.yaml#L928) | bool | Enables agent communication via websockets | `false` |
+| [agent.workingDir](./values.yaml#L920) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
+| [agent.workspaceVolume](./values.yaml#L1013) | object | Workspace volume (defaults to EmptyDir) | `{}` |
+| [agent.yamlMergeStrategy](./values.yaml#L1090) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
+| [agent.yamlTemplate](./values.yaml#L1079) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1298) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1300) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1302) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1301) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1295) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L533) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L538) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -94,12 +94,12 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.agentListenerPort](./values.yaml#L320) | int | Listening port for agents | `50000` |
 | [controller.agentListenerServiceAnnotations](./values.yaml#L353) | object | Annotations for the agentListener service | `{}` |
 | [controller.agentListenerServiceType](./values.yaml#L350) | string | Defines how to expose the agentListener service | `"ClusterIP"` |
-| [controller.backendconfig.annotations](./values.yaml#L742) | object | backendconfig annotations | `{}` |
-| [controller.backendconfig.apiVersion](./values.yaml#L736) | string | backendconfig API version | `"extensions/v1beta1"` |
-| [controller.backendconfig.enabled](./values.yaml#L734) | bool | Enables backendconfig | `false` |
-| [controller.backendconfig.labels](./values.yaml#L740) | object | backendconfig labels | `{}` |
-| [controller.backendconfig.name](./values.yaml#L738) | string | backendconfig name | `nil` |
-| [controller.backendconfig.spec](./values.yaml#L744) | object | backendconfig spec | `{}` |
+| [controller.backendconfig.annotations](./values.yaml#L745) | object | backendconfig annotations | `{}` |
+| [controller.backendconfig.apiVersion](./values.yaml#L739) | string | backendconfig API version | `"extensions/v1beta1"` |
+| [controller.backendconfig.enabled](./values.yaml#L737) | bool | Enables backendconfig | `false` |
+| [controller.backendconfig.labels](./values.yaml#L743) | object | backendconfig labels | `{}` |
+| [controller.backendconfig.name](./values.yaml#L741) | string | backendconfig name | `nil` |
+| [controller.backendconfig.spec](./values.yaml#L747) | object | backendconfig spec | `{}` |
 | [controller.cloudName](./values.yaml#L487) | string | Name of default cloud configuration. | `"kubernetes"` |
 | [controller.clusterIp](./values.yaml#L217) | string | k8s service clusterIP. Only used if serviceType is ClusterIP | `nil` |
 | [controller.componentName](./values.yaml#L34) | string | Used for label app.kubernetes.io/component | `"jenkins-controller"` |
@@ -117,38 +117,38 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.existingSecret](./values.yaml#L456) | string |  | `nil` |
 | [controller.extraPorts](./values.yaml#L388) | list | Optionally configure other ports to expose in the controller container | `[]` |
 | [controller.fsGroup](./values.yaml#L186) | int | Deprecated in favor of `controller.podSecurityContextOverride`. uid that will be used for persistent volume. | `1000` |
-| [controller.googlePodMonitor.enabled](./values.yaml#L805) | bool |  | `false` |
-| [controller.googlePodMonitor.scrapeEndpoint](./values.yaml#L810) | string |  | `"/prometheus"` |
-| [controller.googlePodMonitor.scrapeInterval](./values.yaml#L808) | string |  | `"60s"` |
+| [controller.googlePodMonitor.enabled](./values.yaml#L808) | bool |  | `false` |
+| [controller.googlePodMonitor.scrapeEndpoint](./values.yaml#L813) | string |  | `"/prometheus"` |
+| [controller.googlePodMonitor.scrapeInterval](./values.yaml#L811) | string |  | `"60s"` |
 | [controller.healthProbes](./values.yaml#L248) | bool | Enable Kubernetes Probes configuration configured in `controller.probes` | `true` |
-| [controller.hostAliases](./values.yaml#L758) | list | Allows for adding entries to Pod /etc/hosts | `[]` |
+| [controller.hostAliases](./values.yaml#L761) | list | Allows for adding entries to Pod /etc/hosts | `[]` |
 | [controller.hostNetworking](./values.yaml#L70) | bool |  | `false` |
-| [controller.httpsKeyStore.disableSecretMount](./values.yaml#L826) | bool |  | `false` |
-| [controller.httpsKeyStore.enable](./values.yaml#L817) | bool | Enables HTTPS keystore on jenkins controller | `false` |
-| [controller.httpsKeyStore.fileName](./values.yaml#L834) | string | Jenkins keystore filename which will appear under controller.httpsKeyStore.path | `"keystore.jks"` |
-| [controller.httpsKeyStore.httpPort](./values.yaml#L830) | int | HTTP Port that Jenkins should listen to along with HTTPS, it also serves as the liveness and readiness probes port. | `8081` |
-| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretKey](./values.yaml#L825) | string | Name of the key in the secret that contains the JKS password | `"https-jks-password"` |
-| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName](./values.yaml#L823) | string | Name of the secret that contains the JKS password, if it is not in the same secret as the JKS file | `""` |
-| [controller.httpsKeyStore.jenkinsHttpsJksSecretKey](./values.yaml#L821) | string | Name of the key in the secret that already has ssl keystore | `"jenkins-jks-file"` |
-| [controller.httpsKeyStore.jenkinsHttpsJksSecretName](./values.yaml#L819) | string | Name of the secret that already has ssl keystore | `""` |
-| [controller.httpsKeyStore.jenkinsKeyStoreBase64Encoded](./values.yaml#L839) | string | Base64 encoded Keystore content. Keystore must be converted to base64 then being pasted here | `nil` |
-| [controller.httpsKeyStore.password](./values.yaml#L836) | string | Jenkins keystore password | `"password"` |
-| [controller.httpsKeyStore.path](./values.yaml#L832) | string | Path of HTTPS keystore file | `"/var/jenkins_keystore"` |
+| [controller.httpsKeyStore.disableSecretMount](./values.yaml#L829) | bool |  | `false` |
+| [controller.httpsKeyStore.enable](./values.yaml#L820) | bool | Enables HTTPS keystore on jenkins controller | `false` |
+| [controller.httpsKeyStore.fileName](./values.yaml#L837) | string | Jenkins keystore filename which will appear under controller.httpsKeyStore.path | `"keystore.jks"` |
+| [controller.httpsKeyStore.httpPort](./values.yaml#L833) | int | HTTP Port that Jenkins should listen to along with HTTPS, it also serves as the liveness and readiness probes port. | `8081` |
+| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretKey](./values.yaml#L828) | string | Name of the key in the secret that contains the JKS password | `"https-jks-password"` |
+| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName](./values.yaml#L826) | string | Name of the secret that contains the JKS password, if it is not in the same secret as the JKS file | `""` |
+| [controller.httpsKeyStore.jenkinsHttpsJksSecretKey](./values.yaml#L824) | string | Name of the key in the secret that already has ssl keystore | `"jenkins-jks-file"` |
+| [controller.httpsKeyStore.jenkinsHttpsJksSecretName](./values.yaml#L822) | string | Name of the secret that already has ssl keystore | `""` |
+| [controller.httpsKeyStore.jenkinsKeyStoreBase64Encoded](./values.yaml#L842) | string | Base64 encoded Keystore content. Keystore must be converted to base64 then being pasted here | `nil` |
+| [controller.httpsKeyStore.password](./values.yaml#L839) | string | Jenkins keystore password | `"password"` |
+| [controller.httpsKeyStore.path](./values.yaml#L835) | string | Path of HTTPS keystore file | `"/var/jenkins_keystore"` |
 | [controller.image.pullPolicy](./values.yaml#L47) | string | Controller image pull policy | `"Always"` |
 | [controller.image.registry](./values.yaml#L37) | string | Controller image registry | `"docker.io"` |
 | [controller.image.repository](./values.yaml#L39) | string | Controller image repository | `"jenkins/jenkins"` |
 | [controller.image.tag](./values.yaml#L42) | string | Controller image tag override; i.e., tag: "2.440.1-jdk17" | `nil` |
 | [controller.image.tagLabel](./values.yaml#L45) | string | Controller image tag label | `"jdk17"` |
 | [controller.imagePullSecretName](./values.yaml#L49) | string | Controller image pull secret | `nil` |
-| [controller.ingress.annotations](./values.yaml#L681) | object | Ingress annotations | `{}` |
-| [controller.ingress.apiVersion](./values.yaml#L677) | string | Ingress API version | `"extensions/v1beta1"` |
-| [controller.ingress.enabled](./values.yaml#L660) | bool | Enables ingress | `false` |
-| [controller.ingress.hostName](./values.yaml#L694) | string | Ingress hostname | `nil` |
-| [controller.ingress.labels](./values.yaml#L679) | object | Ingress labels | `{}` |
-| [controller.ingress.path](./values.yaml#L690) | string | Ingress path | `nil` |
-| [controller.ingress.paths](./values.yaml#L664) | list | Override for the default Ingress paths | `[]` |
-| [controller.ingress.resourceRootUrl](./values.yaml#L696) | string | Hostname to serve assets from | `nil` |
-| [controller.ingress.tls](./values.yaml#L698) | list | Ingress TLS configuration | `[]` |
+| [controller.ingress.annotations](./values.yaml#L684) | object | Ingress annotations | `{}` |
+| [controller.ingress.apiVersion](./values.yaml#L680) | string | Ingress API version | `"extensions/v1beta1"` |
+| [controller.ingress.enabled](./values.yaml#L663) | bool | Enables ingress | `false` |
+| [controller.ingress.hostName](./values.yaml#L697) | string | Ingress hostname | `nil` |
+| [controller.ingress.labels](./values.yaml#L682) | object | Ingress labels | `{}` |
+| [controller.ingress.path](./values.yaml#L693) | string | Ingress path | `nil` |
+| [controller.ingress.paths](./values.yaml#L667) | list | Override for the default Ingress paths | `[]` |
+| [controller.ingress.resourceRootUrl](./values.yaml#L699) | string | Hostname to serve assets from | `nil` |
+| [controller.ingress.tls](./values.yaml#L701) | list | Ingress TLS configuration | `[]` |
 | [controller.initConfigMap](./values.yaml#L446) | string | Name of the existing ConfigMap that contains init scripts | `nil` |
 | [controller.initContainerEnv](./values.yaml#L141) | list | Environment variables for Init Container | `[]` |
 | [controller.initContainerEnvFrom](./values.yaml#L137) | list | Environment variable sources for Init Container | `[]` |
@@ -205,31 +205,31 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.probes.startupProbe.periodSeconds](./values.yaml#L260) | int | Set the time interval between two startup probes executions in seconds | `10` |
 | [controller.probes.startupProbe.timeoutSeconds](./values.yaml#L262) | int | Set the timeout for the startup probe in seconds | `5` |
 | [controller.projectNamingStrategy](./values.yaml#L425) | string |  | `"standard"` |
-| [controller.prometheus.alertingRulesAdditionalLabels](./values.yaml#L791) | object | Additional labels to add to the PrometheusRule object | `{}` |
-| [controller.prometheus.alertingrules](./values.yaml#L789) | list | Array of prometheus alerting rules | `[]` |
-| [controller.prometheus.enabled](./values.yaml#L774) | bool | Enables prometheus service monitor | `false` |
-| [controller.prometheus.metricRelabelings](./values.yaml#L801) | list |  | `[]` |
-| [controller.prometheus.prometheusRuleNamespace](./values.yaml#L793) | string | Set a custom namespace where to deploy PrometheusRule resource | `""` |
-| [controller.prometheus.relabelings](./values.yaml#L799) | list |  | `[]` |
-| [controller.prometheus.scrapeEndpoint](./values.yaml#L784) | string | The endpoint prometheus should get metrics from | `"/prometheus"` |
-| [controller.prometheus.scrapeInterval](./values.yaml#L780) | string | How often prometheus should scrape metrics | `"60s"` |
-| [controller.prometheus.serviceMonitorAdditionalLabels](./values.yaml#L776) | object | Additional labels to add to the service monitor object | `{}` |
-| [controller.prometheus.serviceMonitorNamespace](./values.yaml#L778) | string | Set a custom namespace where to deploy ServiceMonitor resource | `nil` |
+| [controller.prometheus.alertingRulesAdditionalLabels](./values.yaml#L794) | object | Additional labels to add to the PrometheusRule object | `{}` |
+| [controller.prometheus.alertingrules](./values.yaml#L792) | list | Array of prometheus alerting rules | `[]` |
+| [controller.prometheus.enabled](./values.yaml#L777) | bool | Enables prometheus service monitor | `false` |
+| [controller.prometheus.metricRelabelings](./values.yaml#L804) | list |  | `[]` |
+| [controller.prometheus.prometheusRuleNamespace](./values.yaml#L796) | string | Set a custom namespace where to deploy PrometheusRule resource | `""` |
+| [controller.prometheus.relabelings](./values.yaml#L802) | list |  | `[]` |
+| [controller.prometheus.scrapeEndpoint](./values.yaml#L787) | string | The endpoint prometheus should get metrics from | `"/prometheus"` |
+| [controller.prometheus.scrapeInterval](./values.yaml#L783) | string | How often prometheus should scrape metrics | `"60s"` |
+| [controller.prometheus.serviceMonitorAdditionalLabels](./values.yaml#L779) | object | Additional labels to add to the service monitor object | `{}` |
+| [controller.prometheus.serviceMonitorNamespace](./values.yaml#L781) | string | Set a custom namespace where to deploy ServiceMonitor resource | `nil` |
 | [controller.resources](./values.yaml#L115) | object | Resource allocation (Requests and Limits) | `{"limits":{"cpu":"2000m","memory":"4096Mi"},"requests":{"cpu":"50m","memory":"256Mi"}}` |
-| [controller.route.annotations](./values.yaml#L753) | object | Route annotations | `{}` |
-| [controller.route.enabled](./values.yaml#L749) | bool | Enables openshift route | `false` |
-| [controller.route.labels](./values.yaml#L751) | object | Route labels | `{}` |
-| [controller.route.path](./values.yaml#L755) | string | Route path | `nil` |
+| [controller.route.annotations](./values.yaml#L756) | object | Route annotations | `{}` |
+| [controller.route.enabled](./values.yaml#L752) | bool | Enables openshift route | `false` |
+| [controller.route.labels](./values.yaml#L754) | object | Route labels | `{}` |
+| [controller.route.path](./values.yaml#L758) | string | Route path | `nil` |
 | [controller.runAsUser](./values.yaml#L183) | int | Deprecated in favor of `controller.podSecurityContextOverride`. uid that jenkins runs with. | `1000` |
 | [controller.schedulerName](./values.yaml#L625) | string | Name of the Kubernetes scheduler to use | `""` |
 | [controller.scriptApproval](./values.yaml#L437) | list | List of groovy functions to approve | `[]` |
-| [controller.secondaryingress.annotations](./values.yaml#L716) | object |  | `{}` |
-| [controller.secondaryingress.apiVersion](./values.yaml#L714) | string |  | `"extensions/v1beta1"` |
-| [controller.secondaryingress.enabled](./values.yaml#L708) | bool |  | `false` |
-| [controller.secondaryingress.hostName](./values.yaml#L723) | string |  | `nil` |
-| [controller.secondaryingress.labels](./values.yaml#L715) | object |  | `{}` |
-| [controller.secondaryingress.paths](./values.yaml#L711) | list |  | `[]` |
-| [controller.secondaryingress.tls](./values.yaml#L724) | string |  | `nil` |
+| [controller.secondaryingress.annotations](./values.yaml#L719) | object |  | `{}` |
+| [controller.secondaryingress.apiVersion](./values.yaml#L717) | string |  | `"extensions/v1beta1"` |
+| [controller.secondaryingress.enabled](./values.yaml#L711) | bool |  | `false` |
+| [controller.secondaryingress.hostName](./values.yaml#L726) | string |  | `nil` |
+| [controller.secondaryingress.labels](./values.yaml#L718) | object |  | `{}` |
+| [controller.secondaryingress.paths](./values.yaml#L714) | list |  | `[]` |
+| [controller.secondaryingress.tls](./values.yaml#L727) | string |  | `nil` |
 | [controller.secretClaims](./values.yaml#L480) | list | List of `SecretClaim` resources to create | `[]` |
 | [controller.securityContextCapabilities](./values.yaml#L192) | object |  | `{}` |
 | [controller.serviceAnnotations](./values.yaml#L230) | object | Jenkins controller service annotations | `{}` |
@@ -260,46 +260,47 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.terminationGracePeriodSeconds](./values.yaml#L635) | string | Set TerminationGracePeriodSeconds | `nil` |
 | [controller.terminationMessagePath](./values.yaml#L637) | string | Set the termination message path | `nil` |
 | [controller.terminationMessagePolicy](./values.yaml#L639) | string | Set the termination message policy | `nil` |
-| [controller.testEnabled](./values.yaml#L813) | bool | Can be used to disable rendering controller test resources when using helm template | `true` |
+| [controller.testEnabled](./values.yaml#L816) | bool | Can be used to disable rendering controller test resources when using helm template | `true` |
 | [controller.tolerations](./values.yaml#L633) | list | Toleration labels for pod assignment | `[]` |
+| [controller.topologySpreadConstraints](./values.yaml#L659) | object | Topology spread constraints | `{}` |
 | [controller.updateStrategy](./values.yaml#L656) | object | Update strategy for StatefulSet | `{}` |
 | [controller.usePodSecurityContext](./values.yaml#L176) | bool | Enable pod security context (must be `true` if podSecurityContextOverride, runAsUser or fsGroup are set) | `true` |
 | [credentialsId](./values.yaml#L27) | string | The Jenkins credentials to access the Kubernetes API server. For the default cluster it is not needed. | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1308) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1310) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1312) | string | Tag of the image to test the framework | `"1.11.0"` |
+| [helmtest.bats.image.registry](./values.yaml#L1311) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1313) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1315) | string | Tag of the image to test the framework | `"1.11.0"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
-| [networkPolicy.apiVersion](./values.yaml#L1238) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
-| [networkPolicy.enabled](./values.yaml#L1233) | bool | Enable the creation of NetworkPolicy resources | `false` |
-| [networkPolicy.externalAgents.except](./values.yaml#L1252) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
-| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1250) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
-| [networkPolicy.internalAgents.allowed](./values.yaml#L1242) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
-| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1246) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
-| [networkPolicy.internalAgents.podLabels](./values.yaml#L1244) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
-| [persistence.accessMode](./values.yaml#L1208) | string | The PVC access mode | `"ReadWriteOnce"` |
-| [persistence.annotations](./values.yaml#L1204) | object | Annotations for the PVC | `{}` |
-| [persistence.dataSource](./values.yaml#L1214) | object | Existing data source to clone PVC from | `{}` |
-| [persistence.enabled](./values.yaml#L1188) | bool | Enable the use of a Jenkins PVC | `true` |
-| [persistence.existingClaim](./values.yaml#L1194) | string | Provide the name of a PVC | `nil` |
-| [persistence.labels](./values.yaml#L1206) | object | Labels for the PVC | `{}` |
-| [persistence.mounts](./values.yaml#L1226) | list | Additional mounts | `[]` |
-| [persistence.size](./values.yaml#L1210) | string | The size of the PVC | `"8Gi"` |
-| [persistence.storageClass](./values.yaml#L1202) | string | Storage class for the PVC | `nil` |
-| [persistence.subPath](./values.yaml#L1219) | string | SubPath for jenkins-home mount | `nil` |
-| [persistence.volumes](./values.yaml#L1221) | list | Additional volumes | `[]` |
-| [rbac.create](./values.yaml#L1258) | bool | Whether RBAC resources are created | `true` |
-| [rbac.readSecrets](./values.yaml#L1260) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
+| [networkPolicy.apiVersion](./values.yaml#L1241) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
+| [networkPolicy.enabled](./values.yaml#L1236) | bool | Enable the creation of NetworkPolicy resources | `false` |
+| [networkPolicy.externalAgents.except](./values.yaml#L1255) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
+| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1253) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
+| [networkPolicy.internalAgents.allowed](./values.yaml#L1245) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
+| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1249) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
+| [networkPolicy.internalAgents.podLabels](./values.yaml#L1247) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
+| [persistence.accessMode](./values.yaml#L1211) | string | The PVC access mode | `"ReadWriteOnce"` |
+| [persistence.annotations](./values.yaml#L1207) | object | Annotations for the PVC | `{}` |
+| [persistence.dataSource](./values.yaml#L1217) | object | Existing data source to clone PVC from | `{}` |
+| [persistence.enabled](./values.yaml#L1191) | bool | Enable the use of a Jenkins PVC | `true` |
+| [persistence.existingClaim](./values.yaml#L1197) | string | Provide the name of a PVC | `nil` |
+| [persistence.labels](./values.yaml#L1209) | object | Labels for the PVC | `{}` |
+| [persistence.mounts](./values.yaml#L1229) | list | Additional mounts | `[]` |
+| [persistence.size](./values.yaml#L1213) | string | The size of the PVC | `"8Gi"` |
+| [persistence.storageClass](./values.yaml#L1205) | string | Storage class for the PVC | `nil` |
+| [persistence.subPath](./values.yaml#L1222) | string | SubPath for jenkins-home mount | `nil` |
+| [persistence.volumes](./values.yaml#L1224) | list | Additional volumes | `[]` |
+| [rbac.create](./values.yaml#L1261) | bool | Whether RBAC resources are created | `true` |
+| [rbac.readSecrets](./values.yaml#L1263) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
-| [serviceAccount.annotations](./values.yaml#L1270) | object | Configures annotations for the ServiceAccount | `{}` |
-| [serviceAccount.create](./values.yaml#L1264) | bool | Configures if a ServiceAccount with this name should be created | `true` |
-| [serviceAccount.extraLabels](./values.yaml#L1272) | object | Configures extra labels for the ServiceAccount | `{}` |
-| [serviceAccount.imagePullSecretName](./values.yaml#L1274) | string | Controller ServiceAccount image pull secret | `nil` |
-| [serviceAccount.name](./values.yaml#L1268) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1285) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.create](./values.yaml#L1279) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1287) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1289) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1283) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccount.annotations](./values.yaml#L1273) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.create](./values.yaml#L1267) | bool | Configures if a ServiceAccount with this name should be created | `true` |
+| [serviceAccount.extraLabels](./values.yaml#L1275) | object | Configures extra labels for the ServiceAccount | `{}` |
+| [serviceAccount.imagePullSecretName](./values.yaml#L1277) | string | Controller ServiceAccount image pull secret | `nil` |
+| [serviceAccount.name](./values.yaml#L1271) | string |  | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1288) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.create](./values.yaml#L1282) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1290) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1292) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1286) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -67,6 +67,10 @@ spec:
       affinity:
 {{ toYaml .Values.controller.affinity | indent 8 }}
       {{- end }}
+      {{- if .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.controller.topologySpreadConstraints | indent 8 }}
+      {{- end }}
       {{- if quote .Values.controller.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       {{- end }}

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -63,6 +63,13 @@ tests:
                     values:
                       - S1
               topologyKey: failure-domain.beta.kubernetes.io/zone
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: "topology.kubernetes.io/zone"
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: jenkins-controller
         terminationGracePeriodSeconds: 120
         priorityClassName: important
         runAsUser: 2000
@@ -110,6 +117,15 @@ tests:
                       values:
                         - S1
                 topologyKey: failure-domain.beta.kubernetes.io/zone
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 1
+              topologyKey: "topology.kubernetes.io/zone"
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: jenkins-controller
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
           value: 120

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -655,6 +655,9 @@ controller:
   # -- Update strategy for StatefulSet
   updateStrategy: {}
 
+  # -- Topology spread constraints
+  topologySpreadConstraints: {}
+
   ingress:
     # -- Enables ingress
     enabled: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

We host multiple jenkins controllers in one of our EKS clusters and we need to be able to spread the controller pods across topology domains.

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
