### PR TITLE
chore(deps): update super-linter to v6.7.0

### DIFF
--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "terminology": {
+      "exclude": [
+        "Git",
+        "XML",
+        "YAML"
+      ]
+    }
+  }
+}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,12 +15,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Lint Code Base
-        uses: super-linter/super-linter@v6.5.1
+        uses: super-linter/super-linter@v6.7.0
         env:
           VALIDATE_ALL_CODEBASE: true
-          VALIDATE_KUBERNETES_KUBECONFORM: false
-          VALIDATE_JSCPD: false
+          VALIDATE_CHECKOV: false
           VALIDATE_GITLEAKS: false
+          VALIDATE_JSCPD: false
+          VALIDATE_KUBERNETES_KUBECONFORM: false
           VALIDATE_YAML: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ The chart `version` should follow [SemVer](https://semver.org/).
 Charts should start at `1.0.0`. Any breaking (backwards incompatible) changes to a chart should:
 
 1. Bump the MAJOR version
-2. In the README, under a section called "Upgrading", describe the manual steps necessary to upgrade to the new (specified) MAJOR version
+2. In the readme, under a section called "Upgrading", describe the manual steps necessary to upgrade to the new (specified) MAJOR version
 
 ### Community Requirements
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.3.4
+
+Update CHANGELOG.md, README.md, and UPGRADING.md for linting
+
 ## 5.3.3
 
 Update `jenkins/inbound-agent` to version `3256.v88a_f6e922152-1`
@@ -346,7 +350,7 @@ Changes in 4.7.0 were reverted.
 
 ## 4.7.0
 
-Runs `config-reload` as an init container, in addition to the sidecar container, to ensure that JCasC YAMLS are present before the main Jenkins container starts. This should fix some race conditions and crashes on startup.
+Runs `config-reload` as an init container, in addition to the sidecar container, to ensure that JCasC YAMLs are present before the main Jenkins container starts. This should fix some race conditions and crashes on startup.
 
 ## 4.6.7
 
@@ -512,7 +516,7 @@ Disable volume mount if disableSecretMount enabled
 
 ## 4.3.9
 
-Document `.Values.agent.directConnection` in README.
+Document `.Values.agent.directConnection` in readme.
 Add default value for `.Values.agent.directConnection` to `values.yaml`
 
 ## 4.3.8
@@ -704,7 +708,7 @@ Fix path of projected secrets from `additionalExistingSecrets`.
 
 ## 4.1.7
 
-Update README with explanation on the required environmental variable `AWS_REGION` in case of using an S3 bucket.
+Update readme with explanation on the required environmental variable `AWS_REGION` in case of using an S3 bucket.
 
 ## 4.1.6
 
@@ -712,7 +716,7 @@ project adminSecret, additionalSecrets and additionalExistingSecrets instead of 
 
 ## 4.1.5
 
-Update README to fix `JAVA_OPTS` name.
+Update readme to fix `JAVA_OPTS` name.
 
 ## 4.1.4
 Update plugins
@@ -827,7 +831,7 @@ Update default plugin versions
 
 ## 3.9.4
 
-Add JAVA_OPTIONS to the README so proxy settings get picked by jenkins-plugin-cli
+Add JAVA_OPTIONS to the readme so proxy settings get picked by jenkins-plugin-cli
 
 ## 3.9.3
 
@@ -1120,7 +1124,7 @@ Update Jenkins image and appVersion to jenkins lts release version 2.263.4
 
 ## 3.1.12
 
-Added GitHub action to automate the updating of LTS releases.
+Added GitHub Action to automate the updating of LTS releases.
 
 ## 3.1.11
 
@@ -1324,7 +1328,7 @@ Added unit tests for most resources in the Helm chart.
 
 ## 2.12.1
 
-Helm chart README update
+Helm chart readme update
 
 ## 2.12.0
 
@@ -1386,7 +1390,7 @@ Fixes #19
 
 ## 2.6.0 First release in jenkinsci GitHub org
 
-Updated README for new location
+Updated readme for new location
 
 ## 2.5.2
 
@@ -1402,7 +1406,7 @@ Add an option to specify that Jenkins master should be initialized only once, du
 
 ## 2.4.1
 
-Reorder README parameters into sections to facilitate chart usage and maintenance
+Reorder readme parameters into sections to facilitate chart usage and maintenance
 
 ## 2.4.0 Update default agent image
 
@@ -1436,7 +1440,7 @@ Configure `REQ_RETRY_CONNECT` to `10` to give Jenkins more time to start up.
 
 Value can be configured via `master.sidecars.configAutoReload.reqRetryConnect`
 
-## 2.1.2 updated README
+## 2.1.2 updated readme
 
 ## 2.1.1 update credentials-binding plugin to 1.23
 
@@ -1450,7 +1454,7 @@ Only render authorizationStrategy and securityRealm when values are set.
 
 ## 2.0.0 Configuration as Code now default + container does not run as root anymore
 
-The README contains more details for this update.
+The readme contains more details for this update.
 Please note that the updated values contain breaking changes.
 
 ## 1.27.0 Update plugin versions & sidecar container
@@ -1615,7 +1619,7 @@ In recent version of configuration-as-code-plugin this is no longer necessary.
 
 ## 1.9.24
 
-Update JCasC auto-reload docs and remove stale ssh key references from version "1.8.0 JCasC auto reload works without ssh keys"
+Update JCasC auto-reload docs and remove stale SSH key references from version "1.8.0 JCasC auto reload works without SSH keys"
 
 ## 1.9.23 Support jenkinsUriPrefix when JCasC is enabled
 
@@ -1740,7 +1744,7 @@ Revert fix in `1.7.10` since direct connection is now disabled by default.
 
 Add `master.schedulerName` to allow setting a Kubernetes custom scheduler
 
-## 1.8.0 JCasC auto reload works without ssh keys
+## 1.8.0 JCasC auto reload works without SSH keys
 
 We make use of the fact that the Jenkins Configuration as Code Plugin can be triggered via http `POST` to `JENKINS_URL/configuration-as-code/reload`and a pre-shared key.
 The sidecar container responsible for reloading config changes is now `kiwigrid/k8s-sidecar:0.1.20` instead of it's fork `shadwell/k8s-sidecar`.
@@ -2268,7 +2272,7 @@ commit: 9de96faa0
 
 ## 0.32.7
 
-Fix Markdown syntax in README (#11496)
+Fix Markdown syntax in readme (#11496)
 commit: a32221a95
 
 ## 0.32.6
@@ -2498,7 +2502,7 @@ commit: e0a20b0b9
 
 ## 0.16.22
 
-avoid lint errors when adding Values.Ingress.Annotations (#7425)
+avoid linting errors when adding Values.Ingress.Annotations (#7425)
 commit: 99eacc854
 
 ## 0.16.21
@@ -2523,7 +2527,7 @@ commit: bf8180018
 
 ## 0.16.17
 
-Add Master.AdminPassword in README (#6987)
+Add Master.AdminPassword in readme (#6987)
 commit: 13e754ad7
 
 ## 0.16.16
@@ -2593,7 +2597,7 @@ commit: fc6100c38
 
 ## 0.16.1
 
-fix typo in jenkins README (#5228)
+fix typo in jenkins readme (#5228)
 commit: 3cd3f4b8b
 
 ## 0.16.0
@@ -2714,7 +2718,7 @@ commit: 9a230a6b1
 Double retry count for Jenkins test
 commit: 129c8e824
 
-Jenkins: Update README | Master.ServiceAnnotations (#2757)
+Jenkins: Update readme | Master.ServiceAnnotations (#2757)
 commit: 6571810bc
 
 ## 0.10.0
@@ -2786,7 +2790,7 @@ commit: 4af5810ff
 
 ## 0.8.4
 
-Add support for supplying JENKINS_OPTS and/or uri prefix (#1405)
+Add support for supplying JENKINS_OPTS and/or URI prefix (#1405)
 commit: 6a331901a
 
 ## 0.8.3
@@ -2996,7 +3000,7 @@ commit: 3cbd3ced6
 Remove 'Getting Started:' from various NOTES.txt. (#181)
 commit: 2f63fd524
 
-docs(\*): update READMEs to reference chart repos (#119)
+docs(\*): update readmes to reference chart repos (#119)
 commit: c7d1bff05
 
 ## 0.1.0

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.3.3
+version: 5.3.4
 appVersion: 2.452.2
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/UPGRADING.md
+++ b/charts/jenkins/UPGRADING.md
@@ -122,7 +122,7 @@ So think of the list below more as a general guideline of what should be done.
 - Test drive those setting on a separate installation
 - Put Jenkins to Quiet Down mode so that it does not accept new jobs
   `<JENKINS_URL>/quietDown`
-- Change permissions of all files and folders to the new user and group id:
+- Change permissions of all files and folders to the new user and group ID:
 
   ```console
   kubectl exec -it <jenkins_pod> -c jenkins /bin/bash


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
Updates super-linter to v6.7.0 as in #1117. Also disables checkov as it is too strict for the default Helm template. Fixes some NATURAL_LANGUAGE issues and ignores some other.
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
