### PR TITLE
chore: run renovate hourly and on push

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,7 +1,10 @@
 name: Renovate
 on:
   schedule:
-    - cron: "0/15 * * * *"
+    - cron: "0 * * * *"
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
This PR changes the schedule to make Renovate run hourly and on push to main to more closely resemble the behavior of the Renovate GitHub App.
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
