### PR TITLE
feat: add support for usageRestricted and skipTlsVerify

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.5.0
+
+Introduce capability of set skipTlsVerify and usageRestricted flags in additionalClouds
+
+
 ## 5.4.4
 
 Update CHANGELOG.md, README.md, and UPGRADING.md for linting

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.4.4
+version: 5.5.0
 appVersion: 2.452.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -8,64 +8,66 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Key | Type | Description | Default |
 |:----|:-----|:---------|:------------|
-| [additionalAgents](./values.yaml#L1165) | object | Configure additional | `{}` |
-| [additionalClouds](./values.yaml#L1190) | object |  | `{}` |
-| [agent.TTYEnabled](./values.yaml#L1083) | bool | Allocate pseudo tty to the side container | `false` |
-| [agent.additionalContainers](./values.yaml#L1118) | list | Add additional containers to the agents | `[]` |
-| [agent.alwaysPullImage](./values.yaml#L976) | bool | Always pull agent container image before build | `false` |
-| [agent.annotations](./values.yaml#L1114) | object | Annotations to apply to the pod | `{}` |
-| [agent.args](./values.yaml#L1077) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
-| [agent.command](./values.yaml#L1075) | string | Command to execute when side container starts | `nil` |
-| [agent.componentName](./values.yaml#L944) | string |  | `"jenkins-agent"` |
-| [agent.connectTimeout](./values.yaml#L1112) | int | Timeout in seconds for an agent to be online | `100` |
-| [agent.containerCap](./values.yaml#L1085) | int | Max number of agents to launch | `10` |
-| [agent.customJenkinsLabels](./values.yaml#L941) | list | Append Jenkins labels to the agent | `[]` |
+| [additionalAgents](./values.yaml#L1169) | object | Configure additional | `{}` |
+| [additionalClouds](./values.yaml#L1194) | object |  | `{}` |
+| [agent.TTYEnabled](./values.yaml#L1087) | bool | Allocate pseudo tty to the side container | `false` |
+| [agent.additionalContainers](./values.yaml#L1122) | list | Add additional containers to the agents | `[]` |
+| [agent.alwaysPullImage](./values.yaml#L980) | bool | Always pull agent container image before build | `false` |
+| [agent.annotations](./values.yaml#L1118) | object | Annotations to apply to the pod | `{}` |
+| [agent.args](./values.yaml#L1081) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
+| [agent.command](./values.yaml#L1079) | string | Command to execute when side container starts | `nil` |
+| [agent.componentName](./values.yaml#L948) | string |  | `"jenkins-agent"` |
+| [agent.connectTimeout](./values.yaml#L1116) | int | Timeout in seconds for an agent to be online | `100` |
+| [agent.containerCap](./values.yaml#L1089) | int | Max number of agents to launch | `10` |
+| [agent.customJenkinsLabels](./values.yaml#L945) | list | Append Jenkins labels to the agent | `[]` |
 | [agent.defaultsProviderTemplate](./values.yaml#L907) | string | The name of the pod template to use for providing default values | `""` |
-| [agent.directConnection](./values.yaml#L947) | bool |  | `false` |
-| [agent.disableDefaultAgent](./values.yaml#L1136) | bool | Disable the default Jenkins Agent configuration | `false` |
+| [agent.directConnection](./values.yaml#L951) | bool |  | `false` |
+| [agent.disableDefaultAgent](./values.yaml#L1140) | bool | Disable the default Jenkins Agent configuration | `false` |
 | [agent.enabled](./values.yaml#L905) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
-| [agent.envVars](./values.yaml#L1058) | list | Environment variables for the agent Pod | `[]` |
-| [agent.hostNetworking](./values.yaml#L955) | bool | Enables the agent to use the host network | `false` |
-| [agent.idleMinutes](./values.yaml#L1090) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
-| [agent.image.repository](./values.yaml#L934) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
-| [agent.image.tag](./values.yaml#L936) | string | Tag of the image to pull | `"3256.v88a_f6e922152-1"` |
-| [agent.imagePullSecretName](./values.yaml#L943) | string | Name of the secret to be used to pull the image | `nil` |
-| [agent.inheritYamlMergeStrategy](./values.yaml#L1110) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
+| [agent.envVars](./values.yaml#L1062) | list | Environment variables for the agent Pod | `[]` |
+| [agent.hostNetworking](./values.yaml#L959) | bool | Enables the agent to use the host network | `false` |
+| [agent.idleMinutes](./values.yaml#L1094) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
+| [agent.image.repository](./values.yaml#L938) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
+| [agent.image.tag](./values.yaml#L940) | string | Tag of the image to pull | `"3256.v88a_f6e922152-1"` |
+| [agent.imagePullSecretName](./values.yaml#L947) | string | Name of the secret to be used to pull the image | `nil` |
+| [agent.inheritYamlMergeStrategy](./values.yaml#L1114) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
 | [agent.jenkinsTunnel](./values.yaml#L915) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
 | [agent.jenkinsUrl](./values.yaml#L911) | string | Overrides the Kubernetes Jenkins URL | `nil` |
-| [agent.jnlpregistry](./values.yaml#L931) | string | Custom registry used to pull the agent jnlp image from | `nil` |
-| [agent.kubernetesConnectTimeout](./values.yaml#L917) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
-| [agent.kubernetesReadTimeout](./values.yaml#L919) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
-| [agent.livenessProbe](./values.yaml#L966) | object |  | `{}` |
-| [agent.maxRequestsPerHostStr](./values.yaml#L921) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
-| [agent.namespace](./values.yaml#L927) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
-| [agent.nodeSelector](./values.yaml#L1069) | object | Node labels for pod assignment | `{}` |
-| [agent.nodeUsageMode](./values.yaml#L939) | string |  | `"NORMAL"` |
-| [agent.podLabels](./values.yaml#L929) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
-| [agent.podName](./values.yaml#L1087) | string | Agent Pod base name | `"default"` |
-| [agent.podRetention](./values.yaml#L985) | string |  | `"Never"` |
-| [agent.podTemplates](./values.yaml#L1146) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
-| [agent.privileged](./values.yaml#L949) | bool | Agent privileged container | `false` |
-| [agent.resources](./values.yaml#L957) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
-| [agent.restrictedPssSecurityContext](./values.yaml#L982) | bool | Set a restricted securityContext on jnlp containers | `false` |
-| [agent.retentionTimeout](./values.yaml#L923) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
-| [agent.runAsGroup](./values.yaml#L953) | string | Configure container group | `nil` |
-| [agent.runAsUser](./values.yaml#L951) | string | Configure container user | `nil` |
-| [agent.secretEnvVars](./values.yaml#L1062) | list | Mount a secret as environment variable | `[]` |
-| [agent.showRawYaml](./values.yaml#L989) | bool |  | `true` |
-| [agent.sideContainerName](./values.yaml#L1079) | string | Side container name | `"jnlp"` |
-| [agent.volumes](./values.yaml#L996) | list | Additional volumes | `[]` |
-| [agent.waitForPodSec](./values.yaml#L925) | int | Seconds to wait for pod to be running | `600` |
-| [agent.websocket](./values.yaml#L946) | bool | Enables agent communication via websockets | `false` |
-| [agent.workingDir](./values.yaml#L938) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
-| [agent.workspaceVolume](./values.yaml#L1031) | object | Workspace volume (defaults to EmptyDir) | `{}` |
-| [agent.yamlMergeStrategy](./values.yaml#L1108) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
-| [agent.yamlTemplate](./values.yaml#L1097) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1316) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1318) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1320) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1319) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1313) | bool | Checks if any deprecated values are used | `true` |
+| [agent.jnlpregistry](./values.yaml#L935) | string | Custom registry used to pull the agent jnlp image from | `nil` |
+| [agent.kubernetesConnectTimeout](./values.yaml#L921) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
+| [agent.kubernetesReadTimeout](./values.yaml#L923) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
+| [agent.livenessProbe](./values.yaml#L970) | object |  | `{}` |
+| [agent.maxRequestsPerHostStr](./values.yaml#L925) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
+| [agent.namespace](./values.yaml#L931) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
+| [agent.nodeSelector](./values.yaml#L1073) | object | Node labels for pod assignment | `{}` |
+| [agent.nodeUsageMode](./values.yaml#L943) | string |  | `"NORMAL"` |
+| [agent.podLabels](./values.yaml#L933) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
+| [agent.podName](./values.yaml#L1091) | string | Agent Pod base name | `"default"` |
+| [agent.podRetention](./values.yaml#L989) | string |  | `"Never"` |
+| [agent.podTemplates](./values.yaml#L1150) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
+| [agent.privileged](./values.yaml#L953) | bool | Agent privileged container | `false` |
+| [agent.resources](./values.yaml#L961) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
+| [agent.restrictedPssSecurityContext](./values.yaml#L986) | bool | Set a restricted securityContext on jnlp containers | `false` |
+| [agent.retentionTimeout](./values.yaml#L927) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
+| [agent.runAsGroup](./values.yaml#L957) | string | Configure container group | `nil` |
+| [agent.runAsUser](./values.yaml#L955) | string | Configure container user | `nil` |
+| [agent.secretEnvVars](./values.yaml#L1066) | list | Mount a secret as environment variable | `[]` |
+| [agent.showRawYaml](./values.yaml#L993) | bool |  | `true` |
+| [agent.sideContainerName](./values.yaml#L1083) | string | Side container name | `"jnlp"` |
+| [agent.skipTlsVerify](./values.yaml#L917) | bool | Disables the verification of the master certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
+| [agent.usageRestricted](./values.yaml#L919) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
+| [agent.volumes](./values.yaml#L1000) | list | Additional volumes | `[]` |
+| [agent.waitForPodSec](./values.yaml#L929) | int | Seconds to wait for pod to be running | `600` |
+| [agent.websocket](./values.yaml#L950) | bool | Enables agent communication via websockets | `false` |
+| [agent.workingDir](./values.yaml#L942) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
+| [agent.workspaceVolume](./values.yaml#L1035) | object | Workspace volume (defaults to EmptyDir) | `{}` |
+| [agent.yamlMergeStrategy](./values.yaml#L1112) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
+| [agent.yamlTemplate](./values.yaml#L1101) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1320) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1322) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1324) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1323) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1317) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L533) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L538) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -270,40 +272,40 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.usePodSecurityContext](./values.yaml#L176) | bool | Enable pod security context (must be `true` if podSecurityContextOverride, runAsUser or fsGroup are set) | `true` |
 | [credentialsId](./values.yaml#L27) | string | The Jenkins credentials to access the Kubernetes API server. For the default cluster it is not needed. | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1329) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1331) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1333) | string | Tag of the image to test the framework | `"1.11.0"` |
+| [helmtest.bats.image.registry](./values.yaml#L1333) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1335) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1337) | string | Tag of the image to test the framework | `"1.11.0"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
-| [networkPolicy.apiVersion](./values.yaml#L1259) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
-| [networkPolicy.enabled](./values.yaml#L1254) | bool | Enable the creation of NetworkPolicy resources | `false` |
-| [networkPolicy.externalAgents.except](./values.yaml#L1273) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
-| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1271) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
-| [networkPolicy.internalAgents.allowed](./values.yaml#L1263) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
-| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1267) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
-| [networkPolicy.internalAgents.podLabels](./values.yaml#L1265) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
-| [persistence.accessMode](./values.yaml#L1229) | string | The PVC access mode | `"ReadWriteOnce"` |
-| [persistence.annotations](./values.yaml#L1225) | object | Annotations for the PVC | `{}` |
-| [persistence.dataSource](./values.yaml#L1235) | object | Existing data source to clone PVC from | `{}` |
-| [persistence.enabled](./values.yaml#L1209) | bool | Enable the use of a Jenkins PVC | `true` |
-| [persistence.existingClaim](./values.yaml#L1215) | string | Provide the name of a PVC | `nil` |
-| [persistence.labels](./values.yaml#L1227) | object | Labels for the PVC | `{}` |
-| [persistence.mounts](./values.yaml#L1247) | list | Additional mounts | `[]` |
-| [persistence.size](./values.yaml#L1231) | string | The size of the PVC | `"8Gi"` |
-| [persistence.storageClass](./values.yaml#L1223) | string | Storage class for the PVC | `nil` |
-| [persistence.subPath](./values.yaml#L1240) | string | SubPath for jenkins-home mount | `nil` |
-| [persistence.volumes](./values.yaml#L1242) | list | Additional volumes | `[]` |
-| [rbac.create](./values.yaml#L1279) | bool | Whether RBAC resources are created | `true` |
-| [rbac.readSecrets](./values.yaml#L1281) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
+| [networkPolicy.apiVersion](./values.yaml#L1263) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
+| [networkPolicy.enabled](./values.yaml#L1258) | bool | Enable the creation of NetworkPolicy resources | `false` |
+| [networkPolicy.externalAgents.except](./values.yaml#L1277) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
+| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1275) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
+| [networkPolicy.internalAgents.allowed](./values.yaml#L1267) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
+| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1271) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
+| [networkPolicy.internalAgents.podLabels](./values.yaml#L1269) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
+| [persistence.accessMode](./values.yaml#L1233) | string | The PVC access mode | `"ReadWriteOnce"` |
+| [persistence.annotations](./values.yaml#L1229) | object | Annotations for the PVC | `{}` |
+| [persistence.dataSource](./values.yaml#L1239) | object | Existing data source to clone PVC from | `{}` |
+| [persistence.enabled](./values.yaml#L1213) | bool | Enable the use of a Jenkins PVC | `true` |
+| [persistence.existingClaim](./values.yaml#L1219) | string | Provide the name of a PVC | `nil` |
+| [persistence.labels](./values.yaml#L1231) | object | Labels for the PVC | `{}` |
+| [persistence.mounts](./values.yaml#L1251) | list | Additional mounts | `[]` |
+| [persistence.size](./values.yaml#L1235) | string | The size of the PVC | `"8Gi"` |
+| [persistence.storageClass](./values.yaml#L1227) | string | Storage class for the PVC | `nil` |
+| [persistence.subPath](./values.yaml#L1244) | string | SubPath for jenkins-home mount | `nil` |
+| [persistence.volumes](./values.yaml#L1246) | list | Additional volumes | `[]` |
+| [rbac.create](./values.yaml#L1283) | bool | Whether RBAC resources are created | `true` |
+| [rbac.readSecrets](./values.yaml#L1285) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
-| [serviceAccount.annotations](./values.yaml#L1291) | object | Configures annotations for the ServiceAccount | `{}` |
-| [serviceAccount.create](./values.yaml#L1285) | bool | Configures if a ServiceAccount with this name should be created | `true` |
-| [serviceAccount.extraLabels](./values.yaml#L1293) | object | Configures extra labels for the ServiceAccount | `{}` |
-| [serviceAccount.imagePullSecretName](./values.yaml#L1295) | string | Controller ServiceAccount image pull secret | `nil` |
-| [serviceAccount.name](./values.yaml#L1289) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1306) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.create](./values.yaml#L1300) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1308) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1310) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1304) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccount.annotations](./values.yaml#L1295) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.create](./values.yaml#L1289) | bool | Configures if a ServiceAccount with this name should be created | `true` |
+| [serviceAccount.extraLabels](./values.yaml#L1297) | object | Configures extra labels for the ServiceAccount | `{}` |
+| [serviceAccount.imagePullSecretName](./values.yaml#L1299) | string | Controller ServiceAccount image pull secret | `nil` |
+| [serviceAccount.name](./values.yaml#L1293) | string |  | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1310) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.create](./values.yaml#L1304) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1312) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1314) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1308) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -54,7 +54,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [agent.secretEnvVars](./values.yaml#L1066) | list | Mount a secret as environment variable | `[]` |
 | [agent.showRawYaml](./values.yaml#L993) | bool |  | `true` |
 | [agent.sideContainerName](./values.yaml#L1083) | string | Side container name | `"jnlp"` |
-| [agent.skipTlsVerify](./values.yaml#L917) | bool | Disables the verification of the master certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
+| [agent.skipTlsVerify](./values.yaml#L917) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
 | [agent.usageRestricted](./values.yaml#L919) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
 | [agent.volumes](./values.yaml#L1000) | list | Additional volumes | `[]` |
 | [agent.waitForPodSec](./values.yaml#L929) | int | Seconds to wait for pod to be running | `600` |

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -164,6 +164,8 @@ jenkins:
       webSocket: true
       {{- end }}
       {{- end }}
+      skipTlsVerify: {{ .Values.agent.skipTlsVerify | default false}}
+      usageRestricted: {{ .Values.agent.usageRestricted | default false}}
       maxRequestsPerHostStr: {{ .Values.agent.maxRequestsPerHostStr | quote }}
       retentionTimeout: {{ .Values.agent.retentionTimeout | quote }}
       waitForPodSec: {{ .Values.agent.waitForPodSec | quote }}
@@ -248,6 +250,8 @@ jenkins:
       webSocket: true
       {{- end }}
       {{- end }}
+      skipTlsVerify: {{ .Values.agent.skipTlsVerify | default false}}
+      usageRestricted: {{ .Values.agent.usageRestricted | default false}}
       maxRequestsPerHostStr: {{ .Values.agent.maxRequestsPerHostStr | quote }}
       retentionTimeout: {{ .Values.agent.retentionTimeout | quote }}
       waitForPodSec: {{ .Values.agent.waitForPodSec | quote }}

--- a/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
@@ -44,7 +44,7 @@ additional clouds:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -94,7 +94,7 @@ additional clouds:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -178,7 +178,7 @@ additional clouds inheriting additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -207,7 +207,7 @@ additional clouds inheriting additional agents:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 9fa611fe5dfbb34bf1dffd17b510353212f493117275c2a1425a991d4fdeffa0
+                id: a40b1fdbcf88c8a9f32eaeb62f63ebe6c33b6e5998dc67fe15b09e7e130aff00
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -257,7 +257,7 @@ additional clouds inheriting additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -286,7 +286,7 @@ additional clouds inheriting additional agents:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 9fa611fe5dfbb34bf1dffd17b510353212f493117275c2a1425a991d4fdeffa0
+                id: a40b1fdbcf88c8a9f32eaeb62f63ebe6c33b6e5998dc67fe15b09e7e130aff00
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -370,7 +370,7 @@ additional clouds overriding additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -399,7 +399,7 @@ additional clouds overriding additional agents:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 9fa611fe5dfbb34bf1dffd17b510353212f493117275c2a1425a991d4fdeffa0
+                id: a40b1fdbcf88c8a9f32eaeb62f63ebe6c33b6e5998dc67fe15b09e7e130aff00
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -449,7 +449,7 @@ additional clouds overriding additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -537,7 +537,7 @@ adds custom labels on agent pods:
             templates:
               - name: "default"
                 namespace: "NAMESPACE"
-                id: 4210d9f2ae423f73ea4a1a56eab7d809d557a8f251e9dc3ef1e5936de45f4a08
+                id: a39847bdf766ea14fe06ea2446e08231ba6274a9150062d5341ef31ad945615f
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -621,7 +621,7 @@ agent namespace and templates:
             templates:
               - name: "default"
                 namespace: "jenkins-agents"
-                id: bdc4543ba71865fa69edb5d7edb0b34e738b2ae3457a20bb9eba46eed4c91fc8
+                id: f99f3ed122900ce2a202ec0cdd33ddc259af72361bcb05f213c4b22adbf30f18
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -650,7 +650,7 @@ agent namespace and templates:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 535ab7168c785305f08312c3f09c8f7003a9ed4b95b062c0e33f2891d73ae2c5
+                id: 725493be6f86f14ea1a0b72864c4f911278b674228f768da81c6d24ffe53a6c1
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -679,7 +679,7 @@ agent namespace and templates:
                 inheritYamlMergeStrategy: false
               - name: "python"
                 namespace: "jenkins-agents"
-                id: a51f0cf2998bfe44971344c255751aa03af9c4803295b1863f33a43cffd41f33
+                id: a8f3ada3ef5264fe6ae88f9fc2a7e6e659a17476b130c8b66b0b0496eb42a1ea
                 containers:
                 - name: "python"
                   alwaysPullImage: false
@@ -780,7 +780,7 @@ agent with liveness probe:
             templates:
               - name: "default"
                 namespace: "default"
-                id: b0a3ac7559990983d624b6b8697fc4b7317339ca028e12c5ffe4d3a3d520a8bf
+                id: 0e85b62bf8a6cf4a210488a8a548b620f0a691f237792fc452ed13321bc88baa
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -871,7 +871,7 @@ agents with liveness probe:
             templates:
               - name: "default"
                 namespace: "default"
-                id: b2775941cae02929213805d9dd60d2f6a1ed114b6efaa827820854107d3a5bd7
+                id: 25e8c0be22fa242398eaf9da221ac883becdd680e678bda29bfd01d35b5f5c0f
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -977,7 +977,7 @@ configure hostnetworking to agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 5c087f618fa937db0eac8c120316ec84583c7205f8d1483fb103ec246b2e4fcf
+                id: 5cbb231c9730aa47e4144e180dc783526d1b9d198735ae2150e9f4e16af870c8
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1062,7 +1062,7 @@ custom dynamic pvc workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4c080601bdca71073fc4ac1ab0f6fcae36e74cc25524535f8ecbe5dcb4d47691
+                id: 62604d91393278c1eeef904ec563b0f9501df2e36a0362704b19a386523a6d2b
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1151,7 +1151,7 @@ custom emptyDir workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: fbdc1875125e5911d57fe839e2b4d410e54553a1950c7d63f70ea875da9e5115
+                id: b80eecfaa0b2d535a5d423758729da494749cf152f468eb00beae6b0c0908b64
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1238,7 +1238,7 @@ custom hostPath workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a8b9ef2271153b249f5a910a45a71cb5a5aff5217c5667088dad3021fd86a57a
+                id: 74db5952b4f7d4248470a55e0de36e43bfa8dc655a88c774c6651512df51793e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1325,7 +1325,7 @@ custom jenkins label:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1409,7 +1409,7 @@ custom nfs workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 90d056430705e172ea6fb05622a42b15964eb718e5c3d5118fe083ef6f715944
+                id: bd401292fb2762de353dea79ce2031f1fcad27d10b1834009861eedf9fc3fcbf
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1498,7 +1498,7 @@ custom other workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 665e125339e8829b7f4b24a0a910c712f0e37c885824175fa138d33dc0f89fdf
+                id: 09b5dc7e43bd30ccf09bb4a5ab630c75491d8c5700e03f3f98c2cc423dec9ff9
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1586,7 +1586,7 @@ custom pvc workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 897a0dca7b3f29669421e781200bbdf5801228fdf5dc32770fe3fd18cad7fdf1
+                id: 74a62941c8071dae53d53ef3f2bd0ee9ff01eaf729573340817f9153092e96ec
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1674,7 +1674,7 @@ customized config:
                 annotations:
                 - key: ci.jenkins-agent/test
                   value: "custom"
-                id: dba455f7c62e2d39ff8d439a7189051d0398b6a79f20550498d55ce89b9e0e30
+                id: df422e7784125a7a4cdc5c9ecb1c1dd7a3e866efec4539c2dc238ac9f21bdecd
                 containers:
                 - name: "sideContainer"
                   alwaysPullImage: true
@@ -1807,7 +1807,7 @@ default config:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1941,7 +1941,7 @@ empty projectNamingStrategy:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2025,7 +2025,7 @@ legacyRemotingSecurityEnabled = false:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2111,7 +2111,7 @@ legacyRemotingSecurityEnabled = true:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2198,7 +2198,7 @@ non-string projectNamingStrategy:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2281,7 +2281,7 @@ set directConnection:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 311f83258c38c0315513cd4a7cb081be2807d12ffbc81c03e7df5feacaed1314
+                id: fafc6ef8b64e1af9244ece4cfd40c1925b4a4dc13a8b5404c9d3f2e4160b0144
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2365,7 +2365,7 @@ set restrictedPssSecurityContext:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 1b09983234d730e3f0a70ef0f6cf7605d1cba214d24071a683e64eabcd854e57
+                id: f56f96ceb3cd18b0fe6981fff827df71303dceb240f1cb0c9b09568be2f82835
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2449,7 +2449,7 @@ set secretEnvVars:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a7cef98e981c5eed3e4f8bd17e2feeaaf4afcf20ba761104a0c7da79de835335
+                id: e3e38b8fcdf5f49be60b1267c084c3b340030cd25518d35417c2d9b6d5dc7b22
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2542,7 +2542,7 @@ specify additional container:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 57a3839dd1578241be4fe021cf6919719cb06f8a6dd7dd5f9d1ee534c9cd09bb
+                id: 82a2f9ca297af32823641dcb830e5191a15f91a229064a81e222acd47a213bd0
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2642,7 +2642,7 @@ specify additional container and clear in additional agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 57a3839dd1578241be4fe021cf6919719cb06f8a6dd7dd5f9d1ee534c9cd09bb
+                id: 82a2f9ca297af32823641dcb830e5191a15f91a229064a81e222acd47a213bd0
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2687,7 +2687,7 @@ specify additional container and clear in additional agent:
                 inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
-                id: 28ba495f7106228332a4abb400758f55648781383c2a43aa5d1db37f1c23a08f
+                id: 77593aec044020e9f980748c3b223f98fd3250114f48b5d92f25ca256ca64a31
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2771,7 +2771,7 @@ specify additional container and overwrite in additional agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 57a3839dd1578241be4fe021cf6919719cb06f8a6dd7dd5f9d1ee534c9cd09bb
+                id: 82a2f9ca297af32823641dcb830e5191a15f91a229064a81e222acd47a213bd0
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2816,7 +2816,7 @@ specify additional container and overwrite in additional agent:
                 inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
-                id: 451d5a7d7017fccb326389172e0e760f1bab8ec029d3c874c192a5462ceaee87
+                id: 8fef7de3d04168e20fe7b61335ba8b28900d1feadaf4c49f104a9ea08574eff1
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2916,7 +2916,7 @@ specify security settings with apiToken override:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2997,7 +2997,7 @@ specify security settings without apiToken override:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3083,7 +3083,7 @@ additional clouds set skipTlsVerify:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3133,7 +3133,7 @@ additional clouds set skipTlsVerify:
             templates:
               - name: "default"
                 namespace: "default"
-                id: caec83b8eaf62687d39d9b23e7d8e02183e4ad3b6a8ecc61aca210c697698ebd
+                id: 9b0ca0c339be83d1a5f35c0705edae53f71fa9ea20cd7b45c6c69b0c787cede8
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3217,7 +3217,7 @@ additional clouds set usageRestricted:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                id: a0f56ca68f65c46f78fc57560ac2831ed6b053bccdbb4f82cf44e3eebcd28cc7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3267,7 +3267,7 @@ additional clouds set usageRestricted:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 2e3153b1b586b9ad4c180c64ee90b6bb7b99b23cf2a992dd4dd7e940ab867195
+                id: 0362076db6784d08f3dc05994bb9e12a025f11c4263f75d37f774206d9100121
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false

--- a/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
@@ -28,6 +28,8 @@ additional clouds:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -76,6 +78,8 @@ additional clouds:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -158,6 +162,8 @@ additional clouds inheriting additional agents:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -235,6 +241,8 @@ additional clouds inheriting additional agents:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -346,6 +354,8 @@ additional clouds overriding additional agents:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -423,6 +433,8 @@ additional clouds overriding additional agents:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -505,6 +517,8 @@ adds custom labels on agent pods:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.NAMESPACE.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.NAMESPACE.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -591,6 +605,8 @@ agent namespace and templates:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.controller-namespace.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.controller-namespace.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -748,6 +764,8 @@ agent with liveness probe:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -837,6 +855,8 @@ agents with liveness probe:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -941,6 +961,8 @@ configure hostnetworking to agent:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1024,6 +1046,8 @@ custom dynamic pvc workspace volume:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1111,6 +1135,8 @@ custom emptyDir workspace volume:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1196,6 +1222,8 @@ custom hostPath workspace volume:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1281,6 +1309,8 @@ custom jenkins label:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1363,6 +1393,8 @@ custom nfs workspace volume:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1450,6 +1482,8 @@ custom other workspace volume:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1536,6 +1570,8 @@ custom pvc workspace volume:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1619,6 +1655,8 @@ customized config:
             readTimeout: "12"
             jenkinsUrl: "http://my-release-jenkins.other.svc.cluster.local:8080"
             jenkinsTunnel: "my-release-jenkins-agent.other.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1753,6 +1791,8 @@ default config:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1835,6 +1875,8 @@ disable agents:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.controller-namespace.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.controller-namespace.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1883,6 +1925,8 @@ empty projectNamingStrategy:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -1965,6 +2009,8 @@ legacyRemotingSecurityEnabled = false:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2049,6 +2095,8 @@ legacyRemotingSecurityEnabled = true:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2134,6 +2182,8 @@ non-string projectNamingStrategy:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2215,6 +2265,8 @@ set directConnection:
             connectTimeout: "5"
             readTimeout: "15"
             directConnection: true
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2297,6 +2349,8 @@ set restrictedPssSecurityContext:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2379,6 +2433,8 @@ set secretEnvVars:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2470,6 +2526,8 @@ specify additional container:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2568,6 +2626,8 @@ specify additional container and clear in additional agent:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2695,6 +2755,8 @@ specify additional container and overwrite in additional agent:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2838,6 +2900,8 @@ specify security settings with apiToken override:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2917,6 +2981,8 @@ specify security settings without apiToken override:
             readTimeout: "15"
             jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
             jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
             maxRequestsPerHostStr: "32"
             retentionTimeout: "5"
             waitForPodSec: "600"
@@ -2968,6 +3034,274 @@ specify security settings without apiToken override:
           usageStatisticsEnabled: true
         gitHostKeyVerificationConfiguration:
           sshHostKeyVerificationStrategy: acceptFirstConnectionStrategy
+      unclassified:
+        location:
+          url: http://RELEASE-NAME-jenkins:8080
+additional clouds set skipTlsVerify:
+  1: |
+    |-
+      jenkins:
+        authorizationStrategy:
+          loggedInUsersCanDoAnything:
+            allowAnonymousRead: false
+        securityRealm:
+          local:
+            allowsSignup: false
+            enableCaptcha: false
+            users:
+            - id: "${chart-admin-username}"
+              name: "Jenkins Admin"
+              password: "${chart-admin-password}"
+        disableRememberMe: false
+        mode: NORMAL
+        numExecutors: 0
+        labelString: ""
+        projectNamingStrategy: "standard"
+        markupFormatter:
+          plainText
+        clouds:
+        - kubernetes:
+            containerCapStr: "10"
+            defaultsProviderTemplate: ""
+            connectTimeout: "5"
+            readTimeout: "15"
+            jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+            jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
+            maxRequestsPerHostStr: "32"
+            retentionTimeout: "5"
+            waitForPodSec: "600"
+            name: "kubernetes"
+            namespace: "default"
+            restrictedPssSecurityContext: false
+            serverUrl: "https://kubernetes.default"
+            credentialsId: ""
+            podLabels:
+            - key: "jenkins/RELEASE-NAME-jenkins-agent"
+              value: "true"
+            templates:
+              - name: "default"
+                namespace: "default"
+                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                containers:
+                - name: "jnlp"
+                  alwaysPullImage: false
+                  args: "^${computer.jnlpmac} ^${computer.name}"
+                  envVars:
+                    - envVar:
+                        key: "JENKINS_URL"
+                        value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                  image: "jenkins/inbound-agent:3256.v88a_f6e922152-1"
+                  privileged: "false"
+                  resourceLimitCpu: 512m
+                  resourceLimitMemory: 512Mi
+                  resourceRequestCpu: 512m
+                  resourceRequestMemory: 512Mi
+                  ttyEnabled: false
+                  workingDir: /home/jenkins/agent
+                idleMinutes: 0
+                instanceCap: 2147483647
+                label: "RELEASE-NAME-jenkins-agent "
+                nodeUsageMode: "NORMAL"
+                podRetention: Never
+                showRawYaml: true
+                serviceAccount: "default"
+                slaveConnectTimeoutStr: "100"
+                yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
+        - kubernetes:
+            containerCapStr: "10"
+            defaultsProviderTemplate: ""
+            connectTimeout: "5"
+            readTimeout: "15"
+            jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+            jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: true
+            usageRestricted: false
+            maxRequestsPerHostStr: "32"
+            retentionTimeout: "5"
+            waitForPodSec: "600"
+            name: "remote-cloud-1"
+            namespace: "default"
+            restrictedPssSecurityContext: false
+            serverUrl: "https://api.remote-cloud.com"
+            credentialsId: "remote-cloud-token"
+            podLabels:
+            - key: "jenkins/RELEASE-NAME-jenkins-agent"
+              value: "true"
+            templates:
+              - name: "default"
+                namespace: "default"
+                id: caec83b8eaf62687d39d9b23e7d8e02183e4ad3b6a8ecc61aca210c697698ebd
+                containers:
+                - name: "jnlp"
+                  alwaysPullImage: false
+                  args: "^${computer.jnlpmac} ^${computer.name}"
+                  envVars:
+                    - envVar:
+                        key: "JENKINS_URL"
+                        value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                  image: "jenkins/inbound-agent:3256.v88a_f6e922152-1"
+                  privileged: "false"
+                  resourceLimitCpu: 512m
+                  resourceLimitMemory: 512Mi
+                  resourceRequestCpu: 512m
+                  resourceRequestMemory: 512Mi
+                  ttyEnabled: false
+                  workingDir: /home/jenkins/agent
+                idleMinutes: 0
+                instanceCap: 2147483647
+                label: "RELEASE-NAME-jenkins-agent "
+                nodeUsageMode: "NORMAL"
+                podRetention: Never
+                showRawYaml: true
+                serviceAccount: "default"
+                slaveConnectTimeoutStr: "100"
+                yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
+        crumbIssuer:
+          standard:
+            excludeClientIPFromCrumb: true
+      security:
+        apiToken:
+          creationOfLegacyTokenEnabled: false
+          tokenGenerationOnCreationEnabled: false
+          usageStatisticsEnabled: true
+      unclassified:
+        location:
+          url: http://RELEASE-NAME-jenkins:8080
+additional clouds set usageRestricted:
+  1: |
+    |-
+      jenkins:
+        authorizationStrategy:
+          loggedInUsersCanDoAnything:
+            allowAnonymousRead: false
+        securityRealm:
+          local:
+            allowsSignup: false
+            enableCaptcha: false
+            users:
+            - id: "${chart-admin-username}"
+              name: "Jenkins Admin"
+              password: "${chart-admin-password}"
+        disableRememberMe: false
+        mode: NORMAL
+        numExecutors: 0
+        labelString: ""
+        projectNamingStrategy: "standard"
+        markupFormatter:
+          plainText
+        clouds:
+        - kubernetes:
+            containerCapStr: "10"
+            defaultsProviderTemplate: ""
+            connectTimeout: "5"
+            readTimeout: "15"
+            jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+            jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: false
+            maxRequestsPerHostStr: "32"
+            retentionTimeout: "5"
+            waitForPodSec: "600"
+            name: "kubernetes"
+            namespace: "default"
+            restrictedPssSecurityContext: false
+            serverUrl: "https://kubernetes.default"
+            credentialsId: ""
+            podLabels:
+            - key: "jenkins/RELEASE-NAME-jenkins-agent"
+              value: "true"
+            templates:
+              - name: "default"
+                namespace: "default"
+                id: a014df243ebc5419b6b774f8b7680e65b67f64d149c3b8af606530a054c550df
+                containers:
+                - name: "jnlp"
+                  alwaysPullImage: false
+                  args: "^${computer.jnlpmac} ^${computer.name}"
+                  envVars:
+                    - envVar:
+                        key: "JENKINS_URL"
+                        value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                  image: "jenkins/inbound-agent:3256.v88a_f6e922152-1"
+                  privileged: "false"
+                  resourceLimitCpu: 512m
+                  resourceLimitMemory: 512Mi
+                  resourceRequestCpu: 512m
+                  resourceRequestMemory: 512Mi
+                  ttyEnabled: false
+                  workingDir: /home/jenkins/agent
+                idleMinutes: 0
+                instanceCap: 2147483647
+                label: "RELEASE-NAME-jenkins-agent "
+                nodeUsageMode: "NORMAL"
+                podRetention: Never
+                showRawYaml: true
+                serviceAccount: "default"
+                slaveConnectTimeoutStr: "100"
+                yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
+        - kubernetes:
+            containerCapStr: "10"
+            defaultsProviderTemplate: ""
+            connectTimeout: "5"
+            readTimeout: "15"
+            jenkinsUrl: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080"
+            jenkinsTunnel: "RELEASE-NAME-jenkins-agent.default.svc.cluster.local:50000"
+            skipTlsVerify: false
+            usageRestricted: true
+            maxRequestsPerHostStr: "32"
+            retentionTimeout: "5"
+            waitForPodSec: "600"
+            name: "remote-cloud-1"
+            namespace: "default"
+            restrictedPssSecurityContext: false
+            serverUrl: "https://api.remote-cloud.com"
+            credentialsId: "remote-cloud-token"
+            podLabels:
+            - key: "jenkins/RELEASE-NAME-jenkins-agent"
+              value: "true"
+            templates:
+              - name: "default"
+                namespace: "default"
+                id: 2e3153b1b586b9ad4c180c64ee90b6bb7b99b23cf2a992dd4dd7e940ab867195
+                containers:
+                - name: "jnlp"
+                  alwaysPullImage: false
+                  args: "^${computer.jnlpmac} ^${computer.name}"
+                  envVars:
+                    - envVar:
+                        key: "JENKINS_URL"
+                        value: "http://RELEASE-NAME-jenkins.default.svc.cluster.local:8080/"
+                  image: "jenkins/inbound-agent:3256.v88a_f6e922152-1"
+                  privileged: "false"
+                  resourceLimitCpu: 512m
+                  resourceLimitMemory: 512Mi
+                  resourceRequestCpu: 512m
+                  resourceRequestMemory: 512Mi
+                  ttyEnabled: false
+                  workingDir: /home/jenkins/agent
+                idleMinutes: 0
+                instanceCap: 2147483647
+                label: "RELEASE-NAME-jenkins-agent "
+                nodeUsageMode: "NORMAL"
+                podRetention: Never
+                showRawYaml: true
+                serviceAccount: "default"
+                slaveConnectTimeoutStr: "100"
+                yamlMergeStrategy: override
+                inheritYamlMergeStrategy: false
+        crumbIssuer:
+          standard:
+            excludeClientIPFromCrumb: true
+      security:
+        apiToken:
+          creationOfLegacyTokenEnabled: false
+          tokenGenerationOnCreationEnabled: false
+          usageStatisticsEnabled: true
       unclassified:
         location:
           url: http://RELEASE-NAME-jenkins:8080

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -765,3 +765,47 @@ tests:
           value:
             jenkins.example.com/anno1: "custom-annotation"
             jenkins.example.com/anno2: "another-annotation"
+  - it: additional clouds set skipTlsVerify
+    set:
+      additionalClouds:
+        remote-cloud-1:
+          kubernetesURL: https://api.remote-cloud.com
+          credentialsId: "remote-cloud-token"
+          agent:
+            skipTlsVerify: true
+    release:
+      namespace: default
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - hasDocuments:
+          count: 1
+      - isNotEmpty:
+          path: data["jcasc-default-config.yaml"]
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^jenkins-
+      - matchSnapshot:
+          path: data["jcasc-default-config.yaml"]
+  - it: additional clouds set usageRestricted
+    set:
+      additionalClouds:
+        remote-cloud-1:
+          kubernetesURL: https://api.remote-cloud.com
+          credentialsId: "remote-cloud-token"
+          agent:
+            usageRestricted: true
+    release:
+      namespace: default
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - hasDocuments:
+          count: 1
+      - isNotEmpty:
+          path: data["jcasc-default-config.yaml"]
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^jenkins-
+      - matchSnapshot:
+          path: data["jcasc-default-config.yaml"]

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -913,7 +913,7 @@ agent:
   # connects to the specified host and port, instead of connecting directly to the Jenkins controller
   # -- Overrides the Kubernetes Jenkins tunnel
   jenkinsTunnel:
-  # -- Disables the verification of the master certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI
+  # -- Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI
   skipTlsVerify: false
   # -- Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI
   usageRestricted: false

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -913,6 +913,10 @@ agent:
   # connects to the specified host and port, instead of connecting directly to the Jenkins controller
   # -- Overrides the Kubernetes Jenkins tunnel
   jenkinsTunnel:
+  # -- Disables the verification of the master certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI
+  skipTlsVerify: false
+  # -- Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI
+  usageRestricted: false
   # -- The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5
   kubernetesConnectTimeout: 5
   # -- The read timeout in seconds for connections to Kubernetes API. The minimum value is 15


### PR DESCRIPTION
Fixes jenkinsci/helm-charts#901

<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->
Add capabilities for set skipTlsVerify and  usageRestricted flags for multicloud configuration. The flag are defaulted to false


If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
