### PR TITLE
Update jenkins-controller-svc.yaml

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.5.6
+
+An explicit ‘agent-listener’ section has been added to the service,  
+aligning with the existing section in the StatefulSet manifest.
+
 ## 5.5.5
 
 Update `jenkins/inbound-agent` to version `3261.v9c670a_4748a_9-1`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.5.5
+version: 5.5.6
 appVersion: 2.462.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/jenkins-controller-svc.yaml
+++ b/charts/jenkins/templates/jenkins-controller-svc.yaml
@@ -32,6 +32,14 @@ spec:
       {{- if (and (eq .Values.controller.serviceType "NodePort") (not (empty .Values.controller.nodePort))) }}
       nodePort: {{.Values.controller.nodePort}}
       {{- end }}
+{{- if .Values.controller.agentListenerEnabled }}
+    - port: {{.Values.controller.agentListenerPort }}
+      name: agent-listener
+      targetPort: {{ .Values.controller.agentListenerPort }}
+      {{- if (and (eq .Values.controller.serviceType "NodePort") (not (empty .Values.controller.agentListenerNodePort))) }}
+      nodePort: {{.Values.controller.agentListenerNodePort}}
+      {{- end }}
+{{- end }}
 {{- range $index, $port := .Values.controller.extraPorts }}
     - port: {{ $port.port }}
       name: {{ $port.name }}

--- a/charts/jenkins/unittests/jenkins-controller-svc-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-svc-test.yaml
@@ -6,6 +6,9 @@ templates:
   - jenkins-controller-svc.yaml
 tests:
   - it: default tests
+    set:
+      controller:
+        agentListenerEnabled: false
     asserts:
       - isKind:
           of: Service
@@ -47,6 +50,7 @@ tests:
         extraPorts:
           - name: BuildInfoProxy
             port: 9000
+        agentListenerEnabled: false
     asserts:
       - equal:
           path: metadata.labels.label
@@ -84,6 +88,7 @@ tests:
           - name: https
             port: 443
             targetPort: 8080
+        agentListenerEnabled: false
     asserts:
       - equal:
           path: metadata.labels.label
@@ -112,6 +117,7 @@ tests:
       controller:
         serviceType: NodePort
         nodePort: 11111
+        agentListenerEnabled: false
     asserts:
        - equal:
           path: spec
@@ -125,11 +131,37 @@ tests:
               app.kubernetes.io/component: jenkins-controller
               app.kubernetes.io/instance: my-release
             type: NodePort
+  - it: node port with agentListenerEnabled
+    set:
+      controller:
+        serviceType: NodePort
+        nodePort: 11111
+        agentListenerEnabled: true
+        agentListenerPort: 50000
+        agentListenerNodePort: 55555
+    asserts:
+       - equal:
+          path: spec
+          value:
+            ports:
+            - name: http
+              port: 8080
+              targetPort: 8080
+              nodePort: 11111
+            - name: agent-listener
+              port: 50000
+              targetPort: 50000
+              nodePort: 55555
+            selector:
+              app.kubernetes.io/component: jenkins-controller
+              app.kubernetes.io/instance: my-release
+            type: NodePort
   - it: load balancer
     set:
       controller:
         serviceType: LoadBalancer
         loadBalancerIP: 10.10.10.10
+        agentListenerEnabled: false
     asserts:
        - equal:
           path: spec
@@ -141,6 +173,31 @@ tests:
             - name: http
               port: 8080
               targetPort: 8080
+            selector:
+              app.kubernetes.io/component: jenkins-controller
+              app.kubernetes.io/instance: my-release
+            type: LoadBalancer
+  - it: load balancer with agentListenerEnabled
+    set:
+      controller:
+        serviceType: LoadBalancer
+        loadBalancerIP: 10.10.10.10
+        agentListenerEnabled: true
+        agentListenerPort: 50000
+    asserts:
+       - equal:
+          path: spec
+          value:
+            loadBalancerIP: 10.10.10.10
+            loadBalancerSourceRanges:
+              - 0.0.0.0/0
+            ports:
+            - name: http
+              port: 8080
+              targetPort: 8080
+            - name: agent-listener
+              port: 50000
+              targetPort: 50000
             selector:
               app.kubernetes.io/component: jenkins-controller
               app.kubernetes.io/instance: my-release


### PR DESCRIPTION
### What does this PR do?

An explicit ‘agent-listener’ section has been added to the service, aligning with the existing section in the StatefulSet manifest.

- Fixes #

`jenkins-controller-svc.yaml`

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
