### PR TITLE
Jenkins Helm chart is now also published to GitHub packages registry (oci://ghcr.io/jenkinsci/helm-charts/jenkins)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -24,10 +25,17 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.12.0
+          version: v3.16.0
 
       - name: Retrieve version from Chart.yaml
         id: chart_version
@@ -83,6 +91,15 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Push Chart to GHCR
+        run: |
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/jenkinsci/helm-charts
+          done
 
       - name: Retrieve release info
         id: release_info

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.6.0
+
+Helm chart is also now deployed on GitHub packages and can be installed from `oci://ghcr.io/jenkinsci/helm-charts/jenkins`
+
 ## 5.5.16
 
 Update `kubernetes` to version `4287.v73451380b_576`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.5.16
+version: 5.6.0
 appVersion: 2.462.2
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.


### PR DESCRIPTION
### What does this PR do?

Publish also the chart to the GHCR registry

- Fixes

https://github.com/jenkinsci/helm-charts/issues/1180

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

This was inspired from https://github.com/fluxcd-community/helm-charts/pull/94/files

Chart is published on both location (the traditional GH page and the GH package)

I've tested the workflow change on my fork

![action](https://github.com/user-attachments/assets/ea2360cf-4063-415a-879f-a12820c98a55)
https://github.com/jonesbusy/helm-charts/actions/runs/10828217018
