### PR TITLE
feat: Add SCC RBAC for OpenShift

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.7.0
+
+Add RBAC support for using the `nonroot` and `nonroot-v2` `SecurityContextConstraints` on OpenShift.
+
 ## 5.6.5
 
 Update `kubernetes` to version `4290.v93ea_4b_b_26a_61`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.6.5
+version: 5.7.0
 appVersion: 2.462.2
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -68,11 +68,11 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [agent.workspaceVolume](./values.yaml#L1049) | object | Workspace volume (defaults to EmptyDir) | `{}` |
 | [agent.yamlMergeStrategy](./values.yaml#L1138) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
 | [agent.yamlTemplate](./values.yaml#L1127) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1346) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1348) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1350) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1349) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1343) | bool | Checks if any deprecated values are used | `true` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1348) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1350) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1352) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1351) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1345) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L539) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L544) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -278,9 +278,9 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.usePodSecurityContext](./values.yaml#L182) | bool | Enable pod security context (must be `true` if podSecurityContextOverride, runAsUser or fsGroup are set) | `true` |
 | [credentialsId](./values.yaml#L27) | string | The Jenkins credentials to access the Kubernetes API server. For the default cluster it is not needed. | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1359) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1361) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1363) | string | Tag of the image to test the framework | `"1.11.0"` |
+| [helmtest.bats.image.registry](./values.yaml#L1361) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1363) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1365) | string | Tag of the image to test the framework | `"1.11.0"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
@@ -304,14 +304,15 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [persistence.volumes](./values.yaml#L1272) | list | Additional volumes | `[]` |
 | [rbac.create](./values.yaml#L1309) | bool | Whether RBAC resources are created | `true` |
 | [rbac.readSecrets](./values.yaml#L1311) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
+| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1313) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
-| [serviceAccount.annotations](./values.yaml#L1321) | object | Configures annotations for the ServiceAccount | `{}` |
-| [serviceAccount.create](./values.yaml#L1315) | bool | Configures if a ServiceAccount with this name should be created | `true` |
-| [serviceAccount.extraLabels](./values.yaml#L1323) | object | Configures extra labels for the ServiceAccount | `{}` |
-| [serviceAccount.imagePullSecretName](./values.yaml#L1325) | string | Controller ServiceAccount image pull secret | `nil` |
-| [serviceAccount.name](./values.yaml#L1319) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1336) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.create](./values.yaml#L1330) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1338) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1340) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1334) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccount.annotations](./values.yaml#L1323) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.create](./values.yaml#L1317) | bool | Configures if a ServiceAccount with this name should be created | `true` |
+| [serviceAccount.extraLabels](./values.yaml#L1325) | object | Configures extra labels for the ServiceAccount | `{}` |
+| [serviceAccount.imagePullSecretName](./values.yaml#L1327) | string | Controller ServiceAccount image pull secret | `nil` |
+| [serviceAccount.name](./values.yaml#L1321) | string |  | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1338) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.create](./values.yaml#L1332) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1340) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1342) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1336) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/templates/rbac.yaml
+++ b/charts/jenkins/templates/rbac.yaml
@@ -99,6 +99,55 @@ subjects:
 ---
 {{- end}}
 
+{{- if .Values.rbac.useOpenShiftNonRootSCC }}
+# This is needed if you are running on OpenShift and using the default
+# containerSecurityContext in the chart. It grants the Jenkins service account
+# permission to use the "nonroot" and "nonroot-v2" SecurityContextConstraints.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $serviceName }}-use-nonroot-scc
+  namespace: {{ template "jenkins.namespace" . }}
+  labels:
+    "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ template "jenkins.label" .}}"
+    {{- end }}
+    "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
+    "app.kubernetes.io/instance": "{{ .Release.Name }}"
+    "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["nonroot", "nonroot-v2"]
+    verbs: ["use"]
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $serviceName }}-use-nonroot-scc
+  namespace: {{ template "jenkins.namespace" . }}
+  labels:
+    "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
+    {{- if .Values.renderHelmLabels }}
+    "helm.sh/chart": "{{ template "jenkins.label" .}}"
+    {{- end }}
+    "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
+    "app.kubernetes.io/instance": "{{ .Release.Name }}"
+    "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "jenkins.fullname" . }}-use-nonroot-scc
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "jenkins.serviceAccountName" . }}
+    namespace: {{ template "jenkins.namespace" . }}
+
+---
+{{- end}}
+
 {{- if .Values.controller.sidecars.configAutoReload.enabled }}
 # The sidecar container which is responsible for reloading configuration changes
 # needs permissions to watch ConfigMaps

--- a/charts/jenkins/unittests/rbac-test.yaml
+++ b/charts/jenkins/unittests/rbac-test.yaml
@@ -215,3 +215,55 @@ tests:
               name: my-release-jenkins
               namespace: my-namespace
 
+  - it: Role use-nonroot-scc
+    set:
+      rbac.useOpenShiftNonRootSCC: true
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: apiVersion
+          value: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: my-release-jenkins-use-nonroot-scc
+      - equal:
+          path: metadata.namespace
+          value: my-namespace
+      - equal:
+          path: rules
+          value:
+            - apiGroups: ["security.openshift.io"]
+              resources: ["securitycontextconstraints"]
+              resourceNames: ["nonroot", "nonroot-v2"]
+              verbs: ["use"]
+
+  - it: RoleBinding use-nonroot-scc
+    set:
+      rbac.useOpenShiftNonRootSCC: true
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: apiVersion
+          value: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: my-release-jenkins-use-nonroot-scc
+      - equal:
+          path: metadata.namespace
+          value: my-namespace
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: my-release-jenkins-use-nonroot-scc
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: my-release-jenkins
+              namespace: my-namespace

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -1309,6 +1309,8 @@ rbac:
   create: true
   # -- Whether the Jenkins service account should be able to read Kubernetes secrets
   readSecrets: false
+  # -- Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints
+  useOpenShiftNonRootSCC: false
 
 serviceAccount:
   # -- Configures if a ServiceAccount with this name should be created


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

OpenShift by default has very stringent pod security requirements for containers that often don't neatly align with upstream k8s Pod Security Standards. The "nonroot-v2" SecurityContextConstraint aligns most closely with the "restricted" pod security standard, but must be explicitly granted to a service account in order to be used. Granting the Jenkins service account permission to use the "nonroot-v2" SCC allows the StatefulSet to deploy on an OpenShift cluster.

- Fixes #1207 

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

- Note that to grant this SCC to Jenkins, the Helm chart needs to be deployed by a user with cluster-admin (or similar) permissions. Does this need to be noted in other documentation?
- Question for future/followup - should we consider a separate `openshift` section in `values.yaml`? I noticed `route` is in the controller options, which is likewise an openshift-ism not available in standard Kubernetes.
