### PR TITLE
replace invalid  "+" with valid character

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.7.5
+
+Fix helm release deployment with flux revision reconciliation
+
 ## 5.7.4
 
 Update `kubernetes` to version `4292.v11898cf8fa_66`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.7.4
+version: 5.7.5
 appVersion: 2.462.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/auto-reload-config.yaml
+++ b/charts/jenkins/templates/auto-reload-config.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     "app.kubernetes.io/name": {{ template "jenkins.name" . }}
     {{- if .Values.renderHelmLabels }}
-    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     {{- end }}
     "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
     "app.kubernetes.io/instance": "{{ $.Release.Name }}"

--- a/charts/jenkins/templates/jcasc-config.yaml
+++ b/charts/jenkins/templates/jcasc-config.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     "app.kubernetes.io/name": {{ template "jenkins.name" $root}}
     {{- if $root.Values.renderHelmLabels }}
-    "helm.sh/chart": "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
+    "helm.sh/chart": "{{ $root.Chart.Name }}-{{ $root.Chart.Version | replace "+" "_" }}"
     {{- end }}
     "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
     "app.kubernetes.io/instance": "{{ $.Release.Name }}"
@@ -36,7 +36,7 @@ metadata:
   labels:
     "app.kubernetes.io/name": {{ template "jenkins.name" $root}}
     {{- if .Values.renderHelmLabels }}
-    "helm.sh/chart": "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
+    "helm.sh/chart": "{{ $root.Chart.Name }}-{{ $root.Chart.Version | replace "+" "_" }}"
     {{- end }}
     "app.kubernetes.io/managed-by": "{{ $.Release.Service }}"
     "app.kubernetes.io/instance": "{{ $.Release.Name }}"


### PR DESCRIPTION
### What does this PR do?

replace '+' with '_' in chart version.

flux will version chart with <chart-version>+<revision> when using revision reconciliation strategy.  This break deployment.


- Fixes #

deployment via flux
```
 Helm upgrade failed for release jenkins/jenkins with chart jenkins@5.6.1+087b605ce3dd.11: 
   cannot patch "jenkins-jenkins-config-credentials" with kind ConfigMap: 
     ConfigMap "jenkins-jenkins-config-credentials" is invalid: 
       metadata.labels: Invalid value: "jenkins-5.6.1+087b605ce3dd.11":
```

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
