### PR TITLE
Revert "chore(deps): update dependency jenkins-x-plugins/jx-release-version to v2.7.7"

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -10,7 +10,7 @@ export HELM_VERSION=v3.16.3
 export HELM_UNITTEST_VERSION=v0.6.3
 
 # renovate: datasource=github-tags depName=jenkins-x-plugins/jx-release-version
-export JENKINS_JX_VERSION=v2.7.7
+export JENKINS_JX_VERSION=v2.7.6
 
 # renovate: datasource=github-releases depName=norwoodj/helm-docs
 export HELM_DOCS_VERSION=1.14.2


### PR DESCRIPTION
Reverts jenkinsci/helm-charts#1239

seeing `jx-release-version: command not found` in renovate actions 