### PR TITLE
Allow setting automountServiceAccountToken

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.8.4
+
+Allow setting [automountServiceAccountToken](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting)
+
 ## 5.8.3
 
 Update `docker.io/kiwigrid/k8s-sidecar` to version `1.29.0`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.3
+version: 5.8.4
 appVersion: 2.479.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 1800 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -68,11 +68,11 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [agent.workspaceVolume](./values.yaml#L1053) | object | Workspace volume (defaults to EmptyDir) | `{}` |
 | [agent.yamlMergeStrategy](./values.yaml#L1142) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
 | [agent.yamlTemplate](./values.yaml#L1131) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1352) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1354) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1356) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1355) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1349) | bool | Checks if any deprecated values are used | `true` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1356) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1358) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1360) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1359) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1353) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L543) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L548) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -279,9 +279,9 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.usePodSecurityContext](./values.yaml#L182) | bool | Enable pod security context (must be `true` if podSecurityContextOverride, runAsUser or fsGroup are set) | `true` |
 | [credentialsId](./values.yaml#L27) | string | The Jenkins credentials to access the Kubernetes API server. For the default cluster it is not needed. | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1365) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1367) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1369) | string | Tag of the image to test the framework | `"1.11.1"` |
+| [helmtest.bats.image.registry](./values.yaml#L1369) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1371) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1373) | string | Tag of the image to test the framework | `"1.11.1"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
@@ -308,12 +308,14 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [rbac.useOpenShiftNonRootSCC](./values.yaml#L1317) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
 | [serviceAccount.annotations](./values.yaml#L1327) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.automountServiceAccountToken](./values.yaml#L1333) | bool | Auto-mount ServiceAccount token | `true` |
 | [serviceAccount.create](./values.yaml#L1321) | bool | Configures if a ServiceAccount with this name should be created | `true` |
 | [serviceAccount.extraLabels](./values.yaml#L1329) | object | Configures extra labels for the ServiceAccount | `{}` |
 | [serviceAccount.imagePullSecretName](./values.yaml#L1331) | string | Controller ServiceAccount image pull secret | `nil` |
 | [serviceAccount.name](./values.yaml#L1325) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1342) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.create](./values.yaml#L1336) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1344) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1346) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1340) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1344) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1350) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccountAgent.create](./values.yaml#L1338) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1346) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1348) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1342) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -107,6 +107,7 @@ spec:
   {{- end }}
 {{- end }}
       serviceAccountName: "{{ template "jenkins.serviceAccountName" . }}"
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- if .Values.controller.hostNetworking }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/jenkins/templates/service-account-agent.yaml
+++ b/charts/jenkins/templates/service-account-agent.yaml
@@ -1,6 +1,7 @@
 {{ if .Values.serviceAccountAgent.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccountAgent.automountServiceAccountToken }}
 metadata:
   name: {{ include "jenkins.serviceAccountAgentName" . }}
   namespace: {{ template "jenkins.agent.namespace" . }}

--- a/charts/jenkins/templates/service-account.yaml
+++ b/charts/jenkins/templates/service-account.yaml
@@ -1,6 +1,7 @@
 {{ if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "jenkins.serviceAccountName" . }}
   namespace: {{ template "jenkins.namespace" . }}

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -22,6 +22,7 @@ default values:
           app.kubernetes.io/managed-by: Helm
           app.kubernetes.io/name: jenkins
       spec:
+        automountServiceAccountToken: true
         containers:
           - args:
               - --httpPort=8080
@@ -242,6 +243,7 @@ test scheme for config-reload:
           app.kubernetes.io/managed-by: Helm
           app.kubernetes.io/name: jenkins
       spec:
+        automountServiceAccountToken: true
         containers:
           - args:
               - --httpPort=8080

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -1329,6 +1329,8 @@ serviceAccount:
   extraLabels: {}
   # -- Controller ServiceAccount image pull secret
   imagePullSecretName:
+  # -- Auto-mount ServiceAccount token
+  automountServiceAccountToken: true
 
 
 serviceAccountAgent:
@@ -1344,6 +1346,8 @@ serviceAccountAgent:
   extraLabels: {}
   # -- Agent ServiceAccount image pull secret
   imagePullSecretName:
+  # -- Auto-mount ServiceAccount token
+  automountServiceAccountToken: true
 
 # -- Checks if any deprecated values are used
 checkDeprecation: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

By default, kubernetes enables "automountServiceAccountToken" for all pods, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting.
This poses a security risk, as pods might get kube-api permissions unintentionally.
More specifically, this fails security compliance tests:
https://learn.microsoft.com/en-us/azure/governance/policy/samples/built-in-policies
https://www.azadvertizer.net/azpolicyadvertizer/kubernetes_block-automount-token.html

Solution - Disable "automountServiceAccountToken", create projected volume for the token, and mount it on relevant containers

### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

This does not effect default behavior, though if someone is looking to comply with security requirements and disable this, they must also manually mount the serviceAccount token, with the following values.yaml:
```
serviceAccount:
  automountServiceAccountToken: false
persistence:
  volumes:
    - name: kube-api-access
      projected:
        defaultMode: 420
        sources:
          - serviceAccountToken:
              expirationSeconds: 3607
              path: token
          - configMap:
              items:
                - key: ca.crt
                  path: ca.crt
              name: kube-root-ca.crt
          - downwardAPI:
              items:
                - fieldRef:
                    apiVersion: v1
                    fieldPath: metadata.namespace
                  path: namespace
  mounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access
      readOnly: true
controller:
  sidecars:
    configAutoReload:
      additionalVolumeMounts:
        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
          name: kube-api-access
          readOnly: true
```