### PR TITLE
fix: fix jenkins-agent renovate version regex

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -17,7 +17,7 @@
   packageRules: [
     {
       matchPackageNames: ["jenkins/inbound-agent"],
-      versioning: "regex:^(?<major>\\d+)?\\.(?<minor>\\w+?)?_(?<patch>\\w+)?-(?<build>\\d+)?$",
+      versioning: "regex:^(?<major>\d+)?\.(?<minor>\w+?)?-(?<build>\d+)?$",
     },
     {
       matchPackageNames: ["jenkins/jenkins"],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
I found a small issue (misunderstanding on my part) in how the version numbers for Jenkins Agents work. Apparently version numbers don't always contain `_` (and the split doesn't specify patch-level changes)?
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
