### PR TITLE
fix: fix renovate jenkins/inbound-agent versioning regex

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -17,7 +17,7 @@
   packageRules: [
     {
       matchPackageNames: ["jenkins/inbound-agent"],
-      versioning: "regex:^(?<major>\\d+)?\\.(?<minor>\\w+?)?-(?<build>\\d+)?$",
+      versioning: "regex:^(?<major>\\d+)[\\w.]+?-(?<minor>\\d+)$",
     },
     {
       matchPackageNames: ["jenkins/jenkins"],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
This PR fixes the jenkins/inbound-agent versioning regex.

I had some misconceptions about the versioning string. I interpreted `3283.v92c105e0f819-8` as `<major>.<minor>-<patch/build>`. The way I understand it now is `<major/remoting-version>-<minor/build/inbound-agent-version>`. As I found out, Renovate only supports numeric versions, and thus only the parts `3283` and `8` can be parsed. I know called these major and minor respectively, although they can be any combination of `major`, `minor`, `patch`, and `build`. Please advise if you'd like me to use another combination for this.
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
