### PR TITLE
fix: Update Jenkins agentListenerPort in config.xml to reflect Helm

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.8.13
+
+Fix `agentListenerPort` not being updated in `config.xml` when set via Helm values.
+
 ## 5.8.12
 
 Update plugin count.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.12
+version: 5.8.13
 appVersion: 2.492.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -309,6 +309,7 @@ jenkins:
   {{- /* restore root */}}
   {{- $_ := set $ "Values" $oldRoot.Values }}
   {{- end }}
+  slaveAgentPort: {{ .Values.controller.agentListenerPort }}
   {{- if .Values.controller.csrf.defaultCrumbIssuer.enabled }}
   crumbIssuer:
     standard:

--- a/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
@@ -121,6 +121,7 @@ additional clouds:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -313,6 +314,7 @@ additional clouds inheriting additional agents:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -476,6 +478,7 @@ additional clouds overriding additional agents:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -610,6 +613,7 @@ additional clouds set skipTlsVerify:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -744,6 +748,7 @@ additional clouds set usageRestricted:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -832,6 +837,7 @@ adds custom labels on agent pods:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -991,6 +997,7 @@ agent namespace and templates:
                     resourceLimitCpu: "1"
                     resourceLimitMemory: "1024Mi"
                     resourceLimitEphemeralStorage: "2Gi"
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1082,6 +1089,7 @@ agent with liveness probe:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1188,6 +1196,7 @@ agents with liveness probe:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1273,6 +1282,7 @@ configure hostnetworking to agent:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1362,6 +1372,7 @@ custom dynamic pvc workspace volume:
                     storageClassName: "gp2"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1449,6 +1460,7 @@ custom emptyDir workspace volume:
                     memory: true
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1536,6 +1548,7 @@ custom hostPath workspace volume:
                     hostPath: "/data"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1620,6 +1633,7 @@ custom jenkins label:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1709,6 +1723,7 @@ custom nfs workspace volume:
                     serverPath: "/data"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1797,6 +1812,7 @@ custom other workspace volume:
                     readOnly: false
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -1885,6 +1901,7 @@ custom pvc workspace volume:
                     readOnly: false
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2017,6 +2034,7 @@ customized config:
                       value: "value"
                 yamlMergeStrategy: merge
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2102,6 +2120,7 @@ default config:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2153,6 +2172,7 @@ disable agents:
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
             credentialsId: ""
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2236,6 +2256,7 @@ disable useDefaultServiceAccount:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2319,6 +2340,7 @@ empty projectNamingStrategy:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2403,6 +2425,7 @@ legacyRemotingSecurityEnabled = false:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2489,6 +2512,7 @@ legacyRemotingSecurityEnabled = true:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2576,6 +2600,7 @@ non-string projectNamingStrategy:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2660,6 +2685,7 @@ set agent.serviceAccount:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2743,6 +2769,7 @@ set directConnection:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2827,6 +2854,7 @@ set restrictedPssSecurityContext:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -2920,6 +2948,7 @@ set secretEnvVars:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -3020,6 +3049,7 @@ specify additional container:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -3149,6 +3179,7 @@ specify additional container and clear in additional agent:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -3294,6 +3325,7 @@ specify additional container and overwrite in additional agent:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -3378,6 +3410,7 @@ specify security settings with apiToken override:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true
@@ -3459,6 +3492,7 @@ specify security settings without apiToken override:
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
+        slaveAgentPort: 50000
         crumbIssuer:
           standard:
             excludeClientIPFromCrumb: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

This PR fixes an issue where the agentListenerPort in Jenkins does not update correctly when modified via Helm values. Specifically, even though the slaveAgentPort is set correctly in the Jenkins container's startup command and environment variables, the /var/jenkins_home/config.xml file retains the default value of 50000, causing Jenkins to continue listening on the incorrect port.

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
