### PR TITLE
fix: update jenkins/jenkins to 2.492.2-jdk21

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 5.8.31
 
-Update `jenkins/jenkins` to version `2.492.3-jdk17`
+Update `jenkins/jenkins` to version `2.492.3-jdk21`
 
 ## 5.8.30
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,9 +12,13 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
-## 5.8.31
+## 5.8.32
 
 Update `jenkins/jenkins` to version `2.492.3-jdk21`
+
+## 5.8.31
+
+Update `jenkins/jenkins` to version `2.492.3-jdk17`
 
 ## 5.8.30
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.31
+version: 5.8.32
 appVersion: 2.492.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.
@@ -38,7 +38,7 @@ annotations:
       url: https://github.com/jenkinsci/helm-charts/issues
   artifacthub.io/images: |
     - name: jenkins
-      image: docker.io/jenkins/jenkins:2.492.3-jdk17
+      image: docker.io/jenkins/jenkins:2.492.3-jdk21
     - name: k8s-sidecar
       image: docker.io/kiwigrid/k8s-sidecar:1.30.3
     - name: inbound-agent

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -145,8 +145,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.image.pullPolicy](./values.yaml#L47) | string | Controller image pull policy | `"Always"` |
 | [controller.image.registry](./values.yaml#L37) | string | Controller image registry | `"docker.io"` |
 | [controller.image.repository](./values.yaml#L39) | string | Controller image repository | `"jenkins/jenkins"` |
-| [controller.image.tag](./values.yaml#L42) | string | Controller image tag override; i.e., tag: "2.440.1-jdk17" | `nil` |
-| [controller.image.tagLabel](./values.yaml#L45) | string | Controller image tag label | `"jdk17"` |
+| [controller.image.tag](./values.yaml#L42) | string | Controller image tag override; i.e., tag: "2.440.1-jdk21" | `nil` |
+| [controller.image.tagLabel](./values.yaml#L45) | string | Controller image tag label | `"jdk21"` |
 | [controller.imagePullSecretName](./values.yaml#L49) | string | Controller image pull secret | `nil` |
 | [controller.ingress.annotations](./values.yaml#L712) | object | Ingress annotations | `{}` |
 | [controller.ingress.apiVersion](./values.yaml#L708) | string | Ingress API version | `"extensions/v1beta1"` |

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -41,7 +41,7 @@ default values:
                 value: "50000"
               - name: CASC_JENKINS_CONFIG
                 value: /var/jenkins_home/casc_configs
-            image: docker.io/jenkins/jenkins:2.492.3-jdk17
+            image: docker.io/jenkins/jenkins:2.492.3-jdk21
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 5
@@ -162,7 +162,7 @@ default values:
           - command:
               - sh
               - /var/jenkins_config/apply_config.sh
-            image: docker.io/jenkins/jenkins:2.492.3-jdk17
+            image: docker.io/jenkins/jenkins:2.492.3-jdk21
             imagePullPolicy: Always
             name: init
             resources:
@@ -262,7 +262,7 @@ test scheme for config-reload:
                 value: "50000"
               - name: CASC_JENKINS_CONFIG
                 value: /var/jenkins_home/casc_configs
-            image: docker.io/jenkins/jenkins:2.492.3-jdk17
+            image: docker.io/jenkins/jenkins:2.492.3-jdk21
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 5
@@ -383,7 +383,7 @@ test scheme for config-reload:
           - command:
               - sh
               - /var/jenkins_config/apply_config.sh
-            image: docker.io/jenkins/jenkins:2.492.3-jdk17
+            image: docker.io/jenkins/jenkins:2.492.3-jdk21
             imagePullPolicy: Always
             name: init
             resources:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -38,11 +38,11 @@ controller:
     # -- Controller image repository
     repository: "jenkins/jenkins"
 
-    # -- Controller image tag override; i.e., tag: "2.440.1-jdk17"
+    # -- Controller image tag override; i.e., tag: "2.440.1-jdk21"
     tag:
 
     # -- Controller image tag label
-    tagLabel: jdk17
+    tagLabel: jdk21
     # -- Controller image pull policy
     pullPolicy: "Always"
   # -- Controller image pull secret


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?
This PR updates Jenkins from JDK17 to JDK21. This new JDK LTS has been supported in the LTS version of Jenkins for quite a while: https://www.jenkins.io/doc/book/platform-information/support-policy-java/
<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer
Not sure what you think about the timing of updating the JDK version. Also; would you prefer a different version bump or is this correct?
<!-- Leave blank if none -->
