### PR TITLE
fix: correct type / default value

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 5.8.44
 
-Fix the default value for `controller.sidecars.configAutoReload.env` (change from `{}` to `[]`) to address `coalesce.go:286: warning: cannot overwrite table with non table` 
+Fix the default value for `controller.sidecars.configAutoReload.env` (change from `{}` to `[]`) to address `coalesce.go:286: warning: cannot overwrite table with non table`.
 
 ## 5.8.43
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.8.44
+
+Fix the default value for `controller.sidecars.configAutoReload.env` (change from `{}` to `[]`) to address `coalesce.go:286: warning: cannot overwrite table with non table` 
+
 ## 5.8.43
 
 Update `configuration-as-code` to version `1967.va_968e15fd05b_`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.43
+version: 5.8.44
 appVersion: 2.504.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -252,7 +252,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.sidecars.configAutoReload.additionalVolumeMounts](./values.yaml#L581) | list | Enables additional volume mounts for the config auto-reload container | `[]` |
 | [controller.sidecars.configAutoReload.containerSecurityContext](./values.yaml#L630) | object | Enable container security context | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true}` |
 | [controller.sidecars.configAutoReload.enabled](./values.yaml#L564) | bool | Enables Jenkins Config as Code auto-reload | `true` |
-| [controller.sidecars.configAutoReload.env](./values.yaml#L612) | object | Environment variables for the Jenkins Config as Code auto-reload container | `{}` |
+| [controller.sidecars.configAutoReload.env](./values.yaml#L612) | list | Environment variables for the Jenkins Config as Code auto-reload container | `[]` |
 | [controller.sidecars.configAutoReload.envFrom](./values.yaml#L610) | list | Environment variable sources for the Jenkins Config as Code auto-reload container | `[]` |
 | [controller.sidecars.configAutoReload.folder](./values.yaml#L623) | string |  | `"/var/jenkins_home/casc_configs"` |
 | [controller.sidecars.configAutoReload.image.registry](./values.yaml#L567) | string | Registry for the image that triggers the reload | `"docker.io"` |

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -609,7 +609,7 @@ controller:
       # -- Environment variable sources for the Jenkins Config as Code auto-reload container
       envFrom: []
       # -- Environment variables for the Jenkins Config as Code auto-reload container
-      env: {}
+      env: []
       #   - name: REQ_TIMEOUT
       #     value: "30"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes an incorrectly declared default value (and type in docs), which was resulting in a warning in Helm: `coalesce.go:286: warning: cannot overwrite table with non table`

If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist

- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

<!-- Leave blank if none -->
