### PR TITLE
Set agent CPU resources requests/limits to exactly .5 CPUs

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.8.57
+
+Update the agent pod's default cpu requests/limits from `512m` to `500m`
+
 ## 5.8.56
 
 Update `jenkins/inbound-agent` to version `3309.v27b_9314fd1a_4-4`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.56
+version: 5.8.57
 appVersion: 2.504.2
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -50,7 +50,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [agent.podRetention](./values.yaml#L1009) | string |  | `"Never"` |
 | [agent.podTemplates](./values.yaml#L1183) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
 | [agent.privileged](./values.yaml#L973) | bool | Agent privileged container | `false` |
-| [agent.resources](./values.yaml#L981) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
+| [agent.resources](./values.yaml#L981) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}}` |
 | [agent.restrictedPssSecurityContext](./values.yaml#L1006) | bool | Set a restricted securityContext on jnlp containers | `false` |
 | [agent.retentionTimeout](./values.yaml#L947) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
 | [agent.runAsGroup](./values.yaml#L977) | string | Configure container group | `nil` |

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -980,11 +980,11 @@ agent:
   # -- Resources allocation (Requests and Limits)
   resources:
     requests:
-      cpu: "512m"
+      cpu: "500m"
       memory: "512Mi"
       # ephemeralStorage:
     limits:
-      cpu: "512m"
+      cpu: "500m"
       memory: "512Mi"
       # ephemeralStorage:
   livenessProbe: {}


### PR DESCRIPTION
While `512m` is technically a valid quantity, it implies that the CPU is a binary-oriented resource like memory, instead of decimal-oriented.

I'd consider this only a patch change, since despite it being a change to the default values, I doubt there's anyone out there strictly relying on those extra 12 milli-CPUs being available. It does potentially mean that more agents will get scheduled than before in a cluster that generally uses "round" numbers for scheduling (e.g. if a node had 1 whole CPU free, it could now schedule 2 agent pods instead of just 1), but the whole point of requests/limits is to allow kubernetes to pack in pods as effectively as possible.

<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
