### PR TITLE
fix: Fix docker-agent git repo url in Chart.yaml

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.8.91
+
+Fix `docker-agent` git repository url
+
 ## 5.8.90
 
 Update `jenkins/inbound-agent` to version `3341.v0766d82b_dec0-1`

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 5.8.91
 
-Fix `docker-agent` git repository url
+Fix `docker-agent` git repository URL
 
 ## 5.8.90
 

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.90
+version: 5.8.91
 appVersion: 2.516.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -9,7 +9,7 @@ description: >
 
 sources:
   - https://github.com/jenkinsci/jenkins
-  - https://github.com/jenkinsci/docker-inbound-agent
+  - https://github.com/jenkinsci/docker-agent
   - https://github.com/maorfr/kube-tasks
   - https://github.com/jenkinsci/configuration-as-code-plugin
 maintainers:


### PR DESCRIPTION
### What does this PR do?

Fix deprecated url. [docker-inbound-agent](https://github.com/jenkinsci/docker-inbound-agent) repository is deprecated and `jenkins/inbound-agent` is now built from the [docker-agent](https://github.com/jenkinsci/docker-agent/) repo, but we forgot to update the reference in `charts/jenkins/Chart.yaml`.