### PR TITLE
Reverting update of k8s-sidecar due to upstream bug

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.8.65
+
+Revert update of `docker.io/kiwigrid/k8s-sidecar` back to `1.30.3` which works due to upstream [bug](https://github.com/python/cpython/issues/135408)
+
 ## 5.8.64
 
 Update `kubernetes` to version `4358.vcfd9c5a_0a_f51`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.64
+version: 5.8.65
 appVersion: 2.504.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.
@@ -40,7 +40,7 @@ annotations:
     - name: jenkins
       image: docker.io/jenkins/jenkins:2.504.3-jdk21
     - name: k8s-sidecar
-      image: docker.io/kiwigrid/k8s-sidecar:1.30.5
+      image: docker.io/kiwigrid/k8s-sidecar:1.30.3
     - name: inbound-agent
       image: jenkins/inbound-agent:3309.v27b_9314fd1a_4-6
   artifacthub.io/category: "integration-delivery"

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -259,7 +259,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.sidecars.configAutoReload.folder](./values.yaml#L627) | string |  | `"/var/jenkins_home/casc_configs"` |
 | [controller.sidecars.configAutoReload.image.registry](./values.yaml#L569) | string | Registry for the image that triggers the reload | `"docker.io"` |
 | [controller.sidecars.configAutoReload.image.repository](./values.yaml#L571) | string | Repository of the image that triggers the reload | `"kiwigrid/k8s-sidecar"` |
-| [controller.sidecars.configAutoReload.image.tag](./values.yaml#L573) | string | Tag for the image that triggers the reload | `"1.30.5"` |
+| [controller.sidecars.configAutoReload.image.tag](./values.yaml#L573) | string | Tag for the image that triggers the reload | `"1.30.3"` |
 | [controller.sidecars.configAutoReload.imagePullPolicy](./values.yaml#L574) | string |  | `"IfNotPresent"` |
 | [controller.sidecars.configAutoReload.logging](./values.yaml#L591) | object | Config auto-reload logging settings | `{"configuration":{"backupCount":3,"formatter":"JSON","logLevel":"INFO","logToConsole":true,"logToFile":false,"maxBytes":1024,"override":false}}` |
 | [controller.sidecars.configAutoReload.logging.configuration.override](./values.yaml#L595) | bool | Enables custom log config utilizing using the settings below. | `false` |

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -120,7 +120,7 @@ default values:
                 value: POST
               - name: REQ_RETRY_CONNECT
                 value: "10"
-            image: docker.io/kiwigrid/k8s-sidecar:1.30.5
+            image: docker.io/kiwigrid/k8s-sidecar:1.30.3
             imagePullPolicy: IfNotPresent
             name: config-reload
             resources: {}
@@ -147,7 +147,7 @@ default values:
                 value: my-namespace
               - name: METHOD
                 value: LIST
-            image: docker.io/kiwigrid/k8s-sidecar:1.30.5
+            image: docker.io/kiwigrid/k8s-sidecar:1.30.3
             imagePullPolicy: IfNotPresent
             name: config-reload-init
             resources: {}
@@ -341,7 +341,7 @@ test scheme for config-reload:
                 value: POST
               - name: REQ_RETRY_CONNECT
                 value: "10"
-            image: docker.io/kiwigrid/k8s-sidecar:1.30.5
+            image: docker.io/kiwigrid/k8s-sidecar:1.30.3
             imagePullPolicy: IfNotPresent
             name: config-reload
             resources: {}
@@ -368,7 +368,7 @@ test scheme for config-reload:
                 value: my-namespace
               - name: METHOD
                 value: LIST
-            image: docker.io/kiwigrid/k8s-sidecar:1.30.5
+            image: docker.io/kiwigrid/k8s-sidecar:1.30.3
             imagePullPolicy: IfNotPresent
             name: config-reload-init
             resources: {}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -570,7 +570,7 @@ controller:
         # -- Repository of the image that triggers the reload
         repository: kiwigrid/k8s-sidecar
         # -- Tag for the image that triggers the reload
-        tag: 1.30.5
+        tag: 1.30.3
       imagePullPolicy: IfNotPresent
       resources:
         {}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->
This PR reverts the update of k8s-sidecar as `1.30.4` and `1.30.5` are both broken. The apparent cause is https://github.com/python/cpython/issues/135408. There's many projects having the same issue as a result.

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
