### PR TITLE
test: unittest fix - allow helm version label to be dynamic

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.8.74
+
+unittest fix - allow helm version label to be dynamic in tests
+
 ## 5.8.73
 
 Standardize labels and add extraLabels support across chart:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.73
+version: 5.8.74
 appVersion: 2.516.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/unittests/__snapshot__/config-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/config-test.yaml.snap
@@ -6,7 +6,7 @@ additional plugins config:
       git:5.7.0
       configuration-as-code:1971.vf9280461ea_89
       kubernetes-credentials-provider
-default config:
+default config without helm labels:
   1: |
     |-
       kubernetes:4358.vcfd9c5a_0a_f51

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -15,13 +15,12 @@ default values:
     template:
       metadata:
         annotations:
-          checksum/config: 6438ed630c02d2c61fe3230c437364220864c92002e2414b37637b2a9bce5607
+          checksum/config: 0dfbdfbd7c5ddacfa10d4f47d8e1ea5fb0d32fe36db120b5b5c0cde06ce12b19
         labels:
           app.kubernetes.io/component: jenkins-controller
           app.kubernetes.io/instance: my-release
           app.kubernetes.io/managed-by: Helm
           app.kubernetes.io/name: jenkins
-          helm.sh/chart: jenkins-5.8.73
       spec:
         automountServiceAccountToken: true
         containers:
@@ -223,7 +222,7 @@ default values:
             name: tmp-volume
 render pod annotations:
   1: |
-    checksum/config: 6438ed630c02d2c61fe3230c437364220864c92002e2414b37637b2a9bce5607
+    checksum/config: 964ceb18a473e1015035d0bc0aefd4a716baf1430997b6cab4dbe54db9e07180
     fixed-annotation: some-fixed-annotation
     templated-annotations: my-release
 test scheme for config-reload:
@@ -237,13 +236,12 @@ test scheme for config-reload:
     template:
       metadata:
         annotations:
-          checksum/config: 6438ed630c02d2c61fe3230c437364220864c92002e2414b37637b2a9bce5607
+          checksum/config: 0dfbdfbd7c5ddacfa10d4f47d8e1ea5fb0d32fe36db120b5b5c0cde06ce12b19
         labels:
           app.kubernetes.io/component: jenkins-controller
           app.kubernetes.io/instance: my-release
           app.kubernetes.io/managed-by: Helm
           app.kubernetes.io/name: jenkins
-          helm.sh/chart: jenkins-5.8.73
       spec:
         automountServiceAccountToken: true
         containers:

--- a/charts/jenkins/unittests/config-test.yaml
+++ b/charts/jenkins/unittests/config-test.yaml
@@ -8,6 +8,22 @@ tests:
           of: ConfigMap
       - hasDocuments:
           count: 1
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/component: jenkins-controller
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: jenkins
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: "^jenkins-[0-9]+\\.[0-9]+\\.[0-9]+$"
+  - it: default config without helm labels
+    set:
+      renderHelmLabels: false
+    asserts:
+      - isKind:
+          of: ConfigMap
       - equal:
           path: metadata.labels
           value:
@@ -15,7 +31,6 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: jenkins
-            helm.sh/chart: jenkins-5.8.73
       - equal:
           path: data["apply_config.sh"]
           value: |-

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -10,6 +10,8 @@ templates:
 tests:
   - it: default values
     template: jenkins-controller-statefulset.yaml
+    set:
+      renderHelmLabels: false
     asserts:
       - isKind:
           of: StatefulSet
@@ -22,9 +24,6 @@ tests:
       - equal:
           path: metadata.namespace
           value: my-namespace
-      - matchRegex:
-          path: metadata.labels["helm.sh/chart"]
-          pattern: ^jenkins-
       - isNull:
           path: metadata.annotations
       - equal:
@@ -558,6 +557,7 @@ tests:
   - it: test scheme for config-reload
     template: jenkins-controller-statefulset.yaml
     set:
+      renderHelmLabels: false
       controller.sidecars.configAutoReload.scheme: "https"
     asserts:
       - matchSnapshot:
@@ -825,4 +825,4 @@ tests:
       - isSubset:
           path: spec.template.metadata.annotations
           content:
-            checksum/config-init-scripts: d0c9eb028da193e56dd8aeb4f214e61bb732ddef82c54455ee3388bb0c33ef57
+            checksum/config-init-scripts: ef946fbeeb0d0cb6f5bd34506d57ccb1dcd932a493dd38bf53e13dc2b9206078


### PR DESCRIPTION
  ### What does this PR do?

  Fixes snapshot tests breaking on automated chart version bumps by using `renderHelmLabels: false` in tests.

  **Context**:
  - Follow-up to https://github.com/jenkinsci/helm-charts/pull/1430#discussion_r2246464837
  - Automated PRs that bump chart versions keep failing tests like https://github.com/jenkinsci/helm-charts/actions/runs/16637614349/job/47081568241#step:8:170 

  **The Problem**: 
  Snapshots hardcode the helm chart version (e.g. `helm.sh/chart: jenkins-5.8.73`), so when automated tools bump the version, tests fail because the snapshot expects the old version but gets the new one. The label got added in my previous PR here https://github.com/jenkinsci/helm-charts/pull/1430

  **The Fix**:
  Use `renderHelmLabels: false` in snapshot tests so they don't include the dynamic version label. Much less complex than trying to make automated PRs also update snapshot files.

  ```[tasklist]
  ### Submitter checklist
  - [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
  - [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
  - [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
  - [x] I ran `.github/helm-docs.sh` from the project root.
```

**Notes:**

- Just test changes - no functional impact. 
- There are lots of other changes since last release, I've not updated the change log to include these, leaving that to your discretion. 