### PR TITLE
Downgrade jenkinx-jx-version

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -10,8 +10,8 @@ export HELM_VERSION=v3.18.4
 # renovate: datasource=github-tags depName=helm-unittest/helm-unittest
 export HELM_UNITTEST_VERSION=v1.0.0
 
-# renovate: datasource=github-tags depName=jenkins-x-plugins/jx-release-version
-export JENKINS_JX_VERSION=v2.7.13
+# renovate: datasource=github-releases depName=jenkins-x-plugins/jx-release-version
+export JENKINS_JX_VERSION=v2.7.9
 
 # renovate: datasource=github-releases depName=norwoodj/helm-docs
 export HELM_DOCS_VERSION=1.14.2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

Last 3 versions have been broken without files attached for download:

<img width="617" height="372" alt="image" src="https://github.com/user-attachments/assets/31c6c83d-aed7-4c84-b390-53c49dcce8e0" />

Downgrade to release before the last working one as I've switched it to the release datasource it should only fetch actually released ones now

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

```[tasklist]
### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.
```

### Special notes for your reviewer

<!-- Leave blank if none -->
