### PR TITLE
Revert "chore(deps): update renovatebot/github-action action to v43.0.6"

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v43.0.6
+        uses: renovatebot/github-action@v43.0.5
         with:
           token: "${{ steps.get_token.outputs.token }}"
           docker-cmd-file: .github/renovate-entrypoint.sh


### PR DESCRIPTION
Reverts jenkinsci/helm-charts#1445

See if this is related to dependency update failures