### PR TITLE
fix: make unittest checksum calculation deterministic

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.8.76
+
+Fix non-deterministic checksum calculation in unit tests by adding `renderHelmLabels: false` to "render pod annotations" test. This resolves Renovate PR failures when chart version changes.
+
 ## 5.8.75
 
 Minor documentation improvements

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.75
+version: 5.8.76
 appVersion: 2.516.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -236,7 +236,7 @@ default values:
             name: tmp-volume
 render pod annotations:
   1: |
-    checksum/config: 196ee73f223bd81f6a9ca60734bd278ae908da6226476f009f60ff7e3c524bf1
+    checksum/config: 0dfbdfbd7c5ddacfa10d4f47d8e1ea5fb0d32fe36db120b5b5c0cde06ce12b19
     fixed-annotation: some-fixed-annotation
     templated-annotations: my-release
 test scheme for config-reload:

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -599,6 +599,7 @@ tests:
   - it: render pod annotations
     template: jenkins-controller-statefulset.yaml
     set:
+      renderHelmLabels: false
       controller:
         podAnnotations:
           templated-annotations: "{{ .Release.Name }}"


### PR DESCRIPTION
### What does this PR do?

Fixes checksum calculation in helm unittest that caused Renovate PRs to fail CI checks.

- Should fix #1456
- Adds missing `renderHelmLabels: false` to "render pod annotations" test  
- Ensures chart version changes don't break unit tests

### Context

- Issue: https://github.com/jenkinsci/helm-charts/issues/1456
- Failed Renovate PR: https://github.com/jenkinsci/helm-charts/pull/1438
- Failed CI job: https://github.com/jenkinsci/helm-charts/actions/runs/16853856504/job/47744007632?pr=1438
- Related fix attempt: https://github.com/jenkinsci/helm-charts/pull/1444

### Root Cause

The "render pod annotations" test was missing `renderHelmLabels: false`, causing checksum to include chart version. When Renovate updated from 5.8.75 → 5.8.76, checksums became non-deterministic between environments.

### Solution

- Add `renderHelmLabels: false` to make test consistent with other tests
- Update snapshot

```[tasklist]
### Submitter checklist
- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.
```