### PR TITLE
Parameterize StatefulSet: replicas, image, ports, resources from valu…

### DIFF
--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -18,7 +18,7 @@ metadata:
   {{- end }}
 spec:
   serviceName: {{ template "jenkins.fullname" . }}
-  replicas: 1
+  replicas: {{ .Values.controller.replicaCount | default 1 }}
   selector:
     matchLabels:
       "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -685,6 +685,7 @@ controller:
   podAnnotations: {}
   # -- Annotations for controller StatefulSet
   statefulSetAnnotations: {}
+  replicaCount: 1
 
   # ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   # -- Update strategy for StatefulSet


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

This PR parameterizes the Jenkins StatefulSet Helm chart to allow configuration via `values.yaml` instead of hardcoding values.  

Specifically, this PR:
- Makes `replicas` configurable via `values.yaml`.
- Makes `image`, `ports`, `resources`, `env`, and volume mounts configurable via `values.yaml`.
- Updates the StatefulSet template to use these dynamic values.
- Ensures backward compatibility with default values if not specified in `values.yaml`.

- Fixes # (optional: link to any related issue)

---

### Submitter checklist

If you modified files in the `./charts/jenkins/` directory, please confirm:

- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.

---

### Special notes for your reviewer

- Reviewers should check that all previously hardcoded values are now parameterized.
- This change does not affect default behavior; if values are not set in `values.yaml`, the chart still works with default values.
- Tested on dev cluster with `replicaCount: 2` and custom `image`/`resources`.
