### PR TITLE
Revert "chore(deps): update dependency python to v3.14.0"

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           # renovate: datasource=custom.python_actions depName=python
-          python-version: 3.14.0
+          python-version: 3.13.7
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2


### PR DESCRIPTION
Reverts jenkinsci/helm-charts#1510

Caused failure in validation of charts: https://github.com/jenkinsci/helm-charts/pull/1512