### PR TITLE
Use kind versions that are available

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -15,8 +15,8 @@ jobs:
         kubernetes_version:
           # See https://kubernetes.io/releases/ for EOL dates
           - "kindest/node:v1.34.2"
-          - "kindest/node:v1.33.6"
-          - "kindest/node:v1.32.10"
+          - "kindest/node:v1.33.4"
+          - "kindest/node:v1.32.8"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

Looks like CI only runs on kind if the chart is changed, so https://github.com/jenkinsci/helm-charts/pull/1541 didn't validate it.

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- Fixes #

If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist
- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

<!-- Leave blank if none -->
