### PR TITLE
Uses cp -f (force) instead of interactive mode

### DIFF
--- a/charts/jenkins/unittests/config-test.yaml
+++ b/charts/jenkins/unittests/config-test.yaml
@@ -51,7 +51,7 @@ tests:
             fi
             echo "copy plugins to shared volume"
             # Copy plugins to shared volume
-            yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
+            cp -f /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/ 2>/dev/null || true
             echo "finished initialization"
       - matchSnapshot:
           path: data["plugins.txt"]
@@ -103,7 +103,7 @@ tests:
             fi
             echo "copy plugins to shared volume"
             # Copy plugins to shared volume
-            yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
+            cp -f /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/ 2>/dev/null || true
             echo "finished initialization"
   - it: install latest specified plugins
     set:
@@ -129,5 +129,5 @@ tests:
             fi
             echo "copy plugins to shared volume"
             # Copy plugins to shared volume
-            yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
+            cp -f /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/ 2>/dev/null || true
             echo "finished initialization"


### PR DESCRIPTION
The init container was failing because the script used yes n | cp -i to copy plugins. The interactive flag (-i) doesn't work reliably in containers, causing the script to fail with set -e.

<!-- markdownlint-disable MD041 -->
```csharp
namespace Jenkins;

internal class JenkinsStack : Pulumi.Stack
{
    public JenkinsStack()
    {
        Pulumi.Config config = new Pulumi.Config();
        string namespaceName = config.Require("namespace");
        string name = config.Require("name");

        // Create namespace
        var ns = new Pulumi.Kubernetes.Core.V1.Namespace(name, new Pulumi.Kubernetes.Types.Inputs.Core.V1.NamespaceArgs
        {
            Metadata = new Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
            {
                Name = namespaceName
            }
        }, new Pulumi.CustomResourceOptions
        {
            RetainOnDelete = namespaceName == "default"
        });

        // Install Jenkins via Helm
        // Note: Jenkins is Tier-0 infrastructure - requires persistent volumes, backups, JCasC
        var jenkinsChart = new Pulumi.Kubernetes.Helm.V4.Chart("jenkins", new Pulumi.Kubernetes.Types.Inputs.Helm.V4.ChartArgs
        {
            Chart = "jenkins",
            Version = "5.8.122", // Use latest stable
            Namespace = ns.Metadata.Apply(m => m.Name),
            RepositoryOpts = new Pulumi.Kubernetes.Types.Inputs.Helm.V4.RepositoryOptsArgs
            {
                Repo = "https://charts.jenkins.io"
            },
            Values = new System.Collections.Generic.Dictionary<string, object>
            {
                ["persistence"] = new System.Collections.Generic.Dictionary<string, object>
                {
                    ["size"] = "50Gi"
                },
                ["controller"] = new System.Collections.Generic.Dictionary<string, object>
                {
                    ["installPlugins"] = new System.Collections.Generic.List<string>
                    {
                        "workflow-aggregator",
                        "git",
                        "kubernetes",
                        "configuration-as-code"
                    }
                }
            },
            ValueYamlFiles = new Pulumi.InputList<Pulumi.AssetOrArchive>
            {
                new Pulumi.FileAsset("Resources/values.yaml")
            }
        }, new Pulumi.ComponentResourceOptions { DependsOn = { ns } });

        // Output Jenkins URL
        JenkinsUrl = Pulumi.Output.Create($"http://jenkins.{namespaceName}.svc.cluster.local:8080");
        NamespaceName = ns.Metadata.Apply(m => m.Name);
    }

    [Pulumi.Output] public Pulumi.Output<string> JenkinsUrl { get; set; }
    [Pulumi.Output] public Pulumi.Output<string> NamespaceName { get; set; }
}

internal class Program
{
    private static System.Threading.Tasks.Task<int> Main() =>
        Pulumi.Deployment.RunAsync<JenkinsStack>();
}
```
### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

- In the Pulumi code above, the `installPlugins` wasn't empty so Jenkins tried to install it but stuck at the copy stage.
If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist

- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

<!-- Leave blank if none -->
