### PR TITLE
fix: add `ingress.resourceRootUrl` to ingress' `spec.tls.hosts`

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.8.128
+
+Add `ingress.resourceRootUrl` to ingress' `spec.tls.hosts`
+
 ## 5.8.127
 
 Update `jenkins/inbound-agent` to version `3355.v388858a_47b_33-6`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.8.127
+version: 5.8.128
 appVersion: 2.541.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/jenkins-controller-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-ingress.yaml
@@ -66,6 +66,15 @@ spec:
 {{- end }}
 {{- if .Values.controller.ingress.tls }}
   tls:
-{{ tpl (toYaml .Values.controller.ingress.tls ) . | indent 4 }}
-{{- end -}}
+{{- range .Values.controller.ingress.tls }}
+  - hosts:
+{{- range .hosts }}
+      - {{ tpl . $ | quote }}
+{{- end }}
+{{- if $.Values.controller.ingress.resourceRootUrl }}
+      - {{ tpl $.Values.controller.ingress.resourceRootUrl $ | quote }}
+{{- end }}
+    secretName: {{ .secretName | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/jenkins/unittests/jenkins-controller-ingress-DRY-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-ingress-DRY-test.yaml
@@ -10,6 +10,7 @@ tests:
     template: jenkins-controller-ingress.yaml
     set:
       global.jenkinsHostname: "jenkins.example.com"
+      global.resourceRootUrlHostname: "assets.jenkins.example.com"
       controller.ingress:
         enabled: true
         hostName: "{{ .Values.global.jenkinsHostname }}"
@@ -17,6 +18,7 @@ tests:
         tls:
           - hosts:
               - "{{ .Values.global.jenkinsHostname }}"
+              - "{{ .Values.global.resourceRootUrlHostname }}"
     asserts:
       - equal:
           path: spec.rules[0].host
@@ -24,3 +26,6 @@ tests:
       - equal:
           path: spec.tls[0].hosts[0]
           value: "jenkins.example.com"
+      - equal:
+          path: spec.tls[0].hosts[1]
+          value: "assets.jenkins.example.com"


### PR DESCRIPTION
### What does this PR do?

This change adds `ingress.resourceRootUrl` to ingress' `spec.tls.hosts`, and takes this in account in the ingress test.

Refs:
- #1587 
- https://github.com/jenkins-infra/helpdesk/issues/4959

If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist

- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

<!-- Leave blank if none -->
