### PR TITLE
feat: Add support for annotations on the HTTPRoute resource

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.2
+
+Add support for annotations on the HTTPRoute resource
+
 ## 5.9.1
 
 Fix templating in secretName for ingress

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.1
+version: 5.9.2
 appVersion: 2.541.2
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -8,73 +8,73 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Key | Type | Description | Default |
 |:----|:-----|:---------|:------------|
-| [additionalAgents](./values.yaml#L1241) | object | Configure additional | `{}` |
-| [additionalClouds](./values.yaml#L1266) | object |  | `{}` |
-| [agent.TTYEnabled](./values.yaml#L1146) | bool | Allocate pseudo tty to the side container | `false` |
-| [agent.additionalContainers](./values.yaml#L1194) | list | Add additional containers to the agents | `[]` |
-| [agent.alwaysPullImage](./values.yaml#L1039) | bool | Always pull agent container image before build | `false` |
-| [agent.annotations](./values.yaml#L1190) | object | Annotations to apply to the pod | `{}` |
-| [agent.args](./values.yaml#L1140) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
-| [agent.command](./values.yaml#L1138) | string | Command to execute when side container starts | `nil` |
-| [agent.componentName](./values.yaml#L1007) | string |  | `"jenkins-agent"` |
-| [agent.connectTimeout](./values.yaml#L1188) | int | Timeout in seconds for an agent to be online | `100` |
-| [agent.containerCap](./values.yaml#L1148) | int | Max number of agents to launch for a whole cluster. | `10` |
-| [agent.customJenkinsLabels](./values.yaml#L1004) | list | Append Jenkins labels to the agent | `[]` |
-| [agent.defaultsProviderTemplate](./values.yaml#L956) | string | The name of the pod template to use for providing default values | `""` |
-| [agent.directConnection](./values.yaml#L1010) | bool |  | `false` |
-| [agent.disableDefaultAgent](./values.yaml#L1212) | bool | Disable the default Jenkins Agent configuration | `false` |
-| [agent.enabled](./values.yaml#L954) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
-| [agent.envVars](./values.yaml#L1121) | list | Environment variables for the agent Pod | `[]` |
-| [agent.garbageCollection.enabled](./values.yaml#L1157) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
-| [agent.garbageCollection.namespaces](./values.yaml#L1159) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
-| [agent.garbageCollection.timeout](./values.yaml#L1164) | int | Timeout value for orphaned pods | `300` |
-| [agent.hostNetworking](./values.yaml#L1018) | bool | Enables the agent to use the host network | `false` |
-| [agent.idleMinutes](./values.yaml#L1167) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
-| [agent.image.registry](./values.yaml#L995) | string | Registry to pull the agent jnlp image from | `""` |
-| [agent.image.repository](./values.yaml#L997) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
-| [agent.image.tag](./values.yaml#L999) | string | Tag of the image to pull | `"3355.v388858a_47b_33-14"` |
-| [agent.imagePullSecretName](./values.yaml#L1006) | string | Name of the secret to be used to pull the image | `nil` |
-| [agent.inheritYamlMergeStrategy](./values.yaml#L1186) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
-| [agent.instanceCap](./values.yaml#L1150) | int | Max number of agents to launch for this type of agent | `2147483647` |
-| [agent.jenkinsTunnel](./values.yaml#L972) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
-| [agent.jenkinsUrl](./values.yaml#L968) | string | Overrides the Kubernetes Jenkins URL | `nil` |
-| [agent.jnlpregistry](./values.yaml#L992) | string | Custom registry used to pull the agent jnlp image from | `nil` |
-| [agent.kubernetesConnectTimeout](./values.yaml#L978) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
-| [agent.kubernetesReadTimeout](./values.yaml#L980) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
-| [agent.livenessProbe](./values.yaml#L1029) | object |  | `{}` |
-| [agent.maxRequestsPerHostStr](./values.yaml#L982) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
-| [agent.namespace](./values.yaml#L988) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
-| [agent.nodeSelector](./values.yaml#L1132) | object | Node labels for pod assignment | `{}` |
-| [agent.nodeUsageMode](./values.yaml#L1002) | string |  | `"NORMAL"` |
-| [agent.podLabels](./values.yaml#L990) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
-| [agent.podName](./values.yaml#L1152) | string | Agent Pod base name | `"default"` |
-| [agent.podRetention](./values.yaml#L1048) | string |  | `"Never"` |
-| [agent.podTemplates](./values.yaml#L1222) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
-| [agent.privileged](./values.yaml#L1012) | bool | Agent privileged container | `false` |
-| [agent.resources](./values.yaml#L1020) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
-| [agent.restrictedPssSecurityContext](./values.yaml#L1045) | bool | Set a restricted securityContext on jnlp containers | `false` |
-| [agent.retentionTimeout](./values.yaml#L984) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
-| [agent.runAsGroup](./values.yaml#L1016) | string | Configure container group | `nil` |
-| [agent.runAsUser](./values.yaml#L1014) | string | Configure container user | `nil` |
-| [agent.secretEnvVars](./values.yaml#L1125) | list | Mount a secret as environment variable | `[]` |
-| [agent.serviceAccount](./values.yaml#L964) | string | Override the default service account | `serviceAccountAgent.name` if `agent.useDefaultServiceAccount` is `true` |
-| [agent.showRawYaml](./values.yaml#L1052) | bool |  | `true` |
-| [agent.sideContainerName](./values.yaml#L1142) | string | Side container name | `"jnlp"` |
-| [agent.skipTlsVerify](./values.yaml#L974) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
-| [agent.usageRestricted](./values.yaml#L976) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
-| [agent.useDefaultServiceAccount](./values.yaml#L960) | bool | Use `serviceAccountAgent.name` as the default value for defaults template `serviceAccount` | `true` |
-| [agent.volumes](./values.yaml#L1059) | list | Additional volumes | `[]` |
-| [agent.waitForPodSec](./values.yaml#L986) | int | Seconds to wait for pod to be running | `600` |
-| [agent.websocket](./values.yaml#L1009) | bool | Enables agent communication via websockets | `false` |
-| [agent.workingDir](./values.yaml#L1001) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
-| [agent.workspaceVolume](./values.yaml#L1094) | object | Workspace volume (defaults to EmptyDir) | `{}` |
-| [agent.yamlMergeStrategy](./values.yaml#L1184) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
-| [agent.yamlTemplate](./values.yaml#L1173) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1399) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1401) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1403) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1402) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1396) | bool | Checks if any deprecated values are used | `true` |
+| [additionalAgents](./values.yaml#L1243) | object | Configure additional | `{}` |
+| [additionalClouds](./values.yaml#L1268) | object |  | `{}` |
+| [agent.TTYEnabled](./values.yaml#L1148) | bool | Allocate pseudo tty to the side container | `false` |
+| [agent.additionalContainers](./values.yaml#L1196) | list | Add additional containers to the agents | `[]` |
+| [agent.alwaysPullImage](./values.yaml#L1041) | bool | Always pull agent container image before build | `false` |
+| [agent.annotations](./values.yaml#L1192) | object | Annotations to apply to the pod | `{}` |
+| [agent.args](./values.yaml#L1142) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
+| [agent.command](./values.yaml#L1140) | string | Command to execute when side container starts | `nil` |
+| [agent.componentName](./values.yaml#L1009) | string |  | `"jenkins-agent"` |
+| [agent.connectTimeout](./values.yaml#L1190) | int | Timeout in seconds for an agent to be online | `100` |
+| [agent.containerCap](./values.yaml#L1150) | int | Max number of agents to launch for a whole cluster. | `10` |
+| [agent.customJenkinsLabels](./values.yaml#L1006) | list | Append Jenkins labels to the agent | `[]` |
+| [agent.defaultsProviderTemplate](./values.yaml#L958) | string | The name of the pod template to use for providing default values | `""` |
+| [agent.directConnection](./values.yaml#L1012) | bool |  | `false` |
+| [agent.disableDefaultAgent](./values.yaml#L1214) | bool | Disable the default Jenkins Agent configuration | `false` |
+| [agent.enabled](./values.yaml#L956) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
+| [agent.envVars](./values.yaml#L1123) | list | Environment variables for the agent Pod | `[]` |
+| [agent.garbageCollection.enabled](./values.yaml#L1159) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
+| [agent.garbageCollection.namespaces](./values.yaml#L1161) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
+| [agent.garbageCollection.timeout](./values.yaml#L1166) | int | Timeout value for orphaned pods | `300` |
+| [agent.hostNetworking](./values.yaml#L1020) | bool | Enables the agent to use the host network | `false` |
+| [agent.idleMinutes](./values.yaml#L1169) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
+| [agent.image.registry](./values.yaml#L997) | string | Registry to pull the agent jnlp image from | `""` |
+| [agent.image.repository](./values.yaml#L999) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
+| [agent.image.tag](./values.yaml#L1001) | string | Tag of the image to pull | `"3355.v388858a_47b_33-14"` |
+| [agent.imagePullSecretName](./values.yaml#L1008) | string | Name of the secret to be used to pull the image | `nil` |
+| [agent.inheritYamlMergeStrategy](./values.yaml#L1188) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
+| [agent.instanceCap](./values.yaml#L1152) | int | Max number of agents to launch for this type of agent | `2147483647` |
+| [agent.jenkinsTunnel](./values.yaml#L974) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
+| [agent.jenkinsUrl](./values.yaml#L970) | string | Overrides the Kubernetes Jenkins URL | `nil` |
+| [agent.jnlpregistry](./values.yaml#L994) | string | Custom registry used to pull the agent jnlp image from | `nil` |
+| [agent.kubernetesConnectTimeout](./values.yaml#L980) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
+| [agent.kubernetesReadTimeout](./values.yaml#L982) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
+| [agent.livenessProbe](./values.yaml#L1031) | object |  | `{}` |
+| [agent.maxRequestsPerHostStr](./values.yaml#L984) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
+| [agent.namespace](./values.yaml#L990) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
+| [agent.nodeSelector](./values.yaml#L1134) | object | Node labels for pod assignment | `{}` |
+| [agent.nodeUsageMode](./values.yaml#L1004) | string |  | `"NORMAL"` |
+| [agent.podLabels](./values.yaml#L992) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
+| [agent.podName](./values.yaml#L1154) | string | Agent Pod base name | `"default"` |
+| [agent.podRetention](./values.yaml#L1050) | string |  | `"Never"` |
+| [agent.podTemplates](./values.yaml#L1224) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
+| [agent.privileged](./values.yaml#L1014) | bool | Agent privileged container | `false` |
+| [agent.resources](./values.yaml#L1022) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
+| [agent.restrictedPssSecurityContext](./values.yaml#L1047) | bool | Set a restricted securityContext on jnlp containers | `false` |
+| [agent.retentionTimeout](./values.yaml#L986) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
+| [agent.runAsGroup](./values.yaml#L1018) | string | Configure container group | `nil` |
+| [agent.runAsUser](./values.yaml#L1016) | string | Configure container user | `nil` |
+| [agent.secretEnvVars](./values.yaml#L1127) | list | Mount a secret as environment variable | `[]` |
+| [agent.serviceAccount](./values.yaml#L966) | string | Override the default service account | `serviceAccountAgent.name` if `agent.useDefaultServiceAccount` is `true` |
+| [agent.showRawYaml](./values.yaml#L1054) | bool |  | `true` |
+| [agent.sideContainerName](./values.yaml#L1144) | string | Side container name | `"jnlp"` |
+| [agent.skipTlsVerify](./values.yaml#L976) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
+| [agent.usageRestricted](./values.yaml#L978) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
+| [agent.useDefaultServiceAccount](./values.yaml#L962) | bool | Use `serviceAccountAgent.name` as the default value for defaults template `serviceAccount` | `true` |
+| [agent.volumes](./values.yaml#L1061) | list | Additional volumes | `[]` |
+| [agent.waitForPodSec](./values.yaml#L988) | int | Seconds to wait for pod to be running | `600` |
+| [agent.websocket](./values.yaml#L1011) | bool | Enables agent communication via websockets | `false` |
+| [agent.workingDir](./values.yaml#L1003) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
+| [agent.workspaceVolume](./values.yaml#L1096) | object | Workspace volume (defaults to EmptyDir) | `{}` |
+| [agent.yamlMergeStrategy](./values.yaml#L1186) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
+| [agent.yamlTemplate](./values.yaml#L1175) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1401) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1403) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1405) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1404) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1398) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L554) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L559) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -129,12 +129,13 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.extraPorts](./values.yaml#L409) | list | Optionally configure other ports to expose in the controller container | `[]` |
 | [controller.fsGroup](./values.yaml#L197) | int | Deprecated in favor of `controller.podSecurityContextOverride`. uid that will be used for persistent volume. | `1000` |
 | [controller.fsGroupChangePolicy](./values.yaml#L200) | string |  | `"OnRootMismatch"` |
-| [controller.googlePodMonitor.enabled](./values.yaml#L875) | bool |  | `false` |
-| [controller.googlePodMonitor.scrapeEndpoint](./values.yaml#L880) | string |  | `"/prometheus"` |
-| [controller.googlePodMonitor.scrapeInterval](./values.yaml#L878) | string |  | `"60s"` |
+| [controller.googlePodMonitor.enabled](./values.yaml#L877) | bool |  | `false` |
+| [controller.googlePodMonitor.scrapeEndpoint](./values.yaml#L882) | string |  | `"/prometheus"` |
+| [controller.googlePodMonitor.scrapeInterval](./values.yaml#L880) | string |  | `"60s"` |
 | [controller.healthProbes](./values.yaml#L269) | bool | Enable Kubernetes Probes configuration configured in `controller.probes` | `true` |
-| [controller.hostAliases](./values.yaml#L828) | list | Allows for adding entries to Pod /etc/hosts | `[]` |
+| [controller.hostAliases](./values.yaml#L830) | list | Allows for adding entries to Pod /etc/hosts | `[]` |
 | [controller.hostNetworking](./values.yaml#L76) | bool |  | `false` |
+| [controller.httpRoute.annotations](./values.yaml#L827) | object | HTTPRoute annotations | `{}` |
 | [controller.httpRoute.apiVersion](./values.yaml#L814) | string |  | `"gateway.networking.k8s.io/v1"` |
 | [controller.httpRoute.enabled](./values.yaml#L813) | bool |  | `false` |
 | [controller.httpRoute.extraRules](./values.yaml#L825) | list |  | `[]` |
@@ -142,17 +143,17 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.httpRoute.kind](./values.yaml#L815) | string |  | `"HTTPRoute"` |
 | [controller.httpRoute.parentRefs](./values.yaml#L817) | list |  | `[]` |
 | [controller.httpRoute.reuseIngressConfiguration](./values.yaml#L821) | bool |  | `false` |
-| [controller.httpsKeyStore.disableSecretMount](./values.yaml#L896) | bool |  | `false` |
-| [controller.httpsKeyStore.enable](./values.yaml#L887) | bool | Enables HTTPS keystore on jenkins controller | `false` |
-| [controller.httpsKeyStore.fileName](./values.yaml#L904) | string | Jenkins keystore filename which will appear under controller.httpsKeyStore.path | `"keystore.jks"` |
-| [controller.httpsKeyStore.httpPort](./values.yaml#L900) | int | HTTP Port that Jenkins should listen to along with HTTPS, it also serves as the liveness and readiness probes port. | `8081` |
-| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretKey](./values.yaml#L895) | string | Name of the key in the secret that contains the JKS password | `"https-jks-password"` |
-| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName](./values.yaml#L893) | string | Name of the secret that contains the JKS password, if it is not in the same secret as the JKS file | `""` |
-| [controller.httpsKeyStore.jenkinsHttpsJksSecretKey](./values.yaml#L891) | string | Name of the key in the secret that already has SSL keystore | `"jenkins-jks-file"` |
-| [controller.httpsKeyStore.jenkinsHttpsJksSecretName](./values.yaml#L889) | string | Name of the secret that already has SSL keystore | `""` |
-| [controller.httpsKeyStore.jenkinsKeyStoreBase64Encoded](./values.yaml#L909) | string | Base64 encoded Keystore content. Keystore must be converted to base64 then being pasted here | `nil` |
-| [controller.httpsKeyStore.password](./values.yaml#L906) | string | Jenkins keystore password | `"password"` |
-| [controller.httpsKeyStore.path](./values.yaml#L902) | string | Path of HTTPS keystore file | `"/var/jenkins_keystore"` |
+| [controller.httpsKeyStore.disableSecretMount](./values.yaml#L898) | bool |  | `false` |
+| [controller.httpsKeyStore.enable](./values.yaml#L889) | bool | Enables HTTPS keystore on jenkins controller | `false` |
+| [controller.httpsKeyStore.fileName](./values.yaml#L906) | string | Jenkins keystore filename which will appear under controller.httpsKeyStore.path | `"keystore.jks"` |
+| [controller.httpsKeyStore.httpPort](./values.yaml#L902) | int | HTTP Port that Jenkins should listen to along with HTTPS, it also serves as the liveness and readiness probes port. | `8081` |
+| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretKey](./values.yaml#L897) | string | Name of the key in the secret that contains the JKS password | `"https-jks-password"` |
+| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName](./values.yaml#L895) | string | Name of the secret that contains the JKS password, if it is not in the same secret as the JKS file | `""` |
+| [controller.httpsKeyStore.jenkinsHttpsJksSecretKey](./values.yaml#L893) | string | Name of the key in the secret that already has SSL keystore | `"jenkins-jks-file"` |
+| [controller.httpsKeyStore.jenkinsHttpsJksSecretName](./values.yaml#L891) | string | Name of the secret that already has SSL keystore | `""` |
+| [controller.httpsKeyStore.jenkinsKeyStoreBase64Encoded](./values.yaml#L911) | string | Base64 encoded Keystore content. Keystore must be converted to base64 then being pasted here | `nil` |
+| [controller.httpsKeyStore.password](./values.yaml#L908) | string | Jenkins keystore password | `"password"` |
+| [controller.httpsKeyStore.path](./values.yaml#L904) | string | Path of HTTPS keystore file | `"/var/jenkins_keystore"` |
 | [controller.image.pullPolicy](./values.yaml#L53) | string | Controller image pull policy | `"Always"` |
 | [controller.image.registry](./values.yaml#L43) | string | Controller image registry | `"docker.io"` |
 | [controller.image.repository](./values.yaml#L45) | string | Controller image repository | `"jenkins/jenkins"` |
@@ -225,16 +226,16 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.probes.startupProbe.periodSeconds](./values.yaml#L281) | int | Set the time interval between two startup probes executions in seconds | `10` |
 | [controller.probes.startupProbe.timeoutSeconds](./values.yaml#L283) | int | Set the timeout for the startup probe in seconds | `5` |
 | [controller.projectNamingStrategy](./values.yaml#L446) | string |  | `"standard"` |
-| [controller.prometheus.alertingRulesAdditionalLabels](./values.yaml#L861) | object | Additional labels to add to the PrometheusRule object | `{}` |
-| [controller.prometheus.alertingrules](./values.yaml#L859) | list | Array of prometheus alerting rules | `[]` |
-| [controller.prometheus.enabled](./values.yaml#L844) | bool | Enables prometheus service monitor | `false` |
-| [controller.prometheus.metricRelabelings](./values.yaml#L871) | list |  | `[]` |
-| [controller.prometheus.prometheusRuleNamespace](./values.yaml#L863) | string | Set a custom namespace where to deploy PrometheusRule resource | `""` |
-| [controller.prometheus.relabelings](./values.yaml#L869) | list |  | `[]` |
-| [controller.prometheus.scrapeEndpoint](./values.yaml#L854) | string | The endpoint prometheus should get metrics from | `"/prometheus"` |
-| [controller.prometheus.scrapeInterval](./values.yaml#L850) | string | How often prometheus should scrape metrics | `"60s"` |
-| [controller.prometheus.serviceMonitorAdditionalLabels](./values.yaml#L846) | object | Additional labels to add to the service monitor object | `{}` |
-| [controller.prometheus.serviceMonitorNamespace](./values.yaml#L848) | string | Set a custom namespace where to deploy ServiceMonitor resource | `nil` |
+| [controller.prometheus.alertingRulesAdditionalLabels](./values.yaml#L863) | object | Additional labels to add to the PrometheusRule object | `{}` |
+| [controller.prometheus.alertingrules](./values.yaml#L861) | list | Array of prometheus alerting rules | `[]` |
+| [controller.prometheus.enabled](./values.yaml#L846) | bool | Enables prometheus service monitor | `false` |
+| [controller.prometheus.metricRelabelings](./values.yaml#L873) | list |  | `[]` |
+| [controller.prometheus.prometheusRuleNamespace](./values.yaml#L865) | string | Set a custom namespace where to deploy PrometheusRule resource | `""` |
+| [controller.prometheus.relabelings](./values.yaml#L871) | list |  | `[]` |
+| [controller.prometheus.scrapeEndpoint](./values.yaml#L856) | string | The endpoint prometheus should get metrics from | `"/prometheus"` |
+| [controller.prometheus.scrapeInterval](./values.yaml#L852) | string | How often prometheus should scrape metrics | `"60s"` |
+| [controller.prometheus.serviceMonitorAdditionalLabels](./values.yaml#L848) | object | Additional labels to add to the service monitor object | `{}` |
+| [controller.prometheus.serviceMonitorNamespace](./values.yaml#L850) | string | Set a custom namespace where to deploy ServiceMonitor resource | `nil` |
 | [controller.publishNotReadyAddresses](./values.yaml#L248) | string |  | `nil` |
 | [controller.resources](./values.yaml#L120) | object | Resource allocation (Requests and Limits) | `{"limits":{"cpu":"2000m","memory":"4096Mi"},"requests":{"cpu":"50m","memory":"256Mi"}}` |
 | [controller.route.annotations](./values.yaml#L806) | object | Route annotations | `{}` |
@@ -286,7 +287,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.terminationGracePeriodSeconds](./values.yaml#L678) | string | Set TerminationGracePeriodSeconds | `nil` |
 | [controller.terminationMessagePath](./values.yaml#L680) | string | Set the termination message path | `nil` |
 | [controller.terminationMessagePolicy](./values.yaml#L682) | string | Set the termination message policy | `nil` |
-| [controller.testEnabled](./values.yaml#L883) | bool | Can be used to disable rendering controller test resources when using helm template | `true` |
+| [controller.testEnabled](./values.yaml#L885) | bool | Can be used to disable rendering controller test resources when using helm template | `true` |
 | [controller.tolerations](./values.yaml#L676) | list | Toleration labels for pod assignment | `[]` |
 | [controller.topologySpreadConstraints](./values.yaml#L702) | object | Topology spread constraints | `{}` |
 | [controller.updateStrategy](./values.yaml#L699) | object | Update strategy for StatefulSet | `{}` |
@@ -295,43 +296,43 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [extraLabels](./values.yaml#L33) | object | Configures extra labels for the agent all objects | `{}` |
 | [extraObjects](./values.yaml#L36) | string | Configures extra manifests | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1412) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1414) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1416) | string | Tag of the image to test the framework | `"1.13.0"` |
+| [helmtest.bats.image.registry](./values.yaml#L1414) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1416) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1418) | string | Tag of the image to test the framework | `"1.13.0"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
-| [networkPolicy.apiVersion](./values.yaml#L1335) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
-| [networkPolicy.enabled](./values.yaml#L1330) | bool | Enable the creation of NetworkPolicy resources | `false` |
-| [networkPolicy.externalAgents.except](./values.yaml#L1350) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
-| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1348) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
-| [networkPolicy.internalAgents.allowed](./values.yaml#L1339) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
-| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1343) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
-| [networkPolicy.internalAgents.podLabels](./values.yaml#L1341) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
-| [persistence.accessMode](./values.yaml#L1305) | string | The PVC access mode | `"ReadWriteOnce"` |
-| [persistence.annotations](./values.yaml#L1301) | object | Annotations for the PVC | `{}` |
-| [persistence.dataSource](./values.yaml#L1311) | object | Existing data source to clone PVC from | `{}` |
-| [persistence.enabled](./values.yaml#L1285) | bool | Enable the use of a Jenkins PVC | `true` |
-| [persistence.existingClaim](./values.yaml#L1291) | string | Provide the name of a PVC | `nil` |
-| [persistence.labels](./values.yaml#L1303) | object | Labels for the PVC | `{}` |
-| [persistence.mounts](./values.yaml#L1323) | list | Additional mounts | `[]` |
-| [persistence.size](./values.yaml#L1307) | string | The size of the PVC | `"8Gi"` |
-| [persistence.storageClass](./values.yaml#L1299) | string | Storage class for the PVC | `nil` |
-| [persistence.subPath](./values.yaml#L1316) | string | SubPath for jenkins-home mount | `nil` |
-| [persistence.volumes](./values.yaml#L1318) | list | Additional volumes | `[]` |
-| [rbac.create](./values.yaml#L1357) | bool | Whether RBAC resources are created | `true` |
-| [rbac.readSecrets](./values.yaml#L1359) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
-| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1361) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
+| [networkPolicy.apiVersion](./values.yaml#L1337) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
+| [networkPolicy.enabled](./values.yaml#L1332) | bool | Enable the creation of NetworkPolicy resources | `false` |
+| [networkPolicy.externalAgents.except](./values.yaml#L1352) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
+| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1350) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
+| [networkPolicy.internalAgents.allowed](./values.yaml#L1341) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
+| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1345) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
+| [networkPolicy.internalAgents.podLabels](./values.yaml#L1343) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
+| [persistence.accessMode](./values.yaml#L1307) | string | The PVC access mode | `"ReadWriteOnce"` |
+| [persistence.annotations](./values.yaml#L1303) | object | Annotations for the PVC | `{}` |
+| [persistence.dataSource](./values.yaml#L1313) | object | Existing data source to clone PVC from | `{}` |
+| [persistence.enabled](./values.yaml#L1287) | bool | Enable the use of a Jenkins PVC | `true` |
+| [persistence.existingClaim](./values.yaml#L1293) | string | Provide the name of a PVC | `nil` |
+| [persistence.labels](./values.yaml#L1305) | object | Labels for the PVC | `{}` |
+| [persistence.mounts](./values.yaml#L1325) | list | Additional mounts | `[]` |
+| [persistence.size](./values.yaml#L1309) | string | The size of the PVC | `"8Gi"` |
+| [persistence.storageClass](./values.yaml#L1301) | string | Storage class for the PVC | `nil` |
+| [persistence.subPath](./values.yaml#L1318) | string | SubPath for jenkins-home mount | `nil` |
+| [persistence.volumes](./values.yaml#L1320) | list | Additional volumes | `[]` |
+| [rbac.create](./values.yaml#L1359) | bool | Whether RBAC resources are created | `true` |
+| [rbac.readSecrets](./values.yaml#L1361) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
+| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1363) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
-| [serviceAccount.annotations](./values.yaml#L1371) | object | Configures annotations for the ServiceAccount | `{}` |
-| [serviceAccount.automountServiceAccountToken](./values.yaml#L1377) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccount.create](./values.yaml#L1365) | bool | Configures if a ServiceAccount with this name should be created | `true` |
-| [serviceAccount.extraLabels](./values.yaml#L1373) | object | Configures extra labels for the ServiceAccount | `{}` |
-| [serviceAccount.imagePullSecretName](./values.yaml#L1375) | string | Controller ServiceAccount image pull secret | `nil` |
-| [serviceAccount.name](./values.yaml#L1369) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1387) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1393) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccountAgent.create](./values.yaml#L1381) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1389) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1391) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1385) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccount.annotations](./values.yaml#L1373) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.automountServiceAccountToken](./values.yaml#L1379) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccount.create](./values.yaml#L1367) | bool | Configures if a ServiceAccount with this name should be created | `true` |
+| [serviceAccount.extraLabels](./values.yaml#L1375) | object | Configures extra labels for the ServiceAccount | `{}` |
+| [serviceAccount.imagePullSecretName](./values.yaml#L1377) | string | Controller ServiceAccount image pull secret | `nil` |
+| [serviceAccount.name](./values.yaml#L1371) | string |  | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1389) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1395) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccountAgent.create](./values.yaml#L1383) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1391) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1393) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1387) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/templates/jenkins-controller-httproute.yaml
+++ b/charts/jenkins/templates/jenkins-controller-httproute.yaml
@@ -17,6 +17,10 @@ metadata:
   name: {{ include "jenkins.fullname" . }}
   labels:
     {{- include "jenkins.labels" . | nindent 4 }}
+  {{- if .Values.controller.httpRoute.annotations }}
+  annotations:
+    {{- tpl (toYaml .Values.controller.httpRoute.annotations) . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.controller.httpRoute.parentRefs }}
   parentRefs:

--- a/charts/jenkins/unittests/jenkins-controller-httproute-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-httproute-test.yaml
@@ -49,6 +49,44 @@ tests:
           value:
             - external.jenkins.example.com
             - internal.jenkins.example.com
+  - it: renders annotations when set
+    set:
+      controller:
+        httpRoute:
+          enabled: true
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          reuseIngressConfiguration: false
+          hostnames:
+            - jenkins.example.com
+          parentRefs:
+            - name: shared-gateway
+              namespace: networking
+          annotations:
+            example.com/key: value
+            another.io/annotation: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/key: value
+            another.io/annotation: "true"
+  - it: does not render annotations when not set
+    set:
+      controller:
+        httpRoute:
+          enabled: true
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          reuseIngressConfiguration: false
+          hostnames:
+            - jenkins.example.com
+          parentRefs:
+            - name: shared-gateway
+              namespace: networking
+    asserts:
+      - notExists:
+          path: metadata.annotations
   - it: matches snapshot
     set:
       controller:
@@ -66,4 +104,4 @@ tests:
     asserts:
       - matchSnapshot:
           path: spec
-    
+

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -823,6 +823,8 @@ controller:
     hostnames: []
     # Extra HTTPRoute rules that will be appended before the default backend
     extraRules: []
+    # -- HTTPRoute annotations
+    annotations: {}
 
   # -- Allows for adding entries to Pod /etc/hosts
   hostAliases: []


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

<!-- Describe the purpose of this PR, and any background context.
*(optional, add the issue number in `Fixes #<issue number>`, to close that issue when the PR gets merged)*
-->

Adds support for annotations on the HTTPRoute resource via values file

If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist

- [x ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x ] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

<!-- Leave blank if none -->
