### PR TITLE
Fix renovate on lint-test.yaml and update helmlint to v1.0.3 for CI

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -57,7 +57,8 @@ jobs:
         run: |
           helm env
           # renovate: datasource=github-tags depName=helm-unittest/helm-unittest
-          helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.3.6 --verify=false
+          HELM_UNITTEST_VERSION=v1.0.3
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version ${HELM_UNITTEST_VERSION} --verify=false
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml


### PR DESCRIPTION
### What does this PR do?

Fix renovate on lint-test.yaml that check only for version: or _VERSION pattern in files (similar to renovate-entrypoint.sh)

If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist

- [ ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ ] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ ] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ ] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

