### PR TITLE
Fix templating in extraObjects

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.4
+
+Fix templating in `extraObjects`
+
 ## 5.9.3
 
 Allow to scale controller to zero replicas during maintenance scenarios.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.3
+version: 5.9.4
 appVersion: 2.541.2
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/extra-objects.yaml
+++ b/charts/jenkins/templates/extra-objects.yaml
@@ -6,7 +6,7 @@
   {{- end -}}
 
   {{- range $index, $object := $extraObjects -}}
-    {{- if $object -}}
+    {{- if $object }}
 ---
       {{- if kindIs "string" $object -}}
         {{- tpl $object $ | nindent 0 -}}

--- a/charts/jenkins/unittests/extra-objects-test.yaml
+++ b/charts/jenkins/unittests/extra-objects-test.yaml
@@ -65,6 +65,36 @@ tests:
       - equal:
           path: metadata.name
           value: test-secret
+  - it: should process multiple manifests
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: test-secret-1
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-configmap-1
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: kind
+          value: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-secret-1
+        documentIndex: 0
+      - equal:
+          path: kind
+          value: ConfigMap
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: test-configmap-1
+        documentIndex: 1
   - it: should process map manifest with tpl values
     set:
       env: prod


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

Fix when multiple manifests are in `extraObjects`

Using this as an example:
```
extraObjects:
  - |-
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: config-map-1
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: config-map-2
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: config-map-3
```

Before the fix, `helm template` would have generated this (invalid) yaml:
```
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-map-1---
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-map-2---
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-map-3
```

With this fix, this is what is generated (note: it also adds an extra line at the top of the template, but most implementations I've seen have this "problem" which should not cause a problem; at least, it doesn't make the yaml invalid):
```

---
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-map-1
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-map-2
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-map-3
```

### Workaround

Using my example, replace `-` (or `- |-`) by `- |` to transform each object to string (do not use `|-`, will result the same issue; will be able to use it after the fix is merged).

If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist

- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

<!-- Leave blank if none -->
