### PR TITLE
fix: don't render `tls` ingress section if its value is `{}`

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.5
+
+Don't render `tls` ingress section if its value is `{}`
+
 ## 5.9.4
 
 Fix templating in `extraObjects`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.4
+version: 5.9.5
 appVersion: 2.541.2
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/jenkins-controller-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-ingress.yaml
@@ -65,6 +65,13 @@ spec:
     host: {{ tpl .Values.controller.ingress.resourceRootUrl . | quote }}
 {{- end }}
 {{- if .Values.controller.ingress.tls }}
+{{- $withTlsEntries := false }}
+{{- range .Values.controller.ingress.tls }}
+  {{- if gt (len .) 0 }}
+    {{- $withTlsEntries = true }}
+  {{- end }}
+{{- end }}
+{{- if $withTlsEntries }}
   tls:
 {{- range .Values.controller.ingress.tls }}
   - hosts:
@@ -75,6 +82,7 @@ spec:
       - {{ tpl $.Values.controller.ingress.resourceRootUrl $ | quote }}
 {{- end }}
     secretName: {{ tpl (.secretName | toString) $ | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

This change prevents `tls` ingress section to be rendered if it doesn't contain any entry.

Amends:
- #1588 

Fixes:
- #1624

### Submitter checklist

- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Testing done

test.yaml:
```yaml
controller:
  ingress:
    enabled: true
    apiVersion: "networking.k8s.io/v1"
    ingressClassName: my-classname
    hostName: mine.me
    resourceRootUrl: assets.mine.me
    tls:
      - {}
```

`helm template . --values test.yaml > test-template.yaml`:
```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  namespace: default
  labels:
    "app.kubernetes.io/name": 'jenkins'
    "app.kubernetes.io/managed-by": "Helm"
    "app.kubernetes.io/instance": "release-name"
    "app.kubernetes.io/component": "jenkins-controller"
    "helm.sh/chart": "jenkins-5.9.5"
  name: release-name-jenkins
spec:
  ingressClassName: "my-classname"
  rules:
  - http:
      paths:
      - backend:
          service:
            name: release-name-jenkins
            port:
              number: 8080
        pathType: ImplementationSpecific
    host: "mine.me"
  - http:
      paths:
      - backend:
          service:
            name: release-name-jenkins
            port:
              number: 8080
        pathType: ImplementationSpecific
    host: "assets.mine.me"
```