### PR TITLE
fix: don't add `secretName: "<nil>"` to ingress if no value defined

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.6
+
+Don't add `secretName: "<nil>"` to ingress if no value defined
+
 ## 5.9.5
 
 Don't render `tls` ingress section if its value is `{}`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.5
+version: 5.9.6
 appVersion: 2.541.2
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/jenkins-controller-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-ingress.yaml
@@ -81,7 +81,9 @@ spec:
 {{- if $.Values.controller.ingress.resourceRootUrl }}
       - {{ tpl $.Values.controller.ingress.resourceRootUrl $ | quote }}
 {{- end }}
+{{- if .secretName }}
     secretName: {{ tpl (.secretName | toString) $ | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

Amends:
- #1588 

Ref:
- https://github.com/jenkinsci/helm-charts/issues/1624#issuecomment-4039077831

### Submitter checklist

- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Testing done

```bash
$ cat test2.yaml 
controller:
  ingress:
    enabled: true
    ingressClassName: nginx
    hostName: foo.bar.com
    tls:
      - hosts:
        - foo.bar.com

$ helm template . --values test2.yaml > test-template2.yaml
```
```yaml
---
# Source: jenkins/templates/jenkins-controller-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  namespace: default
  labels:
    "app.kubernetes.io/name": 'jenkins'
    "app.kubernetes.io/managed-by": "Helm"
    "app.kubernetes.io/instance": "release-name"
    "app.kubernetes.io/component": "jenkins-controller"
    "helm.sh/chart": "jenkins-5.9.6"
  name: release-name-jenkins
spec:
  ingressClassName: "nginx"
  rules:
  - http:
      paths:
      - backend:
          service:
            name: release-name-jenkins
            port:
              number: 8080
        pathType: ImplementationSpecific
    host: "foo.bar.com"
  tls:
  - hosts:
      - "foo.bar.com"
---
```

With resource root URL defined:
```bash
$ cat test3.yaml 
controller:
  ingress:
    enabled: true
    ingressClassName: nginx
    hostName: foo.bar.com
    resourceRootUrl: assets.foo.bar.com
    tls:
      - hosts:
        - foo.bar.com

$ helm template . --values test3.yaml > test-template3.yaml
```
```yaml
---
# Source: jenkins/templates/jenkins-controller-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  namespace: default
  labels:
    "app.kubernetes.io/name": 'jenkins'
    "app.kubernetes.io/managed-by": "Helm"
    "app.kubernetes.io/instance": "release-name"
    "app.kubernetes.io/component": "jenkins-controller"
    "helm.sh/chart": "jenkins-5.9.6"
  name: release-name-jenkins
spec:
  ingressClassName: "nginx"
  rules:
  - http:
      paths:
      - backend:
          service:
            name: release-name-jenkins
            port:
              number: 8080
        pathType: ImplementationSpecific
    host: "foo.bar.com"
  - http:
      paths:
      - backend:
          service:
            name: release-name-jenkins
            port:
              number: 8080
        pathType: ImplementationSpecific
    host: "assets.foo.bar.com"
  tls:
  - hosts:
      - "foo.bar.com"
      - "assets.foo.bar.com"
---
```