### PR TITLE
fix: evaluate tpl values in secondary ingress host and tls hosts(1637)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,37 +53,46 @@ $ helm unittest --strict -f 'unittests/*.yaml' charts/jenkins
 
 ### Chart [ jenkins ] charts/jenkins
 
-2022/01/15 11:25:01 warning: destination for initScripts is a table. Ignoring non-table value []
- PASS  ConfigMap                               charts/jenkins/unittests/config-init-scripts-test.yaml
- PASS  ConfigMap                               charts/jenkins/unittests/config-test.yaml
- PASS  PersistentVolumeClaim                   charts/jenkins/unittests/home-pvc-test.yaml
- PASS  Configuration as Code                   charts/jenkins/unittests/jcasc-config-test.yaml
- PASS  Jenkins Agent Service                   charts/jenkins/unittests/jenkins-agent-svc-test.yaml
- PASS  Controller Prometheus PrometheusRule    charts/jenkins/unittests/jenkins-controller-alerting-rules-test.yaml
- PASS  Controller Primary Ingress              charts/jenkins/unittests/jenkins-controller-ingress-1.19-test.yaml
- PASS  Controller Primary Ingress              charts/jenkins/unittests/jenkins-controller-ingress-test.yaml
- PASS  Network Policy                          charts/jenkins/unittests/jenkins-controller-networkpolicy-test.yaml
- PASS  Controller Pod Disruption Budget        charts/jenkins/unittests/jenkins-controller-pdb-1.21-test.yaml
- PASS  Controller Pod Disruption Budget        charts/jenkins/unittests/jenkins-controller-pdb-test.yaml
- PASS  Controller Secondary Ingress            charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
- PASS  Controller Secondary Ingress            charts/jenkins/unittests/jenkins-controller-secondary-ingress-test.yaml
- PASS  Controller Prometheus ServiceMonitor    charts/jenkins/unittests/jenkins-controller-servicemonitor_test.yaml
- PASS  Jenkins Controller                      charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
- PASS  Jenkins Controller                      charts/jenkins/unittests/jenkins-controller-svc-test.yaml
- PASS  Role Based Access Control               charts/jenkins/unittests/rbac-test.yaml
- PASS  Controller Admin Additional Secrets     charts/jenkins/unittests/secret-additional-test.yaml
- PASS  Controller Secret Claims                charts/jenkins/unittests/secret-claims-test.yaml
+ PASS  ConfigMap  charts/jenkins/unittests/config-init-scripts-test.yaml
+ PASS  ConfigMap  charts/jenkins/unittests/config-test.yaml
+ PASS  test extraObjects  charts/jenkins/unittests/extra-objects-test.yaml
+ PASS  Garbage collection of pods  charts/jenkins/unittests/garbage-collect-test.yaml
+ PASS  PersistentVolumeClaim  charts/jenkins/unittests/home-pvc-test.yaml
+ PASS  Instance cap tests  charts/jenkins/unittests/instance-cap-test.yaml
+2026/03/31 08:28:09 warning: destination for jenkins.controller.projectNamingStrategy is a table. Ignoring non-table value (standard)
+2026/03/31 08:28:09 warning: cannot overwrite table with non table for jenkins.controller.JCasC.security.apiToken (map[creationOfLegacyTokenEnabled:false tokenGenerationOnCreationEnabled:false usageStatisticsEnabled:true])
+ PASS  Configuration as Code  charts/jenkins/unittests/jcasc-config-test.yaml
+ PASS  Jenkins Agent Service  charts/jenkins/unittests/jenkins-agent-svc-test.yaml
+ PASS  Controller Prometheus PrometheusRule  charts/jenkins/unittests/jenkins-controller-alerting-rules-test.yaml
+ PASS  Controller HTTPRoute  charts/jenkins/unittests/jenkins-controller-httproute-test.yaml
+ PASS  Controller Primary Ingress  charts/jenkins/unittests/jenkins-controller-ingress-1.19-test.yaml
+ PASS  Controller Ingress - DRY Support  charts/jenkins/unittests/jenkins-controller-ingress-DRY-test.yaml
+ PASS  Controller Primary Ingress  charts/jenkins/unittests/jenkins-controller-ingress-test.yaml
+ PASS  Network Policy  charts/jenkins/unittests/jenkins-controller-networkpolicy-test.yaml
+ PASS  Controller Pod Disruption Budget  charts/jenkins/unittests/jenkins-controller-pdb-1.21-test.yaml
+ PASS  Controller Pod Disruption Budget  charts/jenkins/unittests/jenkins-controller-pdb-test.yaml
+ PASS  Controller Secondary Ingress  charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
+ PASS  Controller Secondary Ingress  charts/jenkins/unittests/jenkins-controller-secondary-ingress-test.yaml
+ PASS  Controller Prometheus ServiceMonitor  charts/jenkins/unittests/jenkins-controller-servicemonitor_test.yaml
+ PASS  Jenkins Controller  charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+ PASS  Jenkins Controller  charts/jenkins/unittests/jenkins-controller-svc-test.yaml
+ PASS  Role Based Access Control  charts/jenkins/unittests/rbac-test.yaml
+ PASS  Controller Admin Additional Secrets  charts/jenkins/unittests/secret-additional-test.yaml
+ PASS  Controller Secret Claims  charts/jenkins/unittests/secret-claims-test.yaml
  PASS  Controller Additional Existing Secrets  charts/jenkins/unittests/secret-existing-test.yaml
- PASS  Controller Admin Credentials            charts/jenkins/unittests/secret-test.yaml
- PASS  Controller Service Account              charts/jenkins/unittests/service-account-agent-test.yaml
- PASS  Controller Service Account              charts/jenkins/unittests/service-account-test.yaml
+ PASS  Controller Admin Credentials  charts/jenkins/unittests/secret-test.yaml
+ PASS  Controller Service Account  charts/jenkins/unittests/service-account-agent-test.yaml
+ PASS  Controller Service Account  charts/jenkins/unittests/service-account-test.yaml
 
 Charts:      1 passed, 1 total
-Test Suites: 24 passed, 24 total
-Tests:       119 passed, 119 total
-Snapshot:    1 passed, 1 total
-Time:        440.35914ms
+Test Suites: 28 passed, 28 total
+Tests:       214 passed, 214 total
+Snapshot:    50 passed, 50 total
+Time:        2.2434989s
 ```
+
+> **Note!**
+> Some warnings in the sample output are expected. A few unit tests intentionally provide values with a different type than the chart defaults to verify how the templates handle those inputs.
 
 ### Immutability
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,9 @@ minikube service chart-$CHART
 - Must follow [Charts best practices](https://helm.sh/docs/topics/chart_best_practices/)
 - Must pass CI jobs for linting and installing changed charts with the [chart-testing](https://github.com/helm/chart-testing) tool
 - Any change to a chart requires a version bump following [SemVer](https://semver.org/) principles. See [Immutability](#immutability) and [Versioning](#versioning) below
+  - Bump the `version` key in [charts/jenkins/Chart.yaml](charts/jenkins/Chart.yaml)
+  - Add a new changelog entry to [charts/jenkins/CHANGELOG.md](charts/jenkins/CHANGELOG.md) with the new version and a description of the change
+- Run `.github/helm-docs.sh` from the project root. This will update the [charts/jenkins/VALUES.md](charts/jenkins/VALUES.md) file with changes you made in [charts/jenkins/values.yaml](charts/jenkins/values.yaml)
 
 Once changes have been merged, the release job will automatically run to package and release changed charts.
 
@@ -43,7 +46,7 @@ Tests can be executed like this:
 
 ```console
 # install the unittest plugin
-$ helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.3.6
+$ helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.0.3
 
 # run the unittests
 $ helm unittest --strict -f 'unittests/*.yaml' charts/jenkins

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,11 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.13
+
+- Fix [#1637](https://github.com/jenkinsci/helm-charts/issues/1637): Evaluate tpl values in secondary ingress host and tls hosts
+- Fix [#476](https://github.com/jenkinsci/helm-charts/issues/476): Secondary ingress template should have parameters as primary ingress
+
 ## 5.9.12
 
 Update `git` to version `5.10.1`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.12
+version: 5.9.13
 appVersion: 2.541.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -8,73 +8,73 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Key | Type | Description | Default |
 |:----|:-----|:---------|:------------|
-| [additionalAgents](./values.yaml#L1247) | object | Configure additional | `{}` |
-| [additionalClouds](./values.yaml#L1272) | object |  | `{}` |
-| [agent.TTYEnabled](./values.yaml#L1152) | bool | Allocate pseudo tty to the side container | `false` |
-| [agent.additionalContainers](./values.yaml#L1200) | list | Add additional containers to the agents | `[]` |
-| [agent.alwaysPullImage](./values.yaml#L1045) | bool | Always pull agent container image before build | `false` |
-| [agent.annotations](./values.yaml#L1196) | object | Annotations to apply to the pod | `{}` |
-| [agent.args](./values.yaml#L1146) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
-| [agent.command](./values.yaml#L1144) | string | Command to execute when side container starts | `nil` |
-| [agent.componentName](./values.yaml#L1013) | string |  | `"jenkins-agent"` |
-| [agent.connectTimeout](./values.yaml#L1194) | int | Timeout in seconds for an agent to be online | `100` |
-| [agent.containerCap](./values.yaml#L1154) | int | Max number of agents to launch for a whole cluster. | `10` |
-| [agent.customJenkinsLabels](./values.yaml#L1010) | list | Append Jenkins labels to the agent | `[]` |
-| [agent.defaultsProviderTemplate](./values.yaml#L962) | string | The name of the pod template to use for providing default values | `""` |
-| [agent.directConnection](./values.yaml#L1016) | bool |  | `false` |
-| [agent.disableDefaultAgent](./values.yaml#L1218) | bool | Disable the default Jenkins Agent configuration | `false` |
-| [agent.enabled](./values.yaml#L960) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
-| [agent.envVars](./values.yaml#L1127) | list | Environment variables for the agent Pod | `[]` |
-| [agent.garbageCollection.enabled](./values.yaml#L1163) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
-| [agent.garbageCollection.namespaces](./values.yaml#L1165) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
-| [agent.garbageCollection.timeout](./values.yaml#L1170) | int | Timeout value for orphaned pods | `300` |
-| [agent.hostNetworking](./values.yaml#L1024) | bool | Enables the agent to use the host network | `false` |
-| [agent.idleMinutes](./values.yaml#L1173) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
-| [agent.image.registry](./values.yaml#L1001) | string | Registry to pull the agent jnlp image from | `""` |
-| [agent.image.repository](./values.yaml#L1003) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
-| [agent.image.tag](./values.yaml#L1005) | string | Tag of the image to pull | `"3355.v388858a_47b_33-17"` |
-| [agent.imagePullSecretName](./values.yaml#L1012) | string | Name of the secret to be used to pull the image | `nil` |
-| [agent.inheritYamlMergeStrategy](./values.yaml#L1192) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
-| [agent.instanceCap](./values.yaml#L1156) | int | Max number of agents to launch for this type of agent | `2147483647` |
-| [agent.jenkinsTunnel](./values.yaml#L978) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
-| [agent.jenkinsUrl](./values.yaml#L974) | string | Overrides the Kubernetes Jenkins URL | `nil` |
-| [agent.jnlpregistry](./values.yaml#L998) | string | Custom registry used to pull the agent jnlp image from | `nil` |
-| [agent.kubernetesConnectTimeout](./values.yaml#L984) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
-| [agent.kubernetesReadTimeout](./values.yaml#L986) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
-| [agent.livenessProbe](./values.yaml#L1035) | object |  | `{}` |
-| [agent.maxRequestsPerHostStr](./values.yaml#L988) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
-| [agent.namespace](./values.yaml#L994) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
-| [agent.nodeSelector](./values.yaml#L1138) | object | Node labels for pod assignment | `{}` |
-| [agent.nodeUsageMode](./values.yaml#L1008) | string |  | `"NORMAL"` |
-| [agent.podLabels](./values.yaml#L996) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
-| [agent.podName](./values.yaml#L1158) | string | Agent Pod base name | `"default"` |
-| [agent.podRetention](./values.yaml#L1054) | string |  | `"Never"` |
-| [agent.podTemplates](./values.yaml#L1228) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
-| [agent.privileged](./values.yaml#L1018) | bool | Agent privileged container | `false` |
-| [agent.resources](./values.yaml#L1026) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
-| [agent.restrictedPssSecurityContext](./values.yaml#L1051) | bool | Set a restricted securityContext on jnlp containers | `false` |
-| [agent.retentionTimeout](./values.yaml#L990) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
-| [agent.runAsGroup](./values.yaml#L1022) | string | Configure container group | `nil` |
-| [agent.runAsUser](./values.yaml#L1020) | string | Configure container user | `nil` |
-| [agent.secretEnvVars](./values.yaml#L1131) | list | Mount a secret as environment variable | `[]` |
-| [agent.serviceAccount](./values.yaml#L970) | string | Override the default service account | `serviceAccountAgent.name` if `agent.useDefaultServiceAccount` is `true` |
-| [agent.showRawYaml](./values.yaml#L1058) | bool |  | `true` |
-| [agent.sideContainerName](./values.yaml#L1148) | string | Side container name | `"jnlp"` |
-| [agent.skipTlsVerify](./values.yaml#L980) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
-| [agent.usageRestricted](./values.yaml#L982) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
-| [agent.useDefaultServiceAccount](./values.yaml#L966) | bool | Use `serviceAccountAgent.name` as the default value for defaults template `serviceAccount` | `true` |
-| [agent.volumes](./values.yaml#L1065) | list | Additional volumes | `[]` |
-| [agent.waitForPodSec](./values.yaml#L992) | int | Seconds to wait for pod to be running | `600` |
-| [agent.websocket](./values.yaml#L1015) | bool | Enables agent communication via websockets | `false` |
-| [agent.workingDir](./values.yaml#L1007) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
-| [agent.workspaceVolume](./values.yaml#L1100) | object | Workspace volume (defaults to EmptyDir) | `{}` |
-| [agent.yamlMergeStrategy](./values.yaml#L1190) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
-| [agent.yamlTemplate](./values.yaml#L1179) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1405) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1407) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1409) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1408) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1402) | bool | Checks if any deprecated values are used | `true` |
+| [additionalAgents](./values.yaml#L1257) | object | Configure additional | `{}` |
+| [additionalClouds](./values.yaml#L1282) | object |  | `{}` |
+| [agent.TTYEnabled](./values.yaml#L1162) | bool | Allocate pseudo tty to the side container | `false` |
+| [agent.additionalContainers](./values.yaml#L1210) | list | Add additional containers to the agents | `[]` |
+| [agent.alwaysPullImage](./values.yaml#L1055) | bool | Always pull agent container image before build | `false` |
+| [agent.annotations](./values.yaml#L1206) | object | Annotations to apply to the pod | `{}` |
+| [agent.args](./values.yaml#L1156) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
+| [agent.command](./values.yaml#L1154) | string | Command to execute when side container starts | `nil` |
+| [agent.componentName](./values.yaml#L1023) | string |  | `"jenkins-agent"` |
+| [agent.connectTimeout](./values.yaml#L1204) | int | Timeout in seconds for an agent to be online | `100` |
+| [agent.containerCap](./values.yaml#L1164) | int | Max number of agents to launch for a whole cluster. | `10` |
+| [agent.customJenkinsLabels](./values.yaml#L1020) | list | Append Jenkins labels to the agent | `[]` |
+| [agent.defaultsProviderTemplate](./values.yaml#L972) | string | The name of the pod template to use for providing default values | `""` |
+| [agent.directConnection](./values.yaml#L1026) | bool |  | `false` |
+| [agent.disableDefaultAgent](./values.yaml#L1228) | bool | Disable the default Jenkins Agent configuration | `false` |
+| [agent.enabled](./values.yaml#L970) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
+| [agent.envVars](./values.yaml#L1137) | list | Environment variables for the agent Pod | `[]` |
+| [agent.garbageCollection.enabled](./values.yaml#L1173) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
+| [agent.garbageCollection.namespaces](./values.yaml#L1175) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
+| [agent.garbageCollection.timeout](./values.yaml#L1180) | int | Timeout value for orphaned pods | `300` |
+| [agent.hostNetworking](./values.yaml#L1034) | bool | Enables the agent to use the host network | `false` |
+| [agent.idleMinutes](./values.yaml#L1183) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
+| [agent.image.registry](./values.yaml#L1011) | string | Registry to pull the agent jnlp image from | `""` |
+| [agent.image.repository](./values.yaml#L1013) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
+| [agent.image.tag](./values.yaml#L1015) | string | Tag of the image to pull | `"3355.v388858a_47b_33-17"` |
+| [agent.imagePullSecretName](./values.yaml#L1022) | string | Name of the secret to be used to pull the image | `nil` |
+| [agent.inheritYamlMergeStrategy](./values.yaml#L1202) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
+| [agent.instanceCap](./values.yaml#L1166) | int | Max number of agents to launch for this type of agent | `2147483647` |
+| [agent.jenkinsTunnel](./values.yaml#L988) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
+| [agent.jenkinsUrl](./values.yaml#L984) | string | Overrides the Kubernetes Jenkins URL | `nil` |
+| [agent.jnlpregistry](./values.yaml#L1008) | string | Custom registry used to pull the agent jnlp image from | `nil` |
+| [agent.kubernetesConnectTimeout](./values.yaml#L994) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
+| [agent.kubernetesReadTimeout](./values.yaml#L996) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
+| [agent.livenessProbe](./values.yaml#L1045) | object |  | `{}` |
+| [agent.maxRequestsPerHostStr](./values.yaml#L998) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
+| [agent.namespace](./values.yaml#L1004) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
+| [agent.nodeSelector](./values.yaml#L1148) | object | Node labels for pod assignment | `{}` |
+| [agent.nodeUsageMode](./values.yaml#L1018) | string |  | `"NORMAL"` |
+| [agent.podLabels](./values.yaml#L1006) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
+| [agent.podName](./values.yaml#L1168) | string | Agent Pod base name | `"default"` |
+| [agent.podRetention](./values.yaml#L1064) | string |  | `"Never"` |
+| [agent.podTemplates](./values.yaml#L1238) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
+| [agent.privileged](./values.yaml#L1028) | bool | Agent privileged container | `false` |
+| [agent.resources](./values.yaml#L1036) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
+| [agent.restrictedPssSecurityContext](./values.yaml#L1061) | bool | Set a restricted securityContext on jnlp containers | `false` |
+| [agent.retentionTimeout](./values.yaml#L1000) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
+| [agent.runAsGroup](./values.yaml#L1032) | string | Configure container group | `nil` |
+| [agent.runAsUser](./values.yaml#L1030) | string | Configure container user | `nil` |
+| [agent.secretEnvVars](./values.yaml#L1141) | list | Mount a secret as environment variable | `[]` |
+| [agent.serviceAccount](./values.yaml#L980) | string | Override the default service account | `serviceAccountAgent.name` if `agent.useDefaultServiceAccount` is `true` |
+| [agent.showRawYaml](./values.yaml#L1068) | bool |  | `true` |
+| [agent.sideContainerName](./values.yaml#L1158) | string | Side container name | `"jnlp"` |
+| [agent.skipTlsVerify](./values.yaml#L990) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
+| [agent.usageRestricted](./values.yaml#L992) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
+| [agent.useDefaultServiceAccount](./values.yaml#L976) | bool | Use `serviceAccountAgent.name` as the default value for defaults template `serviceAccount` | `true` |
+| [agent.volumes](./values.yaml#L1075) | list | Additional volumes | `[]` |
+| [agent.waitForPodSec](./values.yaml#L1002) | int | Seconds to wait for pod to be running | `600` |
+| [agent.websocket](./values.yaml#L1025) | bool | Enables agent communication via websockets | `false` |
+| [agent.workingDir](./values.yaml#L1017) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
+| [agent.workspaceVolume](./values.yaml#L1110) | object | Workspace volume (defaults to EmptyDir) | `{}` |
+| [agent.yamlMergeStrategy](./values.yaml#L1200) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
+| [agent.yamlTemplate](./values.yaml#L1189) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1415) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1417) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1419) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1418) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1412) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L558) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L563) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -292,7 +292,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.terminationMessagePolicy](./values.yaml#L686) | string | Set the termination message policy | `nil` |
 | [controller.testEnabled](./values.yaml#L899) | bool | Can be used to disable rendering controller test resources when using helm template | `true` |
 | [controller.tolerations](./values.yaml#L680) | list | Toleration labels for pod assignment | `[]` |
-| [controller.topologySpreadConstraints](./values.yaml#L706) | object | Topology spread constraints | `{}` |
+| [controller.topologySpreadConstraints](./values.yaml#L706) | list | Topology spread constraints | `[]` |
 | [controller.updateStrategy](./values.yaml#L703) | object | Update strategy for StatefulSet | `{}` |
 | [controller.usePodSecurityContext](./values.yaml#L191) | bool | Enable pod security context (must be `true` if podSecurityContextOverride, runAsUser or fsGroup are set) | `true` |
 | [credentialsId](./values.yaml#L27) | string | The Jenkins credentials to access the Kubernetes API server. For the default cluster it is not needed. | `nil` |

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -103,12 +103,12 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.agentListenerPort](./values.yaml#L345) | int | Listening port for agents | `50000` |
 | [controller.agentListenerServiceAnnotations](./values.yaml#L378) | object | Annotations for the agentListener service | `{}` |
 | [controller.agentListenerServiceType](./values.yaml#L375) | string | Defines how to expose the agentListener service | `"ClusterIP"` |
-| [controller.backendconfig.annotations](./values.yaml#L799) | object | backendconfig annotations | `{}` |
-| [controller.backendconfig.apiVersion](./values.yaml#L793) | string | backendconfig API version | `"extensions/v1beta1"` |
-| [controller.backendconfig.enabled](./values.yaml#L791) | bool | Enables backendconfig | `false` |
-| [controller.backendconfig.labels](./values.yaml#L797) | object | backendconfig labels | `{}` |
-| [controller.backendconfig.name](./values.yaml#L795) | string | backendconfig name | `nil` |
-| [controller.backendconfig.spec](./values.yaml#L801) | object | backendconfig spec | `{}` |
+| [controller.backendconfig.annotations](./values.yaml#L809) | object | backendconfig annotations | `{}` |
+| [controller.backendconfig.apiVersion](./values.yaml#L803) | string | backendconfig API version | `"extensions/v1beta1"` |
+| [controller.backendconfig.enabled](./values.yaml#L801) | bool | Enables backendconfig | `false` |
+| [controller.backendconfig.labels](./values.yaml#L807) | object | backendconfig labels | `{}` |
+| [controller.backendconfig.name](./values.yaml#L805) | string | backendconfig name | `nil` |
+| [controller.backendconfig.spec](./values.yaml#L811) | object | backendconfig spec | `{}` |
 | [controller.cloudName](./values.yaml#L512) | string | Name of default cloud configuration. | `"kubernetes"` |
 | [controller.clusterIp](./values.yaml#L238) | string | k8s service clusterIP. Only used if serviceType is ClusterIP | `nil` |
 | [controller.componentName](./values.yaml#L40) | string | Used for label app.kubernetes.io/component | `"jenkins-controller"` |
@@ -129,47 +129,48 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.extraPorts](./values.yaml#L413) | list | Optionally configure other ports to expose in the controller container | `[]` |
 | [controller.fsGroup](./values.yaml#L201) | int | Deprecated in favor of `controller.podSecurityContextOverride`. uid that will be used for persistent volume. | `1000` |
 | [controller.fsGroupChangePolicy](./values.yaml#L204) | string |  | `"OnRootMismatch"` |
-| [controller.googlePodMonitor.enabled](./values.yaml#L881) | bool |  | `false` |
-| [controller.googlePodMonitor.scrapeEndpoint](./values.yaml#L886) | string |  | `"/prometheus"` |
-| [controller.googlePodMonitor.scrapeInterval](./values.yaml#L884) | string |  | `"60s"` |
+| [controller.googlePodMonitor.enabled](./values.yaml#L891) | bool |  | `false` |
+| [controller.googlePodMonitor.scrapeEndpoint](./values.yaml#L896) | string |  | `"/prometheus"` |
+| [controller.googlePodMonitor.scrapeInterval](./values.yaml#L894) | string |  | `"60s"` |
 | [controller.healthProbes](./values.yaml#L273) | bool | Enable Kubernetes Probes configuration configured in `controller.probes` | `true` |
-| [controller.hostAliases](./values.yaml#L834) | list | Allows for adding entries to Pod /etc/hosts | `[]` |
+| [controller.hostAliases](./values.yaml#L844) | list | Allows for adding entries to Pod /etc/hosts | `[]` |
 | [controller.hostNetworking](./values.yaml#L80) | bool |  | `false` |
-| [controller.httpRoute.annotations](./values.yaml#L831) | object | HTTPRoute annotations | `{}` |
-| [controller.httpRoute.apiVersion](./values.yaml#L818) | string |  | `"gateway.networking.k8s.io/v1"` |
-| [controller.httpRoute.enabled](./values.yaml#L817) | bool |  | `false` |
-| [controller.httpRoute.extraRules](./values.yaml#L829) | list |  | `[]` |
-| [controller.httpRoute.hostnames](./values.yaml#L827) | list |  | `[]` |
-| [controller.httpRoute.kind](./values.yaml#L819) | string |  | `"HTTPRoute"` |
-| [controller.httpRoute.parentRefs](./values.yaml#L821) | list |  | `[]` |
-| [controller.httpRoute.reuseIngressConfiguration](./values.yaml#L825) | bool |  | `false` |
-| [controller.httpsKeyStore.disableSecretMount](./values.yaml#L902) | bool |  | `false` |
-| [controller.httpsKeyStore.enable](./values.yaml#L893) | bool | Enables HTTPS keystore on jenkins controller | `false` |
-| [controller.httpsKeyStore.fileName](./values.yaml#L910) | string | Jenkins keystore filename which will appear under controller.httpsKeyStore.path | `"keystore.jks"` |
-| [controller.httpsKeyStore.httpPort](./values.yaml#L906) | int | HTTP Port that Jenkins should listen to along with HTTPS, it also serves as the liveness and readiness probes port. | `8081` |
-| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretKey](./values.yaml#L901) | string | Name of the key in the secret that contains the JKS password | `"https-jks-password"` |
-| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName](./values.yaml#L899) | string | Name of the secret that contains the JKS password, if it is not in the same secret as the JKS file | `""` |
-| [controller.httpsKeyStore.jenkinsHttpsJksSecretKey](./values.yaml#L897) | string | Name of the key in the secret that already has SSL keystore | `"jenkins-jks-file"` |
-| [controller.httpsKeyStore.jenkinsHttpsJksSecretName](./values.yaml#L895) | string | Name of the secret that already has SSL keystore | `""` |
-| [controller.httpsKeyStore.jenkinsKeyStoreBase64Encoded](./values.yaml#L915) | string | Base64 encoded Keystore content. Keystore must be converted to base64 then being pasted here | `nil` |
-| [controller.httpsKeyStore.password](./values.yaml#L912) | string | Jenkins keystore password | `"password"` |
-| [controller.httpsKeyStore.path](./values.yaml#L908) | string | Path of HTTPS keystore file | `"/var/jenkins_keystore"` |
+| [controller.httpRoute.annotations](./values.yaml#L841) | object | HTTPRoute annotations | `{}` |
+| [controller.httpRoute.apiVersion](./values.yaml#L828) | string |  | `"gateway.networking.k8s.io/v1"` |
+| [controller.httpRoute.enabled](./values.yaml#L827) | bool |  | `false` |
+| [controller.httpRoute.extraRules](./values.yaml#L839) | list |  | `[]` |
+| [controller.httpRoute.hostnames](./values.yaml#L837) | list |  | `[]` |
+| [controller.httpRoute.kind](./values.yaml#L829) | string |  | `"HTTPRoute"` |
+| [controller.httpRoute.parentRefs](./values.yaml#L831) | list |  | `[]` |
+| [controller.httpRoute.reuseIngressConfiguration](./values.yaml#L835) | bool |  | `false` |
+| [controller.httpsKeyStore.disableSecretMount](./values.yaml#L912) | bool |  | `false` |
+| [controller.httpsKeyStore.enable](./values.yaml#L903) | bool | Enables HTTPS keystore on jenkins controller | `false` |
+| [controller.httpsKeyStore.fileName](./values.yaml#L920) | string | Jenkins keystore filename which will appear under controller.httpsKeyStore.path | `"keystore.jks"` |
+| [controller.httpsKeyStore.httpPort](./values.yaml#L916) | int | HTTP Port that Jenkins should listen to along with HTTPS, it also serves as the liveness and readiness probes port. | `8081` |
+| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretKey](./values.yaml#L911) | string | Name of the key in the secret that contains the JKS password | `"https-jks-password"` |
+| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName](./values.yaml#L909) | string | Name of the secret that contains the JKS password, if it is not in the same secret as the JKS file | `""` |
+| [controller.httpsKeyStore.jenkinsHttpsJksSecretKey](./values.yaml#L907) | string | Name of the key in the secret that already has SSL keystore | `"jenkins-jks-file"` |
+| [controller.httpsKeyStore.jenkinsHttpsJksSecretName](./values.yaml#L905) | string | Name of the secret that already has SSL keystore | `""` |
+| [controller.httpsKeyStore.jenkinsKeyStoreBase64Encoded](./values.yaml#L925) | string | Base64 encoded Keystore content. Keystore must be converted to base64 then being pasted here | `nil` |
+| [controller.httpsKeyStore.password](./values.yaml#L922) | string | Jenkins keystore password | `"password"` |
+| [controller.httpsKeyStore.path](./values.yaml#L918) | string | Path of HTTPS keystore file | `"/var/jenkins_keystore"` |
 | [controller.image.pullPolicy](./values.yaml#L53) | string | Controller image pull policy | `"Always"` |
 | [controller.image.registry](./values.yaml#L43) | string | Controller image registry | `"docker.io"` |
 | [controller.image.repository](./values.yaml#L45) | string | Controller image repository | `"jenkins/jenkins"` |
 | [controller.image.tag](./values.yaml#L48) | string | Controller image tag override; i.e., tag: "2.440.1-jdk21" | `nil` |
 | [controller.image.tagLabel](./values.yaml#L51) | string | Controller image tag label | `"jdk21"` |
 | [controller.imagePullSecretName](./values.yaml#L59) | string | Controller image pull secret | `nil` |
-| [controller.ingress.annotations](./values.yaml#L737) | object | Ingress annotations | `{}` |
-| [controller.ingress.apiVersion](./values.yaml#L733) | string | Ingress API version | `"extensions/v1beta1"` |
-| [controller.ingress.enabled](./values.yaml#L713) | bool | Enables ingress | `false` |
-| [controller.ingress.hostName](./values.yaml#L751) | string | Ingress hostname | `nil` |
-| [controller.ingress.labels](./values.yaml#L735) | object | Ingress labels | `{}` |
-| [controller.ingress.path](./values.yaml#L747) | string | Ingress path | `nil` |
-| [controller.ingress.pathType](./values.yaml#L728) | string | Ingress rule pathType, choices are: Exact, ImplementationSpecific, Prefix | `"ImplementationSpecific"` |
-| [controller.ingress.paths](./values.yaml#L717) | list | Override for the default Ingress paths | `[]` |
-| [controller.ingress.resourceRootUrl](./values.yaml#L753) | string | Hostname to serve assets from | `nil` |
-| [controller.ingress.tls](./values.yaml#L755) | list | Ingress TLS configuration | `[]` |
+| [controller.ingress.annotations](./values.yaml#L737) | object | Primary Ingress annotations | `{}` |
+| [controller.ingress.apiVersion](./values.yaml#L733) | string | Primary Ingress API version | `"networking.k8s.io/v1"` |
+| [controller.ingress.enabled](./values.yaml#L713) | bool | Enables the Primary ingress | `false` |
+| [controller.ingress.hostName](./values.yaml#L753) | string | Primary Ingress hostname | `nil` |
+| [controller.ingress.ingressClassName](./values.yaml#L745) | string | Primary Ingress ingressClassName | `nil` |
+| [controller.ingress.labels](./values.yaml#L735) | object | Primary Ingress labels | `{}` |
+| [controller.ingress.path](./values.yaml#L749) | string | Primary Ingress path | `nil` |
+| [controller.ingress.pathType](./values.yaml#L728) | string | Primary Ingress rule pathType, choices are: Exact, ImplementationSpecific, Prefix | `"ImplementationSpecific"` |
+| [controller.ingress.paths](./values.yaml#L717) | list | Override for the default Primary Ingress paths | `[]` |
+| [controller.ingress.resourceRootUrl](./values.yaml#L755) | string | Primary Hostname to serve assets from | `nil` |
+| [controller.ingress.tls](./values.yaml#L757) | list | Primary Ingress TLS configuration | `[]` |
 | [controller.initConfigMap](./values.yaml#L471) | string | Name of the existing ConfigMap that contains init scripts | `nil` |
 | [controller.initContainerEnv](./values.yaml#L156) | list | Environment variables for Init Container | `[]` |
 | [controller.initContainerEnvFrom](./values.yaml#L152) | list | Environment variable sources for Init Container | `[]` |
@@ -226,33 +227,34 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.probes.startupProbe.periodSeconds](./values.yaml#L285) | int | Set the time interval between two startup probes executions in seconds | `10` |
 | [controller.probes.startupProbe.timeoutSeconds](./values.yaml#L287) | int | Set the timeout for the startup probe in seconds | `5` |
 | [controller.projectNamingStrategy](./values.yaml#L450) | string |  | `"standard"` |
-| [controller.prometheus.alertingRulesAdditionalLabels](./values.yaml#L867) | object | Additional labels to add to the PrometheusRule object | `{}` |
-| [controller.prometheus.alertingrules](./values.yaml#L865) | list | Array of prometheus alerting rules | `[]` |
-| [controller.prometheus.enabled](./values.yaml#L850) | bool | Enables prometheus service monitor | `false` |
-| [controller.prometheus.metricRelabelings](./values.yaml#L877) | list |  | `[]` |
-| [controller.prometheus.prometheusRuleNamespace](./values.yaml#L869) | string | Set a custom namespace where to deploy PrometheusRule resource | `""` |
-| [controller.prometheus.relabelings](./values.yaml#L875) | list |  | `[]` |
-| [controller.prometheus.scrapeEndpoint](./values.yaml#L860) | string | The endpoint prometheus should get metrics from | `"/prometheus"` |
-| [controller.prometheus.scrapeInterval](./values.yaml#L856) | string | How often prometheus should scrape metrics | `"60s"` |
-| [controller.prometheus.serviceMonitorAdditionalLabels](./values.yaml#L852) | object | Additional labels to add to the service monitor object | `{}` |
-| [controller.prometheus.serviceMonitorNamespace](./values.yaml#L854) | string | Set a custom namespace where to deploy ServiceMonitor resource | `nil` |
+| [controller.prometheus.alertingRulesAdditionalLabels](./values.yaml#L877) | object | Additional labels to add to the PrometheusRule object | `{}` |
+| [controller.prometheus.alertingrules](./values.yaml#L875) | list | Array of prometheus alerting rules | `[]` |
+| [controller.prometheus.enabled](./values.yaml#L860) | bool | Enables prometheus service monitor | `false` |
+| [controller.prometheus.metricRelabelings](./values.yaml#L887) | list |  | `[]` |
+| [controller.prometheus.prometheusRuleNamespace](./values.yaml#L879) | string | Set a custom namespace where to deploy PrometheusRule resource | `""` |
+| [controller.prometheus.relabelings](./values.yaml#L885) | list |  | `[]` |
+| [controller.prometheus.scrapeEndpoint](./values.yaml#L870) | string | The endpoint prometheus should get metrics from | `"/prometheus"` |
+| [controller.prometheus.scrapeInterval](./values.yaml#L866) | string | How often prometheus should scrape metrics | `"60s"` |
+| [controller.prometheus.serviceMonitorAdditionalLabels](./values.yaml#L862) | object | Additional labels to add to the service monitor object | `{}` |
+| [controller.prometheus.serviceMonitorNamespace](./values.yaml#L864) | string | Set a custom namespace where to deploy ServiceMonitor resource | `nil` |
 | [controller.publishNotReadyAddresses](./values.yaml#L252) | string |  | `nil` |
 | [controller.replicas](./values.yaml#L56) | int | Number of replicas. Max 1. Can be set to 0 for maintenance scenarios. | `1` |
 | [controller.resources](./values.yaml#L124) | object | Resource allocation (Requests and Limits) | `{"limits":{"cpu":"2000m","memory":"4096Mi"},"requests":{"cpu":"50m","memory":"256Mi"}}` |
-| [controller.route.annotations](./values.yaml#L810) | object | Route annotations | `{}` |
-| [controller.route.enabled](./values.yaml#L806) | bool | Enables openshift route | `false` |
-| [controller.route.labels](./values.yaml#L808) | object | Route labels | `{}` |
-| [controller.route.path](./values.yaml#L812) | string | Route path | `nil` |
+| [controller.route.annotations](./values.yaml#L820) | object | Route annotations | `{}` |
+| [controller.route.enabled](./values.yaml#L816) | bool | Enables openshift route | `false` |
+| [controller.route.labels](./values.yaml#L818) | object | Route labels | `{}` |
+| [controller.route.path](./values.yaml#L822) | string | Route path | `nil` |
 | [controller.runAsUser](./values.yaml#L198) | int | Deprecated in favor of `controller.podSecurityContextOverride`. uid that jenkins runs with. | `1000` |
 | [controller.schedulerName](./values.yaml#L672) | string | Name of the Kubernetes scheduler to use | `""` |
 | [controller.scriptApproval](./values.yaml#L462) | list | List of groovy functions to approve | `[]` |
-| [controller.secondaryingress.annotations](./values.yaml#L773) | object |  | `{}` |
-| [controller.secondaryingress.apiVersion](./values.yaml#L771) | string |  | `"extensions/v1beta1"` |
-| [controller.secondaryingress.enabled](./values.yaml#L765) | bool |  | `false` |
-| [controller.secondaryingress.hostName](./values.yaml#L780) | string |  | `nil` |
-| [controller.secondaryingress.labels](./values.yaml#L772) | object |  | `{}` |
-| [controller.secondaryingress.paths](./values.yaml#L768) | list |  | `[]` |
-| [controller.secondaryingress.tls](./values.yaml#L781) | string |  | `nil` |
+| [controller.secondaryingress.annotations](./values.yaml#L780) | object | Secondary Ingress annotations | `{}` |
+| [controller.secondaryingress.apiVersion](./values.yaml#L776) | string | Secondary Ingress API version | `"networking.k8s.io/v1"` |
+| [controller.secondaryingress.enabled](./values.yaml#L768) | bool | Enables the Secondary Ingress | `false` |
+| [controller.secondaryingress.hostName](./values.yaml#L789) | string | Secondary Ingress hostname | `nil` |
+| [controller.secondaryingress.ingressClassName](./values.yaml#L786) | string | Secondary Ingress ingressClassName | `nil` |
+| [controller.secondaryingress.labels](./values.yaml#L778) | object | Secondary Ingress labels | `{}` |
+| [controller.secondaryingress.paths](./values.yaml#L772) | list | Secondary Ingress paths | `[]` |
+| [controller.secondaryingress.tls](./values.yaml#L791) | string | Secondary Ingress TLS configuration | `nil` |
 | [controller.secretClaims](./values.yaml#L505) | list | List of `SecretClaim` resources to create | `[]` |
 | [controller.securityContextCapabilities](./values.yaml#L210) | object |  | `{}` |
 | [controller.serviceAnnotations](./values.yaml#L255) | object | Jenkins controller service annotations | `{}` |
@@ -288,7 +290,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.terminationGracePeriodSeconds](./values.yaml#L682) | string | Set TerminationGracePeriodSeconds | `nil` |
 | [controller.terminationMessagePath](./values.yaml#L684) | string | Set the termination message path | `nil` |
 | [controller.terminationMessagePolicy](./values.yaml#L686) | string | Set the termination message policy | `nil` |
-| [controller.testEnabled](./values.yaml#L889) | bool | Can be used to disable rendering controller test resources when using helm template | `true` |
+| [controller.testEnabled](./values.yaml#L899) | bool | Can be used to disable rendering controller test resources when using helm template | `true` |
 | [controller.tolerations](./values.yaml#L680) | list | Toleration labels for pod assignment | `[]` |
 | [controller.topologySpreadConstraints](./values.yaml#L706) | object | Topology spread constraints | `{}` |
 | [controller.updateStrategy](./values.yaml#L703) | object | Update strategy for StatefulSet | `{}` |
@@ -297,43 +299,43 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [extraLabels](./values.yaml#L33) | object | Configures extra labels for the agent all objects | `{}` |
 | [extraObjects](./values.yaml#L36) | string | Configures extra manifests | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1418) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1420) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1422) | string | Tag of the image to test the framework | `"1.13.0"` |
+| [helmtest.bats.image.registry](./values.yaml#L1428) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1430) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1432) | string | Tag of the image to test the framework | `"1.13.0"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
-| [networkPolicy.apiVersion](./values.yaml#L1341) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
-| [networkPolicy.enabled](./values.yaml#L1336) | bool | Enable the creation of NetworkPolicy resources | `false` |
-| [networkPolicy.externalAgents.except](./values.yaml#L1356) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
-| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1354) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
-| [networkPolicy.internalAgents.allowed](./values.yaml#L1345) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
-| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1349) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
-| [networkPolicy.internalAgents.podLabels](./values.yaml#L1347) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
-| [persistence.accessMode](./values.yaml#L1311) | string | The PVC access mode | `"ReadWriteOnce"` |
-| [persistence.annotations](./values.yaml#L1307) | object | Annotations for the PVC | `{}` |
-| [persistence.dataSource](./values.yaml#L1317) | object | Existing data source to clone PVC from | `{}` |
-| [persistence.enabled](./values.yaml#L1291) | bool | Enable the use of a Jenkins PVC | `true` |
-| [persistence.existingClaim](./values.yaml#L1297) | string | Provide the name of a PVC | `nil` |
-| [persistence.labels](./values.yaml#L1309) | object | Labels for the PVC | `{}` |
-| [persistence.mounts](./values.yaml#L1329) | list | Additional mounts | `[]` |
-| [persistence.size](./values.yaml#L1313) | string | The size of the PVC | `"8Gi"` |
-| [persistence.storageClass](./values.yaml#L1305) | string | Storage class for the PVC | `nil` |
-| [persistence.subPath](./values.yaml#L1322) | string | SubPath for jenkins-home mount | `nil` |
-| [persistence.volumes](./values.yaml#L1324) | list | Additional volumes | `[]` |
-| [rbac.create](./values.yaml#L1363) | bool | Whether RBAC resources are created | `true` |
-| [rbac.readSecrets](./values.yaml#L1365) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
-| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1367) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
+| [networkPolicy.apiVersion](./values.yaml#L1351) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
+| [networkPolicy.enabled](./values.yaml#L1346) | bool | Enable the creation of NetworkPolicy resources | `false` |
+| [networkPolicy.externalAgents.except](./values.yaml#L1366) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
+| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1364) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
+| [networkPolicy.internalAgents.allowed](./values.yaml#L1355) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
+| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1359) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
+| [networkPolicy.internalAgents.podLabels](./values.yaml#L1357) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
+| [persistence.accessMode](./values.yaml#L1321) | string | The PVC access mode | `"ReadWriteOnce"` |
+| [persistence.annotations](./values.yaml#L1317) | object | Annotations for the PVC | `{}` |
+| [persistence.dataSource](./values.yaml#L1327) | object | Existing data source to clone PVC from | `{}` |
+| [persistence.enabled](./values.yaml#L1301) | bool | Enable the use of a Jenkins PVC | `true` |
+| [persistence.existingClaim](./values.yaml#L1307) | string | Provide the name of a PVC | `nil` |
+| [persistence.labels](./values.yaml#L1319) | object | Labels for the PVC | `{}` |
+| [persistence.mounts](./values.yaml#L1339) | list | Additional mounts | `[]` |
+| [persistence.size](./values.yaml#L1323) | string | The size of the PVC | `"8Gi"` |
+| [persistence.storageClass](./values.yaml#L1315) | string | Storage class for the PVC | `nil` |
+| [persistence.subPath](./values.yaml#L1332) | string | SubPath for jenkins-home mount | `nil` |
+| [persistence.volumes](./values.yaml#L1334) | list | Additional volumes | `[]` |
+| [rbac.create](./values.yaml#L1373) | bool | Whether RBAC resources are created | `true` |
+| [rbac.readSecrets](./values.yaml#L1375) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
+| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1377) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
-| [serviceAccount.annotations](./values.yaml#L1377) | object | Configures annotations for the ServiceAccount | `{}` |
-| [serviceAccount.automountServiceAccountToken](./values.yaml#L1383) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccount.create](./values.yaml#L1371) | bool | Configures if a ServiceAccount with this name should be created | `true` |
-| [serviceAccount.extraLabels](./values.yaml#L1379) | object | Configures extra labels for the ServiceAccount | `{}` |
-| [serviceAccount.imagePullSecretName](./values.yaml#L1381) | string | Controller ServiceAccount image pull secret | `nil` |
-| [serviceAccount.name](./values.yaml#L1375) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1393) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1399) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccountAgent.create](./values.yaml#L1387) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1395) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1397) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1391) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccount.annotations](./values.yaml#L1387) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.automountServiceAccountToken](./values.yaml#L1393) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccount.create](./values.yaml#L1381) | bool | Configures if a ServiceAccount with this name should be created | `true` |
+| [serviceAccount.extraLabels](./values.yaml#L1389) | object | Configures extra labels for the ServiceAccount | `{}` |
+| [serviceAccount.imagePullSecretName](./values.yaml#L1391) | string | Controller ServiceAccount image pull secret | `nil` |
+| [serviceAccount.name](./values.yaml#L1385) | string |  | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1403) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1409) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccountAgent.create](./values.yaml#L1397) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1405) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1407) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1401) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/templates/jenkins-controller-secondary-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-secondary-ingress.yaml
@@ -18,12 +18,13 @@ metadata:
     {{ toYaml .Values.controller.secondaryingress.labels | nindent 4 }}
     {{- end }}
   {{- if .Values.controller.secondaryingress.annotations }}
-  annotations: {{ toYaml .Values.controller.secondaryingress.annotations | nindent 4 }}
+  annotations:
+{{ tpl (toYaml .Values.controller.secondaryingress.annotations) . | indent 4 }}
   {{- end }}
   name: {{ template "jenkins.fullname" . }}-secondary
 spec:
 {{- if .Values.controller.secondaryingress.ingressClassName }}
-  ingressClassName: {{ .Values.controller.secondaryingress.ingressClassName | quote }}
+  ingressClassName: {{ tpl .Values.controller.secondaryingress.ingressClassName . | quote }}
 {{- end }}
   rules:
     - host: {{ tpl .Values.controller.secondaryingress.hostName . | quote }}
@@ -44,6 +45,13 @@ spec:
 {{ end }}
         {{- end}}
 {{- if .Values.controller.secondaryingress.tls }}
+{{- $withTlsEntries := false }}
+{{- range .Values.controller.secondaryingress.tls }}
+  {{- if gt (len .) 0 }}
+    {{- $withTlsEntries = true }}
+  {{- end }}
+{{- end }}
+{{- if $withTlsEntries }}
   tls:
 {{- range .Values.controller.secondaryingress.tls }}
   - hosts:
@@ -52,6 +60,7 @@ spec:
 {{- end }}
 {{- if .secretName }}
     secretName: {{ tpl (.secretName | toString) $ | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/jenkins/templates/jenkins-controller-secondary-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-secondary-ingress.yaml
@@ -26,7 +26,7 @@ spec:
   ingressClassName: {{ .Values.controller.secondaryingress.ingressClassName | quote }}
 {{- end }}
   rules:
-    - host: {{ .Values.controller.secondaryingress.hostName }}
+    - host: {{ tpl .Values.controller.secondaryingress.hostName . | quote }}
       http:
         paths:
         {{- range .Values.controller.secondaryingress.paths }}
@@ -45,6 +45,14 @@ spec:
         {{- end}}
 {{- if .Values.controller.secondaryingress.tls }}
   tls:
-{{ toYaml .Values.controller.secondaryingress.tls | indent 4 }}
+{{- range .Values.controller.secondaryingress.tls }}
+  - hosts:
+{{- range .hosts }}
+      - {{ tpl . $ | quote }}
+{{- end }}
+{{- if .secretName }}
+    secretName: {{ tpl (.secretName | toString) $ | quote }}
+{{- end }}
+{{- end }}
 {{- end -}}
 {{- end }}

--- a/charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
@@ -76,3 +76,82 @@ tests:
             app.kubernetes.io/instance: my-release
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: jenkins
+  - it: hostName with Release.Name template variable
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins-{{ .Release.Name }}.example.com
+        ingressClassName: nginx
+        paths:
+          - /wsagents/
+        tls:
+          - secretName: my-tls-secret
+            hosts:
+              - jenkins-{{ .Release.Name }}.example.com
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: jenkins-my-release.example.com
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: jenkins-my-release.example.com
+      - equal:
+          path: spec.tls[0].secretName
+          value: my-tls-secret
+  - it: multiple TLS hosts with Release.Name template variable
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins-{{ .Release.Name }}.example.com
+        ingressClassName: nginx
+        paths:
+          - /wsagents/
+        tls:
+          - secretName: my-tls-secret
+            hosts:
+              - jenkins-{{ .Release.Name }}.example.com
+              - jenkins-{{ .Release.Name }}.alt.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: jenkins-my-release.example.com
+      - equal:
+          path: spec.tls[0].hosts[1]
+          value: jenkins-my-release.alt.example.com
+  - it: multiple TLS hosts, some with Release.Name template variable
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins-{{ .Release.Name }}.example.com
+        ingressClassName: nginx
+        paths:
+          - /wsagents/
+        tls:
+          - secretName: my-tls-secret
+            hosts:
+              - jenkins-hard-coded.example.com
+              - jenkins-{{ .Release.Name }}.alt.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: jenkins-hard-coded.example.com
+      - equal:
+          path: spec.tls[0].hosts[1]
+          value: jenkins-my-release.alt.example.com
+  - it: TLS without secretName uses default secret
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        ingressClassName: nginx
+        paths:
+          - /github-webhook
+        tls:
+          - hosts:
+              - jenkins.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: jenkins.example.com
+      - isNull:
+          path: spec.tls[0].secretName

--- a/charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
@@ -155,3 +155,55 @@ tests:
           value: jenkins.example.com
       - isNull:
           path: spec.tls[0].secretName
+  - it: empty TLS entry does not render tls block
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        paths:
+          - /github-webhook
+        tls:
+          - {}
+    asserts:
+      - isNull:
+          path: spec.tls
+  - it: annotations with and without template variables
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        paths:
+          - /github-webhook
+        annotations:
+          nginx.ingress.kubernetes.io/app-root: /{{ .Release.Name }}
+          nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            nginx.ingress.kubernetes.io/app-root: /my-release
+            nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+  - it: ingressClassName with template variable
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        ingressClassName: "{{ .Release.Name }}-nginx"
+        paths:
+          - /github-webhook
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: my-release-nginx
+  - it: ingressClassName with hard-coded value
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        ingressClassName: "nginx"
+        paths:
+          - /github-webhook
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx

--- a/charts/jenkins/unittests/jenkins-controller-secondary-ingress-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-secondary-ingress-test.yaml
@@ -74,3 +74,82 @@ tests:
             app.kubernetes.io/instance: my-release
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: jenkins
+  - it: hostName with Release.Name template variable
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins-{{ .Release.Name }}.example.com
+        ingressClassName: nginx
+        paths:
+          - /wsagents/
+        tls:
+          - secretName: my-tls-secret
+            hosts:
+              - jenkins-{{ .Release.Name }}.example.com
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: jenkins-my-release.example.com
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: jenkins-my-release.example.com
+      - equal:
+          path: spec.tls[0].secretName
+          value: my-tls-secret
+  - it: multiple TLS hosts with Release.Name template variable
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins-{{ .Release.Name }}.example.com
+        ingressClassName: nginx
+        paths:
+          - /wsagents/
+        tls:
+          - secretName: my-tls-secret
+            hosts:
+              - jenkins-{{ .Release.Name }}.example.com
+              - jenkins-{{ .Release.Name }}.alt.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: jenkins-my-release.example.com
+      - equal:
+          path: spec.tls[0].hosts[1]
+          value: jenkins-my-release.alt.example.com
+  - it: multiple TLS hosts, some with Release.Name template variable
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins-{{ .Release.Name }}.example.com
+        ingressClassName: nginx
+        paths:
+          - /wsagents/
+        tls:
+          - secretName: my-tls-secret
+            hosts:
+              - jenkins-hard-coded.example.com
+              - jenkins-{{ .Release.Name }}.alt.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: jenkins-hard-coded.example.com
+      - equal:
+          path: spec.tls[0].hosts[1]
+          value: jenkins-my-release.alt.example.com
+  - it: TLS without secretName uses default secret
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        ingressClassName: nginx
+        paths:
+          - /github-webhook
+        tls:
+          - hosts:
+              - jenkins.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: jenkins.example.com
+      - isNull:
+          path: spec.tls[0].secretName

--- a/charts/jenkins/unittests/jenkins-controller-secondary-ingress-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-secondary-ingress-test.yaml
@@ -153,3 +153,55 @@ tests:
           value: jenkins.example.com
       - isNull:
           path: spec.tls[0].secretName
+  - it: empty TLS entry does not render tls block
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        paths:
+          - /github-webhook
+        tls:
+          - {}
+    asserts:
+      - isNull:
+          path: spec.tls
+  - it: annotations with and without template variables
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        paths:
+          - /github-webhook
+        annotations:
+          nginx.ingress.kubernetes.io/app-root: /{{ .Release.Name }}
+          nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            nginx.ingress.kubernetes.io/app-root: /my-release
+            nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+  - it: ingressClassName with template variable
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        ingressClassName: "{{ .Release.Name }}-nginx"
+        paths:
+          - /github-webhook
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: my-release-nginx
+  - it: ingressClassName with hard-coded value
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        ingressClassName: "nginx"
+        paths:
+          - /github-webhook
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -703,7 +703,7 @@ controller:
   updateStrategy: {}
 
   # -- Topology spread constraints
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
 
   # -- DNS config for the pod
   dnsConfig: {}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -709,11 +709,11 @@ controller:
   dnsConfig: {}
 
   ingress:
-    # -- Enables ingress
+    # -- Enables the Primary ingress
     enabled: false
 
     # Override for the default paths that map requests to the backend
-    # -- Override for the default Ingress paths
+    # -- Override for the default Primary Ingress paths
     paths: []
     # - backend:
     #     serviceName: ssl-redirect
@@ -724,16 +724,16 @@ controller:
     #     # Don't use string here, use only integer value!
     #     servicePort: 8080
 
-    # -- Ingress rule pathType, choices are: Exact, ImplementationSpecific, Prefix
+    # -- Primary Ingress rule pathType, choices are: Exact, ImplementationSpecific, Prefix
     pathType: ImplementationSpecific
 
     # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
     # For Kubernetes v1.19+, use 'networking.k8s.io/v1'
-    # -- Ingress API version
-    apiVersion: "extensions/v1beta1"
-    # -- Ingress labels
+    # -- Primary Ingress API version
+    apiVersion: "networking.k8s.io/v1"
+    # -- Primary Ingress labels
     labels: {}
-    # -- Ingress annotations
+    # -- Primary Ingress annotations
     annotations:
       {}
       # kubernetes.io/ingress.class: nginx
@@ -741,17 +741,19 @@ controller:
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
     # ingressClassName: nginx
+    # -- Primary Ingress ingressClassName
+    ingressClassName:
 
     # Set this path to jenkinsUriPrefix above or use annotations to rewrite path
-    # -- Ingress path
+    # -- Primary Ingress path
     path:
 
     # configures the hostname e.g. jenkins.example.com
-    # -- Ingress hostname
+    # -- Primary Ingress hostname
     hostName:
-    # -- Hostname to serve assets from
+    # -- Primary Hostname to serve assets from
     resourceRootUrl:
-    # -- Ingress TLS configuration
+    # -- Primary Ingress TLS configuration
     tls: []
     # - secretName: jenkins.cluster.local
     #   hosts:
@@ -762,22 +764,30 @@ controller:
   # A secondary ingress will let you expose different urls
   # with a different configuration
   secondaryingress:
+    # -- Enables the Secondary Ingress
     enabled: false
     # paths you want forwarded to the backend
     # ex /github-webhook
+    # -- Secondary Ingress paths
     paths: []
     # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
     # For Kubernetes v1.19+, use 'networking.k8s.io/v1'
-    apiVersion: "extensions/v1beta1"
+    # -- Secondary Ingress API version
+    apiVersion: "networking.k8s.io/v1"
+    # -- Secondary Ingress labels
     labels: {}
+    # -- Secondary Ingress annotations
     annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-    # ingressClassName: nginx
+    # -- Secondary Ingress ingressClassName
+    ingressClassName:
     # configures the hostname e.g., jenkins-external.example.com
+    # -- Secondary Ingress hostname
     hostName:
+    # -- Secondary Ingress TLS configuration
     tls:
     # - secretName: jenkins-external.example.com
     #   hosts:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

The `secondaryingress` template was not evaluating Go template expressions in `hostName` and `tls[].hosts[]` values, unlike the primary ingress template. This meant that template variables such as `{{ .Release.Name }}` were rendered as literal strings instead of being interpolated.

This PR fixes the secondary ingress template to use tpl to evaluate `hostName`, `tls[].hosts[]`, and other values, bringing it in line with the primary ingress behavior.

- Fixes #1637
- Fixes #476

### Submitter checklist

- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer