### PR TITLE
feat(jenkins): add agentInjection support to pod template

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.13
+
+Add `agent.agentInjection` to configure "Inject Jenkins agent in agent container" via values
+
 ## 5.9.12
 
 Update `git` to version `5.10.1`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.12
+version: 5.9.13
 appVersion: 2.541.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -8,34 +8,35 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Key | Type | Description | Default |
 |:----|:-----|:---------|:------------|
-| [additionalAgents](./values.yaml#L1247) | object | Configure additional | `{}` |
-| [additionalClouds](./values.yaml#L1272) | object |  | `{}` |
-| [agent.TTYEnabled](./values.yaml#L1152) | bool | Allocate pseudo tty to the side container | `false` |
-| [agent.additionalContainers](./values.yaml#L1200) | list | Add additional containers to the agents | `[]` |
+| [additionalAgents](./values.yaml#L1250) | object | Configure additional | `{}` |
+| [additionalClouds](./values.yaml#L1275) | object |  | `{}` |
+| [agent.TTYEnabled](./values.yaml#L1155) | bool | Allocate pseudo tty to the side container | `false` |
+| [agent.additionalContainers](./values.yaml#L1203) | list | Add additional containers to the agents | `[]` |
+| [agent.agentInjection](./values.yaml#L1061) | bool | Inject the Jenkins agent into the agent container instead of using a separate jnlp sidecar. This avoids version drift between the Jenkins controller and the agent. | `false` |
 | [agent.alwaysPullImage](./values.yaml#L1045) | bool | Always pull agent container image before build | `false` |
-| [agent.annotations](./values.yaml#L1196) | object | Annotations to apply to the pod | `{}` |
-| [agent.args](./values.yaml#L1146) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
-| [agent.command](./values.yaml#L1144) | string | Command to execute when side container starts | `nil` |
+| [agent.annotations](./values.yaml#L1199) | object | Annotations to apply to the pod | `{}` |
+| [agent.args](./values.yaml#L1149) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
+| [agent.command](./values.yaml#L1147) | string | Command to execute when side container starts | `nil` |
 | [agent.componentName](./values.yaml#L1013) | string |  | `"jenkins-agent"` |
-| [agent.connectTimeout](./values.yaml#L1194) | int | Timeout in seconds for an agent to be online | `100` |
-| [agent.containerCap](./values.yaml#L1154) | int | Max number of agents to launch for a whole cluster. | `10` |
+| [agent.connectTimeout](./values.yaml#L1197) | int | Timeout in seconds for an agent to be online | `100` |
+| [agent.containerCap](./values.yaml#L1157) | int | Max number of agents to launch for a whole cluster. | `10` |
 | [agent.customJenkinsLabels](./values.yaml#L1010) | list | Append Jenkins labels to the agent | `[]` |
 | [agent.defaultsProviderTemplate](./values.yaml#L962) | string | The name of the pod template to use for providing default values | `""` |
 | [agent.directConnection](./values.yaml#L1016) | bool |  | `false` |
-| [agent.disableDefaultAgent](./values.yaml#L1218) | bool | Disable the default Jenkins Agent configuration | `false` |
+| [agent.disableDefaultAgent](./values.yaml#L1221) | bool | Disable the default Jenkins Agent configuration | `false` |
 | [agent.enabled](./values.yaml#L960) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
-| [agent.envVars](./values.yaml#L1127) | list | Environment variables for the agent Pod | `[]` |
-| [agent.garbageCollection.enabled](./values.yaml#L1163) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
-| [agent.garbageCollection.namespaces](./values.yaml#L1165) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
-| [agent.garbageCollection.timeout](./values.yaml#L1170) | int | Timeout value for orphaned pods | `300` |
+| [agent.envVars](./values.yaml#L1130) | list | Environment variables for the agent Pod | `[]` |
+| [agent.garbageCollection.enabled](./values.yaml#L1166) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
+| [agent.garbageCollection.namespaces](./values.yaml#L1168) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
+| [agent.garbageCollection.timeout](./values.yaml#L1173) | int | Timeout value for orphaned pods | `300` |
 | [agent.hostNetworking](./values.yaml#L1024) | bool | Enables the agent to use the host network | `false` |
-| [agent.idleMinutes](./values.yaml#L1173) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
+| [agent.idleMinutes](./values.yaml#L1176) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
 | [agent.image.registry](./values.yaml#L1001) | string | Registry to pull the agent jnlp image from | `""` |
 | [agent.image.repository](./values.yaml#L1003) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
 | [agent.image.tag](./values.yaml#L1005) | string | Tag of the image to pull | `"3355.v388858a_47b_33-17"` |
 | [agent.imagePullSecretName](./values.yaml#L1012) | string | Name of the secret to be used to pull the image | `nil` |
-| [agent.inheritYamlMergeStrategy](./values.yaml#L1192) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
-| [agent.instanceCap](./values.yaml#L1156) | int | Max number of agents to launch for this type of agent | `2147483647` |
+| [agent.inheritYamlMergeStrategy](./values.yaml#L1195) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
+| [agent.instanceCap](./values.yaml#L1159) | int | Max number of agents to launch for this type of agent | `2147483647` |
 | [agent.jenkinsTunnel](./values.yaml#L978) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
 | [agent.jenkinsUrl](./values.yaml#L974) | string | Overrides the Kubernetes Jenkins URL | `nil` |
 | [agent.jnlpregistry](./values.yaml#L998) | string | Custom registry used to pull the agent jnlp image from | `nil` |
@@ -44,37 +45,37 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [agent.livenessProbe](./values.yaml#L1035) | object |  | `{}` |
 | [agent.maxRequestsPerHostStr](./values.yaml#L988) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
 | [agent.namespace](./values.yaml#L994) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
-| [agent.nodeSelector](./values.yaml#L1138) | object | Node labels for pod assignment | `{}` |
+| [agent.nodeSelector](./values.yaml#L1141) | object | Node labels for pod assignment | `{}` |
 | [agent.nodeUsageMode](./values.yaml#L1008) | string |  | `"NORMAL"` |
 | [agent.podLabels](./values.yaml#L996) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
-| [agent.podName](./values.yaml#L1158) | string | Agent Pod base name | `"default"` |
+| [agent.podName](./values.yaml#L1161) | string | Agent Pod base name | `"default"` |
 | [agent.podRetention](./values.yaml#L1054) | string |  | `"Never"` |
-| [agent.podTemplates](./values.yaml#L1228) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
+| [agent.podTemplates](./values.yaml#L1231) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
 | [agent.privileged](./values.yaml#L1018) | bool | Agent privileged container | `false` |
 | [agent.resources](./values.yaml#L1026) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
 | [agent.restrictedPssSecurityContext](./values.yaml#L1051) | bool | Set a restricted securityContext on jnlp containers | `false` |
 | [agent.retentionTimeout](./values.yaml#L990) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
 | [agent.runAsGroup](./values.yaml#L1022) | string | Configure container group | `nil` |
 | [agent.runAsUser](./values.yaml#L1020) | string | Configure container user | `nil` |
-| [agent.secretEnvVars](./values.yaml#L1131) | list | Mount a secret as environment variable | `[]` |
+| [agent.secretEnvVars](./values.yaml#L1134) | list | Mount a secret as environment variable | `[]` |
 | [agent.serviceAccount](./values.yaml#L970) | string | Override the default service account | `serviceAccountAgent.name` if `agent.useDefaultServiceAccount` is `true` |
 | [agent.showRawYaml](./values.yaml#L1058) | bool |  | `true` |
-| [agent.sideContainerName](./values.yaml#L1148) | string | Side container name | `"jnlp"` |
+| [agent.sideContainerName](./values.yaml#L1151) | string | Side container name | `"jnlp"` |
 | [agent.skipTlsVerify](./values.yaml#L980) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
 | [agent.usageRestricted](./values.yaml#L982) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
 | [agent.useDefaultServiceAccount](./values.yaml#L966) | bool | Use `serviceAccountAgent.name` as the default value for defaults template `serviceAccount` | `true` |
-| [agent.volumes](./values.yaml#L1065) | list | Additional volumes | `[]` |
+| [agent.volumes](./values.yaml#L1068) | list | Additional volumes | `[]` |
 | [agent.waitForPodSec](./values.yaml#L992) | int | Seconds to wait for pod to be running | `600` |
 | [agent.websocket](./values.yaml#L1015) | bool | Enables agent communication via websockets | `false` |
 | [agent.workingDir](./values.yaml#L1007) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
-| [agent.workspaceVolume](./values.yaml#L1100) | object | Workspace volume (defaults to EmptyDir) | `{}` |
-| [agent.yamlMergeStrategy](./values.yaml#L1190) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
-| [agent.yamlTemplate](./values.yaml#L1179) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1405) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1407) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1409) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1408) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1402) | bool | Checks if any deprecated values are used | `true` |
+| [agent.workspaceVolume](./values.yaml#L1103) | object | Workspace volume (defaults to EmptyDir) | `{}` |
+| [agent.yamlMergeStrategy](./values.yaml#L1193) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
+| [agent.yamlTemplate](./values.yaml#L1182) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1408) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1410) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1412) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1411) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1405) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L558) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L563) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -297,43 +298,43 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [extraLabels](./values.yaml#L33) | object | Configures extra labels for the agent all objects | `{}` |
 | [extraObjects](./values.yaml#L36) | string | Configures extra manifests | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1418) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1420) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1422) | string | Tag of the image to test the framework | `"1.13.0"` |
+| [helmtest.bats.image.registry](./values.yaml#L1421) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1423) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1425) | string | Tag of the image to test the framework | `"1.13.0"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
-| [networkPolicy.apiVersion](./values.yaml#L1341) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
-| [networkPolicy.enabled](./values.yaml#L1336) | bool | Enable the creation of NetworkPolicy resources | `false` |
-| [networkPolicy.externalAgents.except](./values.yaml#L1356) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
-| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1354) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
-| [networkPolicy.internalAgents.allowed](./values.yaml#L1345) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
-| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1349) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
-| [networkPolicy.internalAgents.podLabels](./values.yaml#L1347) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
-| [persistence.accessMode](./values.yaml#L1311) | string | The PVC access mode | `"ReadWriteOnce"` |
-| [persistence.annotations](./values.yaml#L1307) | object | Annotations for the PVC | `{}` |
-| [persistence.dataSource](./values.yaml#L1317) | object | Existing data source to clone PVC from | `{}` |
-| [persistence.enabled](./values.yaml#L1291) | bool | Enable the use of a Jenkins PVC | `true` |
-| [persistence.existingClaim](./values.yaml#L1297) | string | Provide the name of a PVC | `nil` |
-| [persistence.labels](./values.yaml#L1309) | object | Labels for the PVC | `{}` |
-| [persistence.mounts](./values.yaml#L1329) | list | Additional mounts | `[]` |
-| [persistence.size](./values.yaml#L1313) | string | The size of the PVC | `"8Gi"` |
-| [persistence.storageClass](./values.yaml#L1305) | string | Storage class for the PVC | `nil` |
-| [persistence.subPath](./values.yaml#L1322) | string | SubPath for jenkins-home mount | `nil` |
-| [persistence.volumes](./values.yaml#L1324) | list | Additional volumes | `[]` |
-| [rbac.create](./values.yaml#L1363) | bool | Whether RBAC resources are created | `true` |
-| [rbac.readSecrets](./values.yaml#L1365) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
-| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1367) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
+| [networkPolicy.apiVersion](./values.yaml#L1344) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
+| [networkPolicy.enabled](./values.yaml#L1339) | bool | Enable the creation of NetworkPolicy resources | `false` |
+| [networkPolicy.externalAgents.except](./values.yaml#L1359) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
+| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1357) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
+| [networkPolicy.internalAgents.allowed](./values.yaml#L1348) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
+| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1352) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
+| [networkPolicy.internalAgents.podLabels](./values.yaml#L1350) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
+| [persistence.accessMode](./values.yaml#L1314) | string | The PVC access mode | `"ReadWriteOnce"` |
+| [persistence.annotations](./values.yaml#L1310) | object | Annotations for the PVC | `{}` |
+| [persistence.dataSource](./values.yaml#L1320) | object | Existing data source to clone PVC from | `{}` |
+| [persistence.enabled](./values.yaml#L1294) | bool | Enable the use of a Jenkins PVC | `true` |
+| [persistence.existingClaim](./values.yaml#L1300) | string | Provide the name of a PVC | `nil` |
+| [persistence.labels](./values.yaml#L1312) | object | Labels for the PVC | `{}` |
+| [persistence.mounts](./values.yaml#L1332) | list | Additional mounts | `[]` |
+| [persistence.size](./values.yaml#L1316) | string | The size of the PVC | `"8Gi"` |
+| [persistence.storageClass](./values.yaml#L1308) | string | Storage class for the PVC | `nil` |
+| [persistence.subPath](./values.yaml#L1325) | string | SubPath for jenkins-home mount | `nil` |
+| [persistence.volumes](./values.yaml#L1327) | list | Additional volumes | `[]` |
+| [rbac.create](./values.yaml#L1366) | bool | Whether RBAC resources are created | `true` |
+| [rbac.readSecrets](./values.yaml#L1368) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
+| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1370) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
-| [serviceAccount.annotations](./values.yaml#L1377) | object | Configures annotations for the ServiceAccount | `{}` |
-| [serviceAccount.automountServiceAccountToken](./values.yaml#L1383) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccount.create](./values.yaml#L1371) | bool | Configures if a ServiceAccount with this name should be created | `true` |
-| [serviceAccount.extraLabels](./values.yaml#L1379) | object | Configures extra labels for the ServiceAccount | `{}` |
-| [serviceAccount.imagePullSecretName](./values.yaml#L1381) | string | Controller ServiceAccount image pull secret | `nil` |
-| [serviceAccount.name](./values.yaml#L1375) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1393) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1399) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccountAgent.create](./values.yaml#L1387) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1395) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1397) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1391) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccount.annotations](./values.yaml#L1380) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.automountServiceAccountToken](./values.yaml#L1386) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccount.create](./values.yaml#L1374) | bool | Configures if a ServiceAccount with this name should be created | `true` |
+| [serviceAccount.extraLabels](./values.yaml#L1382) | object | Configures extra labels for the ServiceAccount | `{}` |
+| [serviceAccount.imagePullSecretName](./values.yaml#L1384) | string | Controller ServiceAccount image pull secret | `nil` |
+| [serviceAccount.name](./values.yaml#L1378) | string |  | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1396) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1402) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccountAgent.create](./values.yaml#L1390) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1398) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1400) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1394) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -511,6 +511,7 @@ Returns kubernetes pod template configuration as code
   nodeUsageMode: {{ quote .Values.agent.nodeUsageMode }}
   podRetention: {{ .Values.agent.podRetention }}
   showRawYaml: {{ .Values.agent.showRawYaml }}
+  agentInjection: {{ .Values.agent.agentInjection }}
 {{- $asaname := default (include "jenkins.serviceAccountAgentName" .) .Values.agent.serviceAccount -}}
 {{- if or (.Values.agent.useDefaultServiceAccount) (.Values.agent.serviceAccount) }}
   serviceAccount: "{{ $asaname }}"

--- a/charts/jenkins/unittests/__snapshot__/garbage-collect-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/garbage-collect-test.yaml.snap
@@ -49,7 +49,7 @@ namespaces:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: 6d4f6f01c485f5ae8059ef93966485e47b9064b20b681d43f5c980a7ee9d27ad
+                id: 73f6266d4a3c18d1a789831428438c3533b3142b944df0c12a565cda5e528784
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -72,6 +72,7 @@ namespaces:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -136,7 +137,7 @@ one cloud:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: b2c401ac0299c541f06d078cb63cdd55da1f573ed367f9da8dbad17289061629
+                id: 48fb53ae15176ab3a623b840ee23ca54f7d10688348144ad87788b74322a7e16
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -159,6 +160,7 @@ one cloud:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -223,7 +225,7 @@ second cloud:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: b2c401ac0299c541f06d078cb63cdd55da1f573ed367f9da8dbad17289061629
+                id: 48fb53ae15176ab3a623b840ee23ca54f7d10688348144ad87788b74322a7e16
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -246,6 +248,7 @@ second cloud:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -275,7 +278,7 @@ second cloud:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: 6fd9fbab311179fe56cae4651f083f0dde3356d6a56ea70a6e1c95f6fca9e939
+                id: 13ccbbe86825821b70ad5fd5c2dac5980e789613454f0bb663bdeced83d273dd
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -298,6 +301,7 @@ second cloud:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override

--- a/charts/jenkins/unittests/__snapshot__/instance-cap-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/instance-cap-test.yaml.snap
@@ -44,7 +44,7 @@ default-cap:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -67,6 +67,7 @@ default-cap:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -129,7 +130,7 @@ limited-cap:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: e6a974968f094a4729edb47305de73e29809e86ae3257ccb354f0947c79bb5a6
+                id: 797b6d9451db5292db26e45cfbafe3112054e9c3c233c9eda37f6d88e3323a6b
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -152,6 +153,7 @@ limited-cap:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override

--- a/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
@@ -44,7 +44,7 @@ additional clouds:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -67,6 +67,7 @@ additional clouds:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -94,7 +95,7 @@ additional clouds:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -117,6 +118,7 @@ additional clouds:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -179,7 +181,7 @@ additional clouds inheriting additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -202,13 +204,14 @@ additional clouds inheriting additional agents:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 6259994af2ee2301f5f7570a0c6ac0cb657a723f2bca0e498c24656cb6c15909
+                id: f4d3a213d8dd38bcfe3a1b3b2a8060a3a4a702e721e524b061cf12c627cf5609
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -231,6 +234,7 @@ additional clouds inheriting additional agents:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -258,7 +262,7 @@ additional clouds inheriting additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -281,13 +285,14 @@ additional clouds inheriting additional agents:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 6259994af2ee2301f5f7570a0c6ac0cb657a723f2bca0e498c24656cb6c15909
+                id: f4d3a213d8dd38bcfe3a1b3b2a8060a3a4a702e721e524b061cf12c627cf5609
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -310,6 +315,7 @@ additional clouds inheriting additional agents:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -372,7 +378,7 @@ additional clouds overriding additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -395,13 +401,14 @@ additional clouds overriding additional agents:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 6259994af2ee2301f5f7570a0c6ac0cb657a723f2bca0e498c24656cb6c15909
+                id: f4d3a213d8dd38bcfe3a1b3b2a8060a3a4a702e721e524b061cf12c627cf5609
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -424,6 +431,7 @@ additional clouds overriding additional agents:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -451,7 +459,7 @@ additional clouds overriding additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -474,6 +482,7 @@ additional clouds overriding additional agents:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -536,7 +545,7 @@ additional clouds set skipTlsVerify:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -559,6 +568,7 @@ additional clouds set skipTlsVerify:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -586,7 +596,7 @@ additional clouds set skipTlsVerify:
             templates:
               - name: "default"
                 namespace: "default"
-                id: bf70cb0b26538de026a98a3e1856804763e4004cc6e963cdd35ccc142951000c
+                id: 1d4e61721f462e18c228827857797593fe31790676a194f8792b155b7140a80a
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -609,6 +619,7 @@ additional clouds set skipTlsVerify:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -671,7 +682,7 @@ additional clouds set usageRestricted:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -694,6 +705,7 @@ additional clouds set usageRestricted:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -721,7 +733,7 @@ additional clouds set usageRestricted:
             templates:
               - name: "default"
                 namespace: "default"
-                id: b3216560ba164efbb83d9246fad512a18b746046d34e9a038cb44cb497c33b39
+                id: d16c5815a5b6a7a63418d7c33e413434136c446434f1948ac349fc422b9eebf6
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -744,6 +756,7 @@ additional clouds set usageRestricted:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -810,7 +823,7 @@ adds custom labels on agent pods:
             templates:
               - name: "default"
                 namespace: "NAMESPACE"
-                id: 6d3c5cc625b0d802ceb341ae669e3a1e7cc6ee02a29e3a6337a9bd09766d0942
+                id: 725d86b80f88568ae806f0b1e544a92a77257b776611bd7710fb115066cdb12c
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -833,6 +846,7 @@ adds custom labels on agent pods:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -895,7 +909,7 @@ agent namespace and templates:
             templates:
               - name: "default"
                 namespace: "jenkins-agents"
-                id: 5fdda4ecda00705756db7e1adadbc096ac9e49691603fc70491af940aefb410e
+                id: 3a5f20e0fec08bfaf5e7aca48ea12d9b42fc3622396a6c9d166e16e873a044c1
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -918,13 +932,14 @@ agent namespace and templates:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: bb800a1c3085f77f33e2209f2c16aa5ea4894bc919b25e32d0a7cc7fba80f205
+                id: 942137a85aef5a07a5af6ca2430929a60f0da6957f1466938125357ed6e642c0
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -947,13 +962,14 @@ agent namespace and templates:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
               - name: "python"
                 namespace: "jenkins-agents"
-                id: 475cb70f861ac29f9234e42d92fe6f06327b45ee8b567381058c4fd2ed91f1b2
+                id: fa5756404fe229e78d63dfa371a3b7a746cb0be0a9e0ac1a0fc5d020e41c0857
                 containers:
                 - name: "python"
                   alwaysPullImage: false
@@ -977,6 +993,7 @@ agent namespace and templates:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -1055,7 +1072,7 @@ agent with liveness probe:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 1def21008325f99909f8d4a4334c109573c5871b34b80c382d1444c29e4bbc32
+                id: ff10b94737da226dd730c150edef26c267ae681601ac5282d3d42ff38a686845
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1085,6 +1102,7 @@ agent with liveness probe:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -1147,7 +1165,7 @@ agents with liveness probe:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 6494500d2b8055ce6cfbcaf6a72323264dea095add44f21247a24d122cc57c3a
+                id: 6d5ffe9e2f0ff36d8f616dc8f22d4523a6a390afd27714eb144025f2ce977fe2
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1192,6 +1210,7 @@ agents with liveness probe:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -1254,7 +1273,7 @@ configure hostnetworking to agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 8e9e045f6b1fdf682dc982aaf8d198c95543671e45fb81e12c95c5d23d7897ec
+                id: 6552298e5b50656ba2b43c9e5bb8a15ed9876a59972e158fdd2b3bf5181155af
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1278,6 +1297,7 @@ configure hostnetworking to agent:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -1340,7 +1360,7 @@ custom dynamic pvc workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: c147bfafd9173bedffe61f9e640c9a601fc41d1d5a4e1130c867007add9e045d
+                id: 5eaebf7dd1bc457da40093b1bbff24eb5b2dc6c4c3685b5fcd90549ea06d7060
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1363,6 +1383,7 @@ custom dynamic pvc workspace volume:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 workspaceVolume:
@@ -1430,7 +1451,7 @@ custom emptyDir workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 3a35c71bb4fe1e49c4cabe0e85ceb9ae15775dfdac1569ffce49505f71ddd914
+                id: 8756b037ccad190d81a95b1db3fba0d25a4876ee235d112714bb65304a67ecfe
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1453,6 +1474,7 @@ custom emptyDir workspace volume:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 workspaceVolume:
@@ -1518,7 +1540,7 @@ custom hostPath workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: b75967cd9785a1366f0adda2e311ee3566956085a957d31a1723335aada70991
+                id: 9080db1f9ba109e9be3ffd1e947e6ec00dc1e9b4db6007adaf420f27b5a0c5da
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1541,6 +1563,7 @@ custom hostPath workspace volume:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 workspaceVolume:
@@ -1606,7 +1629,7 @@ custom jenkins label:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1629,6 +1652,7 @@ custom jenkins label:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -1691,7 +1715,7 @@ custom nfs workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 37d1341c52bbdf7e34c8c0170cf495b669fec07f5105b1bc1769da6fe964022a
+                id: 8f3e0c08fffcd27a0b1a73a67f37d8ad9516f8b28c8980182a6daab4b8947773
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1714,6 +1738,7 @@ custom nfs workspace volume:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 workspaceVolume:
@@ -1781,7 +1806,7 @@ custom other workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 6f533182a2960ca4b528f464bcc3047437af7bf4cdb78a591f92751c3b299e2f
+                id: 51c0d5d133b5ecbe92b1f0e43d62ae0239bd6cdddf4fa62b3e433f51bbc44076
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1804,6 +1829,7 @@ custom other workspace volume:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 workspaceVolume:
@@ -1870,7 +1896,7 @@ custom pvc workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 1172ef1ef45ff320d2a5b6561f7a69cb92e9b2fbba1e5ffde381f6de592933fc
+                id: 82c2e1cc8427bdfa898bd5356a8953baf0df4794cc30d390f4a9e2117f3ea086
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1893,6 +1919,7 @@ custom pvc workspace volume:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 workspaceVolume:
@@ -1959,7 +1986,7 @@ customized config:
                 annotations:
                 - key: ci.jenkins-agent/test
                   value: "custom"
-                id: f5eac9df656fa71574142e06fc04f282b6e6ef56c598d8e0ca7bc3ec0d9405ba
+                id: 6d03f1a3c70f8d8cb7227951ae9223ead7a37d6a6c2fe339fccebc6d10059df8
                 containers:
                 - name: "sideContainer"
                   alwaysPullImage: true
@@ -1994,6 +2021,7 @@ customized config:
                 nodeUsageMode: "NORMAL"
                 podRetention: onFailure
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "agent-serviceaccount"
                 slaveConnectTimeoutStr: "111"
                 volumes:
@@ -2093,7 +2121,7 @@ default config:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2116,6 +2144,7 @@ default config:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -2230,7 +2259,7 @@ disable useDefaultServiceAccount:
             templates:
               - name: "default"
                 namespace: "NAMESPACE"
-                id: f126ea0f1045b7234fe2b06e9aeae1e8cc71e5122f14ffd887f113e83f68b9f3
+                id: 559fd5b1f68e40d352cb808a699a397074a310fe32aaed0ba46ed53fc3970b4f
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2253,6 +2282,7 @@ disable useDefaultServiceAccount:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
@@ -2313,7 +2343,7 @@ empty projectNamingStrategy:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2336,6 +2366,7 @@ empty projectNamingStrategy:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -2398,7 +2429,7 @@ legacyRemotingSecurityEnabled = false:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2421,6 +2452,7 @@ legacyRemotingSecurityEnabled = false:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -2485,7 +2517,7 @@ legacyRemotingSecurityEnabled = true:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2508,6 +2540,7 @@ legacyRemotingSecurityEnabled = true:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -2573,7 +2606,7 @@ non-string projectNamingStrategy:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2596,6 +2629,7 @@ non-string projectNamingStrategy:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -2658,7 +2692,7 @@ none lts version:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2681,6 +2715,7 @@ none lts version:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -2740,7 +2775,7 @@ set agent.serviceAccount:
             templates:
               - name: "default"
                 namespace: "NAMESPACE"
-                id: f656eb319011254e54ca3f31d9763c3e0c04d8e22c06de32472352004038588f
+                id: 60429f1cf9c2832aa47d7216b4a32c4aad06c3f3adea563f8b5c37e1df2f4853
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2763,6 +2798,7 @@ set agent.serviceAccount:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "testing"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -2824,7 +2860,7 @@ set directConnection:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 5ee7d2fe56ab9740cebc4646d15ea280d1750b2f2b7fa712c284cea6691c457b
+                id: 185e72bc37df32a242f0f3a82ec52d1ae53ddf1cdf71f08455220c3a683aa157
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2847,6 +2883,7 @@ set directConnection:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -2909,7 +2946,7 @@ set restrictedPssSecurityContext:
             templates:
               - name: "default"
                 namespace: "default"
-                id: c6a7bf7d6b700ed9ccb523347e4d3d6692ad129bb3be0291d6ec007e102e6951
+                id: 7a42ae806095d999b448918b4705b3d39855e1dd9f3cc9397c540e5402e5c405
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2932,6 +2969,7 @@ set restrictedPssSecurityContext:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -2994,7 +3032,7 @@ set secretEnvVars:
             templates:
               - name: "default"
                 namespace: "default"
-                id: b9bf1213d21cc60832db20f26c571ee246654ab4c9554fc9d23ff1ff4aafb728
+                id: 7048b299b388548dc7d800e47b127964c81c3529182bca740bdf9175a2fc62fd
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3026,6 +3064,7 @@ set secretEnvVars:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -3088,7 +3127,7 @@ specify additional container:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 0df073d6b9ea749ac5ded94e36a1a9771e9c9e8891576ab0699c63bd3412418d
+                id: 0b369ee6e1b298fc24dcc36cb8c6e1fc082c08039382a7838718bc48bc492520
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3127,6 +3166,7 @@ specify additional container:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -3189,7 +3229,7 @@ specify additional container and clear in additional agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 0df073d6b9ea749ac5ded94e36a1a9771e9c9e8891576ab0699c63bd3412418d
+                id: 0b369ee6e1b298fc24dcc36cb8c6e1fc082c08039382a7838718bc48bc492520
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3228,13 +3268,14 @@ specify additional container and clear in additional agent:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
-                id: 8cb800c0b03e860486e8fb83187e36a88b9b2123fe2ea98cd5b985d50e6cfbdb
+                id: d69c5f9ee23f50428348c9898df57af4123ad297aeabecc4b32bd17c3cb17ce3
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3257,6 +3298,7 @@ specify additional container and clear in additional agent:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -3319,7 +3361,7 @@ specify additional container and overwrite in additional agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 0df073d6b9ea749ac5ded94e36a1a9771e9c9e8891576ab0699c63bd3412418d
+                id: 0b369ee6e1b298fc24dcc36cb8c6e1fc082c08039382a7838718bc48bc492520
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3358,13 +3400,14 @@ specify additional container and overwrite in additional agent:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
                 inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
-                id: 6fa3ebca1074cbb9fc10daeb9ea7ad814267449d324ab53a25af3805684f7730
+                id: f6087a7373e32f6ac6d9ade80fce98f0be6ce64866ceec7b96e0f04432071408
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3403,6 +3446,7 @@ specify additional container and overwrite in additional agent:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -3465,7 +3509,7 @@ specify security settings with apiToken override:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3488,6 +3532,7 @@ specify security settings with apiToken override:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override
@@ -3547,7 +3592,7 @@ specify security settings without apiToken override:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f4d4365a0fec0782b890b993b76313dc849cf66ca57c3fdedba41bcdef3b7069
+                id: 76f85b27deecb44e7db2542be82af8cef1c6ed86d90a37f5d00685c37e6c78d7
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3570,6 +3615,7 @@ specify security settings without apiToken override:
                 nodeUsageMode: "NORMAL"
                 podRetention: Never
                 showRawYaml: true
+                agentInjection: false
                 serviceAccount: "default"
                 slaveConnectTimeoutStr: "100"
                 yamlMergeStrategy: override

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -1056,6 +1056,9 @@ agent:
   # in the job Console Output. This can be helpful for either security reasons
   # or simply to clean up the output to make it easier to read.
   showRawYaml: true
+  # -- Inject the Jenkins agent into the agent container instead of using a separate jnlp sidecar.
+  # This avoids version drift between the Jenkins controller and the agent.
+  agentInjection: false
 
   # You can define the volumes that you want to mount for this container
   # Allowed types are: ConfigMap, EmptyDir, EphemeralVolume, HostPath, Nfs, PVC, Secret


### PR DESCRIPTION
## Summary

Expose the `agentInjection` property from the Kubernetes plugin `PodTemplate` in the Helm chart values.

This allows users to configure the **"Inject Jenkins agent in agent container"** option via `values.yaml`:

```yaml
agent:
  agentInjection: true
```

Instead of manually setting it in the Jenkins UI (Manage Jenkins → Clouds → Kubernetes → Pod Templates → default).

## Changes

- `charts/jenkins/values.yaml`: Added `agent.agentInjection` (default: `false`)
- `charts/jenkins/templates/_helpers.tpl`: Render `agentInjection` in the pod template JCasC config

## Motivation

Using `agentInjection` avoids version drift between the Jenkins controller and the agent by injecting the agent into the agent container instead of using a separate jnlp sidecar. Currently this option can only be set via the UI, which is not compatible with GitOps/IaC workflows.

Fixes #1343