### PR TITLE
Added addMasterProxyEnvVars

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -14,7 +14,7 @@ Those entries include a reference to the git commit to be able to get more detai
 
 ## 5.9.30
 
-Solves: [#1691](https://github.com/jenkinsci/helm-charts/issues/1691) Added addMasterProxyEnvVars to allow agents to use proxy env settings from the controller.
+Added addMasterProxyEnvVars to allow agents to use proxy env settings from the controller.
 
 ## 5.9.29
 

--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.30
+
+Solves: [#1691](https://github.com/jenkinsci/helm-charts/issues/1691) Added addMasterProxyEnvVars to allow agents to use proxy env settings from the controller.
+
 ## 5.9.29
 
 Update `docker.io/kiwigrid/k8s-sidecar` to version `2.7.4`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.29
+version: 5.9.30
 appVersion: 2.555.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -8,73 +8,74 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Key | Type | Description | Default |
 |:----|:-----|:---------|:------------|
-| [additionalAgents](./values.yaml#L1257) | object | Configure additional | `{}` |
-| [additionalClouds](./values.yaml#L1282) | object |  | `{}` |
-| [agent.TTYEnabled](./values.yaml#L1162) | bool | Allocate pseudo tty to the side container | `false` |
-| [agent.additionalContainers](./values.yaml#L1210) | list | Add additional containers to the agents | `[]` |
-| [agent.alwaysPullImage](./values.yaml#L1055) | bool | Always pull agent container image before build | `false` |
-| [agent.annotations](./values.yaml#L1206) | object | Annotations to apply to the pod | `{}` |
-| [agent.args](./values.yaml#L1156) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
-| [agent.command](./values.yaml#L1154) | string | Command to execute when side container starts | `nil` |
-| [agent.componentName](./values.yaml#L1023) | string |  | `"jenkins-agent"` |
-| [agent.connectTimeout](./values.yaml#L1204) | int | Timeout in seconds for an agent to be online | `100` |
-| [agent.containerCap](./values.yaml#L1164) | int | Max number of agents to launch for a whole cluster. | `10` |
-| [agent.customJenkinsLabels](./values.yaml#L1020) | list | Append Jenkins labels to the agent | `[]` |
-| [agent.defaultsProviderTemplate](./values.yaml#L972) | string | The name of the pod template to use for providing default values | `""` |
-| [agent.directConnection](./values.yaml#L1026) | bool |  | `false` |
-| [agent.disableDefaultAgent](./values.yaml#L1228) | bool | Disable the default Jenkins Agent configuration | `false` |
-| [agent.enabled](./values.yaml#L970) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
-| [agent.envVars](./values.yaml#L1137) | list | Environment variables for the agent Pod | `[]` |
-| [agent.garbageCollection.enabled](./values.yaml#L1173) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
-| [agent.garbageCollection.namespaces](./values.yaml#L1175) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
-| [agent.garbageCollection.timeout](./values.yaml#L1180) | int | Timeout value for orphaned pods | `300` |
-| [agent.hostNetworking](./values.yaml#L1034) | bool | Enables the agent to use the host network | `false` |
-| [agent.idleMinutes](./values.yaml#L1183) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
-| [agent.image.registry](./values.yaml#L1011) | string | Registry to pull the agent jnlp image from | `""` |
-| [agent.image.repository](./values.yaml#L1013) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
-| [agent.image.tag](./values.yaml#L1015) | string | Tag of the image to pull | `"3355.v388858a_47b_33-23"` |
-| [agent.imagePullSecretName](./values.yaml#L1022) | string | Name of the secret to be used to pull the image | `nil` |
-| [agent.inheritYamlMergeStrategy](./values.yaml#L1202) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
-| [agent.instanceCap](./values.yaml#L1166) | int | Max number of agents to launch for this type of agent | `2147483647` |
-| [agent.jenkinsTunnel](./values.yaml#L988) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
-| [agent.jenkinsUrl](./values.yaml#L984) | string | Overrides the Kubernetes Jenkins URL | `nil` |
-| [agent.jnlpregistry](./values.yaml#L1008) | string | Custom registry used to pull the agent jnlp image from | `nil` |
-| [agent.kubernetesConnectTimeout](./values.yaml#L994) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
-| [agent.kubernetesReadTimeout](./values.yaml#L996) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
-| [agent.livenessProbe](./values.yaml#L1045) | object |  | `{}` |
-| [agent.maxRequestsPerHostStr](./values.yaml#L998) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
-| [agent.namespace](./values.yaml#L1004) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
-| [agent.nodeSelector](./values.yaml#L1148) | object | Node labels for pod assignment | `{}` |
-| [agent.nodeUsageMode](./values.yaml#L1018) | string |  | `"NORMAL"` |
-| [agent.podLabels](./values.yaml#L1006) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
-| [agent.podName](./values.yaml#L1168) | string | Agent Pod base name | `"default"` |
-| [agent.podRetention](./values.yaml#L1064) | string |  | `"Never"` |
-| [agent.podTemplates](./values.yaml#L1238) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
-| [agent.privileged](./values.yaml#L1028) | bool | Agent privileged container | `false` |
-| [agent.resources](./values.yaml#L1036) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
-| [agent.restrictedPssSecurityContext](./values.yaml#L1061) | bool | Set a restricted securityContext on jnlp containers | `false` |
-| [agent.retentionTimeout](./values.yaml#L1000) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
-| [agent.runAsGroup](./values.yaml#L1032) | string | Configure container group | `nil` |
-| [agent.runAsUser](./values.yaml#L1030) | string | Configure container user | `nil` |
-| [agent.secretEnvVars](./values.yaml#L1141) | list | Mount a secret as environment variable | `[]` |
-| [agent.serviceAccount](./values.yaml#L980) | string | Override the default service account | `serviceAccountAgent.name` if `agent.useDefaultServiceAccount` is `true` |
-| [agent.showRawYaml](./values.yaml#L1068) | bool |  | `true` |
-| [agent.sideContainerName](./values.yaml#L1158) | string | Side container name | `"jnlp"` |
-| [agent.skipTlsVerify](./values.yaml#L990) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
-| [agent.usageRestricted](./values.yaml#L992) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
-| [agent.useDefaultServiceAccount](./values.yaml#L976) | bool | Use `serviceAccountAgent.name` as the default value for defaults template `serviceAccount` | `true` |
-| [agent.volumes](./values.yaml#L1075) | list | Additional volumes | `[]` |
-| [agent.waitForPodSec](./values.yaml#L1002) | int | Seconds to wait for pod to be running | `600` |
-| [agent.websocket](./values.yaml#L1025) | bool | Enables agent communication via websockets | `false` |
-| [agent.workingDir](./values.yaml#L1017) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
-| [agent.workspaceVolume](./values.yaml#L1110) | object | Workspace volume (defaults to EmptyDir) | `{}` |
-| [agent.yamlMergeStrategy](./values.yaml#L1200) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
-| [agent.yamlTemplate](./values.yaml#L1189) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1415) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1417) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1419) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1418) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1412) | bool | Checks if any deprecated values are used | `true` |
+| [additionalAgents](./values.yaml#L1260) | object | Configure additional | `{}` |
+| [additionalClouds](./values.yaml#L1285) | object |  | `{}` |
+| [agent.TTYEnabled](./values.yaml#L1165) | bool | Allocate pseudo tty to the side container | `false` |
+| [agent.addMasterProxyEnvVars](./values.yaml#L970) | bool | Add the environment proxy settings form jenkins controller to the agents. | `false` |
+| [agent.additionalContainers](./values.yaml#L1213) | list | Add additional containers to the agents | `[]` |
+| [agent.alwaysPullImage](./values.yaml#L1058) | bool | Always pull agent container image before build | `false` |
+| [agent.annotations](./values.yaml#L1209) | object | Annotations to apply to the pod | `{}` |
+| [agent.args](./values.yaml#L1159) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
+| [agent.command](./values.yaml#L1157) | string | Command to execute when side container starts | `nil` |
+| [agent.componentName](./values.yaml#L1026) | string |  | `"jenkins-agent"` |
+| [agent.connectTimeout](./values.yaml#L1207) | int | Timeout in seconds for an agent to be online | `100` |
+| [agent.containerCap](./values.yaml#L1167) | int | Max number of agents to launch for a whole cluster. | `10` |
+| [agent.customJenkinsLabels](./values.yaml#L1023) | list | Append Jenkins labels to the agent | `[]` |
+| [agent.defaultsProviderTemplate](./values.yaml#L975) | string | The name of the pod template to use for providing default values | `""` |
+| [agent.directConnection](./values.yaml#L1029) | bool |  | `false` |
+| [agent.disableDefaultAgent](./values.yaml#L1231) | bool | Disable the default Jenkins Agent configuration | `false` |
+| [agent.enabled](./values.yaml#L973) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
+| [agent.envVars](./values.yaml#L1140) | list | Environment variables for the agent Pod | `[]` |
+| [agent.garbageCollection.enabled](./values.yaml#L1176) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
+| [agent.garbageCollection.namespaces](./values.yaml#L1178) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
+| [agent.garbageCollection.timeout](./values.yaml#L1183) | int | Timeout value for orphaned pods | `300` |
+| [agent.hostNetworking](./values.yaml#L1037) | bool | Enables the agent to use the host network | `false` |
+| [agent.idleMinutes](./values.yaml#L1186) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
+| [agent.image.registry](./values.yaml#L1014) | string | Registry to pull the agent jnlp image from | `""` |
+| [agent.image.repository](./values.yaml#L1016) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
+| [agent.image.tag](./values.yaml#L1018) | string | Tag of the image to pull | `"3355.v388858a_47b_33-23"` |
+| [agent.imagePullSecretName](./values.yaml#L1025) | string | Name of the secret to be used to pull the image | `nil` |
+| [agent.inheritYamlMergeStrategy](./values.yaml#L1205) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
+| [agent.instanceCap](./values.yaml#L1169) | int | Max number of agents to launch for this type of agent | `2147483647` |
+| [agent.jenkinsTunnel](./values.yaml#L991) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
+| [agent.jenkinsUrl](./values.yaml#L987) | string | Overrides the Kubernetes Jenkins URL | `nil` |
+| [agent.jnlpregistry](./values.yaml#L1011) | string | Custom registry used to pull the agent jnlp image from | `nil` |
+| [agent.kubernetesConnectTimeout](./values.yaml#L997) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
+| [agent.kubernetesReadTimeout](./values.yaml#L999) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
+| [agent.livenessProbe](./values.yaml#L1048) | object |  | `{}` |
+| [agent.maxRequestsPerHostStr](./values.yaml#L1001) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
+| [agent.namespace](./values.yaml#L1007) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
+| [agent.nodeSelector](./values.yaml#L1151) | object | Node labels for pod assignment | `{}` |
+| [agent.nodeUsageMode](./values.yaml#L1021) | string |  | `"NORMAL"` |
+| [agent.podLabels](./values.yaml#L1009) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
+| [agent.podName](./values.yaml#L1171) | string | Agent Pod base name | `"default"` |
+| [agent.podRetention](./values.yaml#L1067) | string |  | `"Never"` |
+| [agent.podTemplates](./values.yaml#L1241) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
+| [agent.privileged](./values.yaml#L1031) | bool | Agent privileged container | `false` |
+| [agent.resources](./values.yaml#L1039) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
+| [agent.restrictedPssSecurityContext](./values.yaml#L1064) | bool | Set a restricted securityContext on jnlp containers | `false` |
+| [agent.retentionTimeout](./values.yaml#L1003) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
+| [agent.runAsGroup](./values.yaml#L1035) | string | Configure container group | `nil` |
+| [agent.runAsUser](./values.yaml#L1033) | string | Configure container user | `nil` |
+| [agent.secretEnvVars](./values.yaml#L1144) | list | Mount a secret as environment variable | `[]` |
+| [agent.serviceAccount](./values.yaml#L983) | string | Override the default service account | `serviceAccountAgent.name` if `agent.useDefaultServiceAccount` is `true` |
+| [agent.showRawYaml](./values.yaml#L1071) | bool |  | `true` |
+| [agent.sideContainerName](./values.yaml#L1161) | string | Side container name | `"jnlp"` |
+| [agent.skipTlsVerify](./values.yaml#L993) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
+| [agent.usageRestricted](./values.yaml#L995) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
+| [agent.useDefaultServiceAccount](./values.yaml#L979) | bool | Use `serviceAccountAgent.name` as the default value for defaults template `serviceAccount` | `true` |
+| [agent.volumes](./values.yaml#L1078) | list | Additional volumes | `[]` |
+| [agent.waitForPodSec](./values.yaml#L1005) | int | Seconds to wait for pod to be running | `600` |
+| [agent.websocket](./values.yaml#L1028) | bool | Enables agent communication via websockets | `false` |
+| [agent.workingDir](./values.yaml#L1020) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
+| [agent.workspaceVolume](./values.yaml#L1113) | object | Workspace volume (defaults to EmptyDir) | `{}` |
+| [agent.yamlMergeStrategy](./values.yaml#L1203) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
+| [agent.yamlTemplate](./values.yaml#L1192) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1418) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1420) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1422) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1421) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1415) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L558) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L563) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -299,43 +300,43 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [extraLabels](./values.yaml#L33) | object | Configures extra labels for the agent all objects | `{}` |
 | [extraObjects](./values.yaml#L36) | string | Configures extra manifests | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1428) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1430) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1432) | string | Tag of the image to test the framework | `"1.13.0"` |
+| [helmtest.bats.image.registry](./values.yaml#L1431) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1433) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1435) | string | Tag of the image to test the framework | `"1.13.0"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
-| [networkPolicy.apiVersion](./values.yaml#L1351) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
-| [networkPolicy.enabled](./values.yaml#L1346) | bool | Enable the creation of NetworkPolicy resources | `false` |
-| [networkPolicy.externalAgents.except](./values.yaml#L1366) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
-| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1364) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
-| [networkPolicy.internalAgents.allowed](./values.yaml#L1355) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
-| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1359) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
-| [networkPolicy.internalAgents.podLabels](./values.yaml#L1357) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
-| [persistence.accessMode](./values.yaml#L1321) | string | The PVC access mode | `"ReadWriteOnce"` |
-| [persistence.annotations](./values.yaml#L1317) | object | Annotations for the PVC | `{}` |
-| [persistence.dataSource](./values.yaml#L1327) | object | Existing data source to clone PVC from | `{}` |
-| [persistence.enabled](./values.yaml#L1301) | bool | Enable the use of a Jenkins PVC | `true` |
-| [persistence.existingClaim](./values.yaml#L1307) | string | Provide the name of a PVC | `nil` |
-| [persistence.labels](./values.yaml#L1319) | object | Labels for the PVC | `{}` |
-| [persistence.mounts](./values.yaml#L1339) | list | Additional mounts | `[]` |
-| [persistence.size](./values.yaml#L1323) | string | The size of the PVC | `"8Gi"` |
-| [persistence.storageClass](./values.yaml#L1315) | string | Storage class for the PVC | `nil` |
-| [persistence.subPath](./values.yaml#L1332) | string | SubPath for jenkins-home mount | `nil` |
-| [persistence.volumes](./values.yaml#L1334) | list | Additional volumes | `[]` |
-| [rbac.create](./values.yaml#L1373) | bool | Whether RBAC resources are created | `true` |
-| [rbac.readSecrets](./values.yaml#L1375) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
-| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1377) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
+| [networkPolicy.apiVersion](./values.yaml#L1354) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
+| [networkPolicy.enabled](./values.yaml#L1349) | bool | Enable the creation of NetworkPolicy resources | `false` |
+| [networkPolicy.externalAgents.except](./values.yaml#L1369) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
+| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1367) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
+| [networkPolicy.internalAgents.allowed](./values.yaml#L1358) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
+| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1362) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
+| [networkPolicy.internalAgents.podLabels](./values.yaml#L1360) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
+| [persistence.accessMode](./values.yaml#L1324) | string | The PVC access mode | `"ReadWriteOnce"` |
+| [persistence.annotations](./values.yaml#L1320) | object | Annotations for the PVC | `{}` |
+| [persistence.dataSource](./values.yaml#L1330) | object | Existing data source to clone PVC from | `{}` |
+| [persistence.enabled](./values.yaml#L1304) | bool | Enable the use of a Jenkins PVC | `true` |
+| [persistence.existingClaim](./values.yaml#L1310) | string | Provide the name of a PVC | `nil` |
+| [persistence.labels](./values.yaml#L1322) | object | Labels for the PVC | `{}` |
+| [persistence.mounts](./values.yaml#L1342) | list | Additional mounts | `[]` |
+| [persistence.size](./values.yaml#L1326) | string | The size of the PVC | `"8Gi"` |
+| [persistence.storageClass](./values.yaml#L1318) | string | Storage class for the PVC | `nil` |
+| [persistence.subPath](./values.yaml#L1335) | string | SubPath for jenkins-home mount | `nil` |
+| [persistence.volumes](./values.yaml#L1337) | list | Additional volumes | `[]` |
+| [rbac.create](./values.yaml#L1376) | bool | Whether RBAC resources are created | `true` |
+| [rbac.readSecrets](./values.yaml#L1378) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
+| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1380) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
-| [serviceAccount.annotations](./values.yaml#L1387) | object | Configures annotations for the ServiceAccount | `{}` |
-| [serviceAccount.automountServiceAccountToken](./values.yaml#L1393) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccount.create](./values.yaml#L1381) | bool | Configures if a ServiceAccount with this name should be created | `true` |
-| [serviceAccount.extraLabels](./values.yaml#L1389) | object | Configures extra labels for the ServiceAccount | `{}` |
-| [serviceAccount.imagePullSecretName](./values.yaml#L1391) | string | Controller ServiceAccount image pull secret | `nil` |
-| [serviceAccount.name](./values.yaml#L1385) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1403) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1409) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccountAgent.create](./values.yaml#L1397) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1405) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1407) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1401) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccount.annotations](./values.yaml#L1390) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.automountServiceAccountToken](./values.yaml#L1396) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccount.create](./values.yaml#L1384) | bool | Configures if a ServiceAccount with this name should be created | `true` |
+| [serviceAccount.extraLabels](./values.yaml#L1392) | object | Configures extra labels for the ServiceAccount | `{}` |
+| [serviceAccount.imagePullSecretName](./values.yaml#L1394) | string | Controller ServiceAccount image pull secret | `nil` |
+| [serviceAccount.name](./values.yaml#L1388) | string |  | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1406) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1412) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccountAgent.create](./values.yaml#L1400) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1408) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1410) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1404) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -196,6 +196,7 @@ jenkins:
       namespace: "{{ template "jenkins.agent.namespace" . }}"
       restrictedPssSecurityContext: {{ .Values.agent.restrictedPssSecurityContext }}
       serverUrl: "{{ .Values.kubernetesURL }}"
+      addMasterProxyEnvVars: {{ .Values.agent.addMasterProxyEnvVars | default false }}
       credentialsId: "{{ .Values.credentialsId }}"
       {{- if .Values.agent.enabled }}
       podLabels:

--- a/charts/jenkins/unittests/__snapshot__/garbage-collect-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/garbage-collect-test.yaml.snap
@@ -42,6 +42,7 @@ namespaces:
             namespace: "my-namespace"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/my-release-jenkins-agent"
@@ -49,7 +50,7 @@ namespaces:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: 7dbf2c1c2eabcc4287fb80986558579d1d1685640364fde006527f37bab94cc8
+                id: 5d88103ee52121cb6392e72eb251b1dc98bc2ea62bf46545b30c3e30406667ae
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -126,6 +127,7 @@ one cloud:
             namespace: "my-namespace"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/my-release-jenkins-agent"
@@ -133,7 +135,7 @@ one cloud:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: b8b3187f6b2ceb0ffe7f613edfd9af7afa50952d843f97a0b22af348d1fd8ca4
+                id: 46c3234798484c8d0ca5cadd2dbc297af49069ce33e95814cd167ae9e04b6c7b
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -210,6 +212,7 @@ second cloud:
             namespace: "my-namespace"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/my-release-jenkins-agent"
@@ -217,7 +220,7 @@ second cloud:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: b8b3187f6b2ceb0ffe7f613edfd9af7afa50952d843f97a0b22af348d1fd8ca4
+                id: 46c3234798484c8d0ca5cadd2dbc297af49069ce33e95814cd167ae9e04b6c7b
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -269,7 +272,7 @@ second cloud:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: cf705f942da01f59a2ee6abe52b6c9f807afcb49b594da9b45aba62b5477099a
+                id: 56c6024505c5649c177bab38a257362405937e593e69e6b4c3ab7365a1c5f2cd
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false

--- a/charts/jenkins/unittests/__snapshot__/instance-cap-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/instance-cap-test.yaml.snap
@@ -37,6 +37,7 @@ default-cap:
             namespace: "my-namespace"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/my-release-jenkins-agent"
@@ -44,7 +45,7 @@ default-cap:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -119,6 +120,7 @@ limited-cap:
             namespace: "my-namespace"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/my-release-jenkins-agent"
@@ -126,7 +128,7 @@ limited-cap:
             templates:
               - name: "default"
                 namespace: "my-namespace"
-                id: 2dabafd6f47150a04f57585957f5179b9cb01fa97697910a9ebb75da60310a10
+                id: a4a7ebb0f686949e5dda69a77a985c3dc3cff7b6da8df189b1599c8d36a3cfad
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false

--- a/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jcasc-config-test.yaml.snap
@@ -37,6 +37,7 @@ additional clouds:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -44,7 +45,7 @@ additional clouds:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -94,7 +95,7 @@ additional clouds:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -169,6 +170,7 @@ additional clouds inheriting additional agents:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -176,7 +178,7 @@ additional clouds inheriting additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -205,7 +207,7 @@ additional clouds inheriting additional agents:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 6259994af2ee2301f5f7570a0c6ac0cb657a723f2bca0e498c24656cb6c15909
+                id: 7c099826a824dcb8dff735eb3758cc9cd68ce2b5acae9eb36c7a20977a43a130
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -255,7 +257,7 @@ additional clouds inheriting additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -284,7 +286,7 @@ additional clouds inheriting additional agents:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 6259994af2ee2301f5f7570a0c6ac0cb657a723f2bca0e498c24656cb6c15909
+                id: 7c099826a824dcb8dff735eb3758cc9cd68ce2b5acae9eb36c7a20977a43a130
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -359,6 +361,7 @@ additional clouds overriding additional agents:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -366,7 +369,7 @@ additional clouds overriding additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -395,7 +398,7 @@ additional clouds overriding additional agents:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: 6259994af2ee2301f5f7570a0c6ac0cb657a723f2bca0e498c24656cb6c15909
+                id: 7c099826a824dcb8dff735eb3758cc9cd68ce2b5acae9eb36c7a20977a43a130
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -445,7 +448,7 @@ additional clouds overriding additional agents:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -520,6 +523,7 @@ additional clouds set skipTlsVerify:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -527,7 +531,7 @@ additional clouds set skipTlsVerify:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -577,7 +581,7 @@ additional clouds set skipTlsVerify:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 63d6f6b4a6f77c186997ee840d17387b0c0794f47387fbd3b104147fa5efa234
+                id: 3f343485ee68426c80d322b121967b406a397f2f205b4ac6cd542a20edd57a0f
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -652,6 +656,7 @@ additional clouds set usageRestricted:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -659,7 +664,7 @@ additional clouds set usageRestricted:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -709,7 +714,7 @@ additional clouds set usageRestricted:
             templates:
               - name: "default"
                 namespace: "default"
-                id: d815081e62a1768a35fbb5679304badcd6f0ac2514efbde582c89e43fb76ee51
+                id: be54a6c5db1d1ea76ce41d19bfcf8835e21bfda4838bcf47da2dd3689989b0a2
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -784,6 +789,7 @@ adds custom labels on agent pods:
             namespace: "NAMESPACE"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -795,7 +801,7 @@ adds custom labels on agent pods:
             templates:
               - name: "default"
                 namespace: "NAMESPACE"
-                id: 9ded257aa33400bd689e9115784d2e964cbddba0b811a5f0123e57ee66ee99b9
+                id: dd184968a4ed9dda932ba0191b7b3c46f4badbd78c721aec83fd41fd5f2943e1
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -870,6 +876,7 @@ agent namespace and templates:
             namespace: "jenkins-agents"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -877,7 +884,7 @@ agent namespace and templates:
             templates:
               - name: "default"
                 namespace: "jenkins-agents"
-                id: b642bbb18182aa59cf3d5823f411a0c99eac1eb0fc59555dc1e852feecaa84f4
+                id: 619371d57947e0f25dd5faf44d284da2c5e2535298473736c701cf9589a71ea4
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -906,7 +913,7 @@ agent namespace and templates:
                 inheritYamlMergeStrategy: false
               - name: "maven"
                 namespace: "maven"
-                id: bb800a1c3085f77f33e2209f2c16aa5ea4894bc919b25e32d0a7cc7fba80f205
+                id: 691a7c5eb3421920f70e25b14b15fbce13282d4bf7b9efd84344029d7db5f777
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -935,7 +942,7 @@ agent namespace and templates:
                 inheritYamlMergeStrategy: false
               - name: "python"
                 namespace: "jenkins-agents"
-                id: 475cb70f861ac29f9234e42d92fe6f06327b45ee8b567381058c4fd2ed91f1b2
+                id: b113a83d5e91a3eae813e147e118452ad5a1b458d761a826a5bb82a298419845
                 containers:
                 - name: "python"
                   alwaysPullImage: false
@@ -1027,6 +1034,7 @@ agent with liveness probe:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1034,7 +1042,7 @@ agent with liveness probe:
             templates:
               - name: "default"
                 namespace: "default"
-                id: c7ae8c36d8a8c1ecd613f7b5074c91b55c7b64ea1705435c545b9dd762f844b9
+                id: e1e54c7ec6a4f149baa0f5dd1604e077439810e4d739a824b1a7999edafb6573
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1116,6 +1124,7 @@ agents with liveness probe:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1123,7 +1132,7 @@ agents with liveness probe:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 67e71fbace88e0f187e6b59e5b3e23a78aab3553a310feb151a499dbb29a8d58
+                id: aa6d962e2ec284b8fac7672c27d4793abe18f005f0fb6d2c160041e535305a74
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1220,6 +1229,7 @@ configure hostnetworking to agent:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1227,7 +1237,7 @@ configure hostnetworking to agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: a3d8b1761b0d92cecfd5e31f089ec8e28df17c3dd1da4a10b35473c550f4af16
+                id: eb86a69520afe771e96c2f4add0a178e7a4ee0525d8c82aec4c14a12f11b3095
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1303,6 +1313,7 @@ custom dynamic pvc workspace volume:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1310,7 +1321,7 @@ custom dynamic pvc workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 05c9efd7742a8f315c34674fdd62e35324e36e03a01cc29629149054b9bc4dd4
+                id: c9a747c071be23b9ef72949631866bdcf0f88076db3f0a1a050fd94a5f6cbdd4
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1390,6 +1401,7 @@ custom emptyDir workspace volume:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1397,7 +1409,7 @@ custom emptyDir workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 6b912865be129c06e6f75f9000c074337c0aa1ee07d1d081bafc4e4022e1317c
+                id: d148a4ffcbcf4c0b434684fe4c9db20953f6e9729c435ae9bfe6be1c46c7649c
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1475,6 +1487,7 @@ custom hostPath workspace volume:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1482,7 +1495,7 @@ custom hostPath workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 603b4335598bbf0e87b4f0f974634facf61749d5931a2888b49ed0d6bf6be467
+                id: c764934b644a8c17bce102945b842883c779802ebf5176fff2d144df2abd9ac3
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1560,6 +1573,7 @@ custom jenkins label:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1567,7 +1581,7 @@ custom jenkins label:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1642,6 +1656,7 @@ custom nfs workspace volume:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1649,7 +1664,7 @@ custom nfs workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: c726f86369b2b365a9d307e8cf0c4a50010cc299965268291fac5212b6f61748
+                id: b37aac63ccc5c55efc29ee9579c3c47f47df306e1e8e66906a45f2386cace6c3
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1729,6 +1744,7 @@ custom other workspace volume:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1736,7 +1752,7 @@ custom other workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 430f3fca3a54aa76b6c4d563da358ecdc86c0fe0d71e11dfbd55e22b9a50c8d9
+                id: f80afb09fb0739ecd80a61e6884a62c98c95fd1571194950b66d88754fff009c
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1815,6 +1831,7 @@ custom pvc workspace volume:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -1822,7 +1839,7 @@ custom pvc workspace volume:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 2a30caebdd050a9fea6d56c578ca82c08c24428fb104c565277118c9ed10675c
+                id: eb9d0bc94c2b41d02dab1194acb7ac4118ac3cfb324122038a63a04188b86ce1
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -1898,6 +1915,7 @@ customized config:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/my-release-jenkins-agent"
@@ -1908,7 +1926,7 @@ customized config:
                 annotations:
                 - key: ci.jenkins-agent/test
                   value: "custom"
-                id: f5eac9df656fa71574142e06fc04f282b6e6ef56c598d8e0ca7bc3ec0d9405ba
+                id: c7d25b0816dbd4ebd5d8435596172bcff9b334d32f75ca624ccecb9af3895ccc
                 containers:
                 - name: "sideContainer"
                   alwaysPullImage: true
@@ -2032,6 +2050,7 @@ default config:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2039,7 +2058,7 @@ default config:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2114,6 +2133,7 @@ disable agents:
             namespace: "controller-namespace"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
         slaveAgentPort: 50000
       security:
@@ -2163,6 +2183,7 @@ disable useDefaultServiceAccount:
             namespace: "NAMESPACE"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2170,7 +2191,7 @@ disable useDefaultServiceAccount:
             templates:
               - name: "default"
                 namespace: "NAMESPACE"
-                id: 9106c4144b0de1502d04bf37a37ed41053e2183e6e82a9ad1400952acb0d6985
+                id: 394489cbe13aa0ce8781cfe275da26551517759597cb5517d5d6029e1b8c0c41
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2243,6 +2264,7 @@ empty projectNamingStrategy:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2250,7 +2272,7 @@ empty projectNamingStrategy:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2325,6 +2347,7 @@ legacyRemotingSecurityEnabled = false:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2332,7 +2355,7 @@ legacyRemotingSecurityEnabled = false:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2409,6 +2432,7 @@ legacyRemotingSecurityEnabled = true:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2416,7 +2440,7 @@ legacyRemotingSecurityEnabled = true:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2494,6 +2518,7 @@ non-string projectNamingStrategy:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2501,7 +2526,7 @@ non-string projectNamingStrategy:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2576,6 +2601,7 @@ none lts version:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2583,7 +2609,7 @@ none lts version:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2658,6 +2684,7 @@ set agent.serviceAccount:
             namespace: "NAMESPACE"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2665,7 +2692,7 @@ set agent.serviceAccount:
             templates:
               - name: "default"
                 namespace: "NAMESPACE"
-                id: f2a059b2280b0eac09a936f7d0651d43df8ada7d94dc8341045875bfffdac67b
+                id: 9c0b18d6a0f385fc8c6c48e9d07a2bfb1b1f0b296455e65694ac128059166a70
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2739,6 +2766,7 @@ set directConnection:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2746,7 +2774,7 @@ set directConnection:
             templates:
               - name: "default"
                 namespace: "default"
-                id: cefa2db5f9122633c9698f9708b0c23c59ef67268b887cc5e5d8f5ab90003999
+                id: b176378f082367697d6306149f4d2a9d85c925cdfeac8ad051dbf7d562799450
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2821,6 +2849,7 @@ set restrictedPssSecurityContext:
             namespace: "default"
             restrictedPssSecurityContext: true
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2828,7 +2857,7 @@ set restrictedPssSecurityContext:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 5592ea28004baa37efa14844fa8e46d4ba8cdef58dd4e1b6715cd69946c28d98
+                id: 178ee998035a8f1ae0d720555f7da970b04986720dc2e3b306d4b7320d13c57d
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2903,6 +2932,7 @@ set secretEnvVars:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -2910,7 +2940,7 @@ set secretEnvVars:
             templates:
               - name: "default"
                 namespace: "default"
-                id: d3dcfcf3bd9b65ce264e3e572ab610d0e4bb598d9180de1722eb6fb274fe0a04
+                id: b959d041b00160bf00e75a0af5bfea38ec6ed9f7da63c0fafa4244b6b2b24182
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -2994,6 +3024,7 @@ specify additional container:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -3001,7 +3032,7 @@ specify additional container:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f0c40a3d7387f9986f12efad3b605d00edd208768f6778990b5194666fd9b391
+                id: 32e3584d01e6035a57c68f69f5864129db75b740388c466edc936b54491839a5
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3092,6 +3123,7 @@ specify additional container and clear in additional agent:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -3099,7 +3131,7 @@ specify additional container and clear in additional agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f0c40a3d7387f9986f12efad3b605d00edd208768f6778990b5194666fd9b391
+                id: 32e3584d01e6035a57c68f69f5864129db75b740388c466edc936b54491839a5
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3144,7 +3176,7 @@ specify additional container and clear in additional agent:
                 inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
-                id: 7a0f898e228c1e83e6c55c096d81f8ae73da1935d45afd2cc5b68b29a9daca2d
+                id: 6c06c48ac3e94761bee8cd271281f230a8272b36919409ee65a58adca61c15ee
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3219,6 +3251,7 @@ specify additional container and overwrite in additional agent:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -3226,7 +3259,7 @@ specify additional container and overwrite in additional agent:
             templates:
               - name: "default"
                 namespace: "default"
-                id: f0c40a3d7387f9986f12efad3b605d00edd208768f6778990b5194666fd9b391
+                id: 32e3584d01e6035a57c68f69f5864129db75b740388c466edc936b54491839a5
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3271,7 +3304,7 @@ specify additional container and overwrite in additional agent:
                 inheritYamlMergeStrategy: false
               - name: "additional-agent"
                 namespace: "default"
-                id: 3eabd9c876c707f82e15d38a5c88e3fd7d8d8d6bbe739ed7d2f0b9ec14320f0e
+                id: 678986b613383e3401fb5cf649280f2184a580ae733f8ef8725259491f60bf65
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3362,6 +3395,7 @@ specify security settings with apiToken override:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -3369,7 +3403,7 @@ specify security settings with apiToken override:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false
@@ -3441,6 +3475,7 @@ specify security settings without apiToken override:
             namespace: "default"
             restrictedPssSecurityContext: false
             serverUrl: "https://kubernetes.default"
+            addMasterProxyEnvVars: false
             credentialsId: ""
             podLabels:
             - key: "jenkins/RELEASE-NAME-jenkins-agent"
@@ -3448,7 +3483,7 @@ specify security settings without apiToken override:
             templates:
               - name: "default"
                 namespace: "default"
-                id: 4d595aac8e0d04f25846098240d46af0d9cd935ec385070b24b6ef199b63c182
+                id: 932ec669918116ed60ebb0ddf682b62e30c19584a3795e18ae5ca9b88175131e
                 containers:
                 - name: "jnlp"
                   alwaysPullImage: false

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -966,6 +966,9 @@ controller:
 #        hYAzODo1Jt59pcqqKJEas0C/lFJEB3frw4ImNx5fNlJYOpx+ijfQs9m39CevDq0=
 
 agent:
+  # -- Add the environment proxy settings form jenkins controller to the agents.
+  addMasterProxyEnvVars: false
+
   # -- Enable Kubernetes plugin jnlp-agent podTemplate
   enabled: true
   # -- The name of the pod template to use for providing default values


### PR DESCRIPTION
Added addMasterProxyEnvVars to allow agents to use proxy env settings from the controller.

<!-- markdownlint-disable MD041 -->

### What does this PR do?

Adds addMasterProxyEnvVars to the cloud configuration so that proxy environment defined in the controller are being transferred to the agents.

- Fixes #1691

If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist

- [* ] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [ *] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [ *] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [ *] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

Is first time contributing to this project. The unit test are passing. If I'm missed something please let me know.
