### PR TITLE
chore: add `yes n |` to cp in config.yaml to avoid overwrite prompt

### DIFF
--- a/charts/jenkins/templates/config.yaml
+++ b/charts/jenkins/templates/config.yaml
@@ -34,7 +34,7 @@ data:
 {{- if .Values.controller.installPlugins }}
     echo "download plugins"
     # Install missing plugins
-    cp /var/jenkins_config/plugins.txt {{ .Values.controller.jenkinsHome }};
+    yes n | cp /var/jenkins_config/plugins.txt {{ .Values.controller.jenkinsHome }};
     rm -rf {{ .Values.controller.jenkinsRef }}/plugins/*.lock
     version () { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
     if [ -f "{{ .Values.controller.jenkinsWar }}" ] && [ -n "$(command -v jenkins-plugin-cli)" 2>/dev/null ] && [ $(version $(jenkins-plugin-cli --version)) -ge $(version "2.1.1") ]; then


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### fix: prevent interactive overwrite prompt when copying plugins.txt

 In the init container script, the `cp` command may be aliased to `cp -i`
on some systems, causing an interactive prompt if plugins.txt already
exists. This blocks non‑interactive startup.

Prefix the command with `yes n |` to automatically answer "no" to any
overwrite question, ensuring the container runs without user intervention.

- Fixes #
### Submitter checklist

- [ ] I change the content  in `./charts/jenkins/templates/config.yaml`.

### Special notes for your reviewer
