### PR TITLE
Allow overriding the secondary ingress path type

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.37
+
+Allow overriding the secondary ingress path type
+
 ## 5.9.36
 
 Update `docker.io/kiwigrid/k8s-sidecar` to version `2.8.1`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.36
+version: 5.9.37
 appVersion: 2.568.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -8,74 +8,74 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 | Key | Type | Description | Default |
 |:----|:-----|:---------|:------------|
-| [additionalAgents](./values.yaml#L1260) | object | Configure additional | `{}` |
-| [additionalClouds](./values.yaml#L1285) | object |  | `{}` |
-| [agent.TTYEnabled](./values.yaml#L1165) | bool | Allocate pseudo tty to the side container | `false` |
-| [agent.addMasterProxyEnvVars](./values.yaml#L970) | bool | Add the environment proxy settings form jenkins controller to the agents. | `false` |
-| [agent.additionalContainers](./values.yaml#L1213) | list | Add additional containers to the agents | `[]` |
-| [agent.alwaysPullImage](./values.yaml#L1058) | bool | Always pull agent container image before build | `false` |
-| [agent.annotations](./values.yaml#L1209) | object | Annotations to apply to the pod | `{}` |
-| [agent.args](./values.yaml#L1159) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
-| [agent.command](./values.yaml#L1157) | string | Command to execute when side container starts | `nil` |
-| [agent.componentName](./values.yaml#L1026) | string |  | `"jenkins-agent"` |
-| [agent.connectTimeout](./values.yaml#L1207) | int | Timeout in seconds for an agent to be online | `100` |
-| [agent.containerCap](./values.yaml#L1167) | int | Max number of agents to launch for a whole cluster. | `10` |
-| [agent.customJenkinsLabels](./values.yaml#L1023) | list | Append Jenkins labels to the agent | `[]` |
-| [agent.defaultsProviderTemplate](./values.yaml#L975) | string | The name of the pod template to use for providing default values | `""` |
-| [agent.directConnection](./values.yaml#L1029) | bool |  | `false` |
-| [agent.disableDefaultAgent](./values.yaml#L1231) | bool | Disable the default Jenkins Agent configuration | `false` |
-| [agent.enabled](./values.yaml#L973) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
-| [agent.envVars](./values.yaml#L1140) | list | Environment variables for the agent Pod | `[]` |
-| [agent.garbageCollection.enabled](./values.yaml#L1176) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
-| [agent.garbageCollection.namespaces](./values.yaml#L1178) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
-| [agent.garbageCollection.timeout](./values.yaml#L1183) | int | Timeout value for orphaned pods | `300` |
-| [agent.hostNetworking](./values.yaml#L1037) | bool | Enables the agent to use the host network | `false` |
-| [agent.idleMinutes](./values.yaml#L1186) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
-| [agent.image.registry](./values.yaml#L1014) | string | Registry to pull the agent jnlp image from | `""` |
-| [agent.image.repository](./values.yaml#L1016) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
-| [agent.image.tag](./values.yaml#L1018) | string | Tag of the image to pull | `"3383.vc8881d4b_0e76-1"` |
-| [agent.imagePullSecretName](./values.yaml#L1025) | string | Name of the secret to be used to pull the image | `nil` |
-| [agent.inheritYamlMergeStrategy](./values.yaml#L1205) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
-| [agent.instanceCap](./values.yaml#L1169) | int | Max number of agents to launch for this type of agent | `2147483647` |
-| [agent.jenkinsTunnel](./values.yaml#L991) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
-| [agent.jenkinsUrl](./values.yaml#L987) | string | Overrides the Kubernetes Jenkins URL | `nil` |
-| [agent.jnlpregistry](./values.yaml#L1011) | string | Custom registry used to pull the agent jnlp image from | `nil` |
-| [agent.kubernetesConnectTimeout](./values.yaml#L997) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
-| [agent.kubernetesReadTimeout](./values.yaml#L999) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
-| [agent.livenessProbe](./values.yaml#L1048) | object |  | `{}` |
-| [agent.maxRequestsPerHostStr](./values.yaml#L1001) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
-| [agent.namespace](./values.yaml#L1007) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
-| [agent.nodeSelector](./values.yaml#L1151) | object | Node labels for pod assignment | `{}` |
-| [agent.nodeUsageMode](./values.yaml#L1021) | string |  | `"NORMAL"` |
-| [agent.podLabels](./values.yaml#L1009) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
-| [agent.podName](./values.yaml#L1171) | string | Agent Pod base name | `"default"` |
-| [agent.podRetention](./values.yaml#L1067) | string |  | `"Never"` |
-| [agent.podTemplates](./values.yaml#L1241) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
-| [agent.privileged](./values.yaml#L1031) | bool | Agent privileged container | `false` |
-| [agent.resources](./values.yaml#L1039) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
-| [agent.restrictedPssSecurityContext](./values.yaml#L1064) | bool | Set a restricted securityContext on jnlp containers | `false` |
-| [agent.retentionTimeout](./values.yaml#L1003) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
-| [agent.runAsGroup](./values.yaml#L1035) | string | Configure container group | `nil` |
-| [agent.runAsUser](./values.yaml#L1033) | string | Configure container user | `nil` |
-| [agent.secretEnvVars](./values.yaml#L1144) | list | Mount a secret as environment variable | `[]` |
-| [agent.serviceAccount](./values.yaml#L983) | string | Override the default service account | `serviceAccountAgent.name` if `agent.useDefaultServiceAccount` is `true` |
-| [agent.showRawYaml](./values.yaml#L1071) | bool |  | `true` |
-| [agent.sideContainerName](./values.yaml#L1161) | string | Side container name | `"jnlp"` |
-| [agent.skipTlsVerify](./values.yaml#L993) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
-| [agent.usageRestricted](./values.yaml#L995) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
-| [agent.useDefaultServiceAccount](./values.yaml#L979) | bool | Use `serviceAccountAgent.name` as the default value for defaults template `serviceAccount` | `true` |
-| [agent.volumes](./values.yaml#L1078) | list | Additional volumes | `[]` |
-| [agent.waitForPodSec](./values.yaml#L1005) | int | Seconds to wait for pod to be running | `600` |
-| [agent.websocket](./values.yaml#L1028) | bool | Enables agent communication via websockets | `false` |
-| [agent.workingDir](./values.yaml#L1020) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
-| [agent.workspaceVolume](./values.yaml#L1113) | object | Workspace volume (defaults to EmptyDir) | `{}` |
-| [agent.yamlMergeStrategy](./values.yaml#L1203) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
-| [agent.yamlTemplate](./values.yaml#L1192) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
-| [awsSecurityGroupPolicies.enabled](./values.yaml#L1418) | bool |  | `false` |
-| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1420) | string |  | `""` |
-| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1422) | object |  | `{}` |
-| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1421) | list |  | `[]` |
-| [checkDeprecation](./values.yaml#L1415) | bool | Checks if any deprecated values are used | `true` |
+| [additionalAgents](./values.yaml#L1262) | object | Configure additional | `{}` |
+| [additionalClouds](./values.yaml#L1287) | object |  | `{}` |
+| [agent.TTYEnabled](./values.yaml#L1167) | bool | Allocate pseudo tty to the side container | `false` |
+| [agent.addMasterProxyEnvVars](./values.yaml#L972) | bool | Add the environment proxy settings form jenkins controller to the agents. | `false` |
+| [agent.additionalContainers](./values.yaml#L1215) | list | Add additional containers to the agents | `[]` |
+| [agent.alwaysPullImage](./values.yaml#L1060) | bool | Always pull agent container image before build | `false` |
+| [agent.annotations](./values.yaml#L1211) | object | Annotations to apply to the pod | `{}` |
+| [agent.args](./values.yaml#L1161) | string | Arguments passed to command to execute | `"${computer.jnlpmac} ${computer.name}"` |
+| [agent.command](./values.yaml#L1159) | string | Command to execute when side container starts | `nil` |
+| [agent.componentName](./values.yaml#L1028) | string |  | `"jenkins-agent"` |
+| [agent.connectTimeout](./values.yaml#L1209) | int | Timeout in seconds for an agent to be online | `100` |
+| [agent.containerCap](./values.yaml#L1169) | int | Max number of agents to launch for a whole cluster. | `10` |
+| [agent.customJenkinsLabels](./values.yaml#L1025) | list | Append Jenkins labels to the agent | `[]` |
+| [agent.defaultsProviderTemplate](./values.yaml#L977) | string | The name of the pod template to use for providing default values | `""` |
+| [agent.directConnection](./values.yaml#L1031) | bool |  | `false` |
+| [agent.disableDefaultAgent](./values.yaml#L1233) | bool | Disable the default Jenkins Agent configuration | `false` |
+| [agent.enabled](./values.yaml#L975) | bool | Enable Kubernetes plugin jnlp-agent podTemplate | `true` |
+| [agent.envVars](./values.yaml#L1142) | list | Environment variables for the agent Pod | `[]` |
+| [agent.garbageCollection.enabled](./values.yaml#L1178) | bool | When enabled, Jenkins will periodically check for orphan pods that have not been touched for the given timeout period and delete them. | `false` |
+| [agent.garbageCollection.namespaces](./values.yaml#L1180) | string | Namespaces to look at for garbage collection, in addition to the default namespace defined for the cloud. One namespace per line. | `""` |
+| [agent.garbageCollection.timeout](./values.yaml#L1185) | int | Timeout value for orphaned pods | `300` |
+| [agent.hostNetworking](./values.yaml#L1039) | bool | Enables the agent to use the host network | `false` |
+| [agent.idleMinutes](./values.yaml#L1188) | int | Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it | `0` |
+| [agent.image.registry](./values.yaml#L1016) | string | Registry to pull the agent jnlp image from | `""` |
+| [agent.image.repository](./values.yaml#L1018) | string | Repository to pull the agent jnlp image from | `"jenkins/inbound-agent"` |
+| [agent.image.tag](./values.yaml#L1020) | string | Tag of the image to pull | `"3383.vc8881d4b_0e76-1"` |
+| [agent.imagePullSecretName](./values.yaml#L1027) | string | Name of the secret to be used to pull the image | `nil` |
+| [agent.inheritYamlMergeStrategy](./values.yaml#L1207) | bool | Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one | `false` |
+| [agent.instanceCap](./values.yaml#L1171) | int | Max number of agents to launch for this type of agent | `2147483647` |
+| [agent.jenkinsTunnel](./values.yaml#L993) | string | Overrides the Kubernetes Jenkins tunnel | `nil` |
+| [agent.jenkinsUrl](./values.yaml#L989) | string | Overrides the Kubernetes Jenkins URL | `nil` |
+| [agent.jnlpregistry](./values.yaml#L1013) | string | Custom registry used to pull the agent jnlp image from | `nil` |
+| [agent.kubernetesConnectTimeout](./values.yaml#L999) | int | The connection timeout in seconds for connections to Kubernetes API. The minimum value is 5 | `5` |
+| [agent.kubernetesReadTimeout](./values.yaml#L1001) | int | The read timeout in seconds for connections to Kubernetes API. The minimum value is 15 | `15` |
+| [agent.livenessProbe](./values.yaml#L1050) | object |  | `{}` |
+| [agent.maxRequestsPerHostStr](./values.yaml#L1003) | string | The maximum concurrent connections to Kubernetes API | `"32"` |
+| [agent.namespace](./values.yaml#L1009) | string | Namespace in which the Kubernetes agents should be launched | `nil` |
+| [agent.nodeSelector](./values.yaml#L1153) | object | Node labels for pod assignment | `{}` |
+| [agent.nodeUsageMode](./values.yaml#L1023) | string |  | `"NORMAL"` |
+| [agent.podLabels](./values.yaml#L1011) | object | Custom Pod labels (an object with `label-key: label-value` pairs) | `{}` |
+| [agent.podName](./values.yaml#L1173) | string | Agent Pod base name | `"default"` |
+| [agent.podRetention](./values.yaml#L1069) | string |  | `"Never"` |
+| [agent.podTemplates](./values.yaml#L1243) | object | Configures extra pod templates for the default kubernetes cloud | `{}` |
+| [agent.privileged](./values.yaml#L1033) | bool | Agent privileged container | `false` |
+| [agent.resources](./values.yaml#L1041) | object | Resources allocation (Requests and Limits) | `{"limits":{"cpu":"512m","memory":"512Mi"},"requests":{"cpu":"512m","memory":"512Mi"}}` |
+| [agent.restrictedPssSecurityContext](./values.yaml#L1066) | bool | Set a restricted securityContext on jnlp containers | `false` |
+| [agent.retentionTimeout](./values.yaml#L1005) | int | Time in minutes after which the Kubernetes cloud plugin will clean up an idle worker that has not already terminated | `5` |
+| [agent.runAsGroup](./values.yaml#L1037) | string | Configure container group | `nil` |
+| [agent.runAsUser](./values.yaml#L1035) | string | Configure container user | `nil` |
+| [agent.secretEnvVars](./values.yaml#L1146) | list | Mount a secret as environment variable | `[]` |
+| [agent.serviceAccount](./values.yaml#L985) | string | Override the default service account | `serviceAccountAgent.name` if `agent.useDefaultServiceAccount` is `true` |
+| [agent.showRawYaml](./values.yaml#L1073) | bool |  | `true` |
+| [agent.sideContainerName](./values.yaml#L1163) | string | Side container name | `"jnlp"` |
+| [agent.skipTlsVerify](./values.yaml#L995) | bool | Disables the verification of the controller certificate on remote connection. This flag correspond to the "Disable https certificate check" flag in kubernetes plugin UI | `false` |
+| [agent.usageRestricted](./values.yaml#L997) | bool | Enable the possibility to restrict the usage of this agent to specific folder. This flag correspond to the "Restrict pipeline support to authorized folders" flag in kubernetes plugin UI | `false` |
+| [agent.useDefaultServiceAccount](./values.yaml#L981) | bool | Use `serviceAccountAgent.name` as the default value for defaults template `serviceAccount` | `true` |
+| [agent.volumes](./values.yaml#L1080) | list | Additional volumes | `[]` |
+| [agent.waitForPodSec](./values.yaml#L1007) | int | Seconds to wait for pod to be running | `600` |
+| [agent.websocket](./values.yaml#L1030) | bool | Enables agent communication via websockets | `false` |
+| [agent.workingDir](./values.yaml#L1022) | string | Configure working directory for default agent | `"/home/jenkins/agent"` |
+| [agent.workspaceVolume](./values.yaml#L1115) | object | Workspace volume (defaults to EmptyDir) | `{}` |
+| [agent.yamlMergeStrategy](./values.yaml#L1205) | string | Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates. Possible values: "merge" or "override" | `"override"` |
+| [agent.yamlTemplate](./values.yaml#L1194) | string | The raw yaml of a Pod API Object to merge into the agent spec | `""` |
+| [awsSecurityGroupPolicies.enabled](./values.yaml#L1420) | bool |  | `false` |
+| [awsSecurityGroupPolicies.policies[0].name](./values.yaml#L1422) | string |  | `""` |
+| [awsSecurityGroupPolicies.policies[0].podSelector](./values.yaml#L1424) | object |  | `{}` |
+| [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1423) | list |  | `[]` |
+| [checkDeprecation](./values.yaml#L1417) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
 | [controller.JCasC.authorizationStrategy](./values.yaml#L558) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L563) | object | Annotations for the JCasC ConfigMap | `{}` |
@@ -104,12 +104,12 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.agentListenerPort](./values.yaml#L345) | int | Listening port for agents | `50000` |
 | [controller.agentListenerServiceAnnotations](./values.yaml#L378) | object | Annotations for the agentListener service | `{}` |
 | [controller.agentListenerServiceType](./values.yaml#L375) | string | Defines how to expose the agentListener service | `"ClusterIP"` |
-| [controller.backendconfig.annotations](./values.yaml#L809) | object | backendconfig annotations | `{}` |
-| [controller.backendconfig.apiVersion](./values.yaml#L803) | string | backendconfig API version | `"extensions/v1beta1"` |
-| [controller.backendconfig.enabled](./values.yaml#L801) | bool | Enables backendconfig | `false` |
-| [controller.backendconfig.labels](./values.yaml#L807) | object | backendconfig labels | `{}` |
-| [controller.backendconfig.name](./values.yaml#L805) | string | backendconfig name | `nil` |
-| [controller.backendconfig.spec](./values.yaml#L811) | object | backendconfig spec | `{}` |
+| [controller.backendconfig.annotations](./values.yaml#L811) | object | backendconfig annotations | `{}` |
+| [controller.backendconfig.apiVersion](./values.yaml#L805) | string | backendconfig API version | `"extensions/v1beta1"` |
+| [controller.backendconfig.enabled](./values.yaml#L803) | bool | Enables backendconfig | `false` |
+| [controller.backendconfig.labels](./values.yaml#L809) | object | backendconfig labels | `{}` |
+| [controller.backendconfig.name](./values.yaml#L807) | string | backendconfig name | `nil` |
+| [controller.backendconfig.spec](./values.yaml#L813) | object | backendconfig spec | `{}` |
 | [controller.cloudName](./values.yaml#L512) | string | Name of default cloud configuration. | `"kubernetes"` |
 | [controller.clusterIp](./values.yaml#L238) | string | k8s service clusterIP. Only used if serviceType is ClusterIP | `nil` |
 | [controller.componentName](./values.yaml#L40) | string | Used for label app.kubernetes.io/component | `"jenkins-controller"` |
@@ -130,31 +130,31 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.extraPorts](./values.yaml#L413) | list | Optionally configure other ports to expose in the controller container | `[]` |
 | [controller.fsGroup](./values.yaml#L201) | int | Deprecated in favor of `controller.podSecurityContextOverride`. uid that will be used for persistent volume. | `1000` |
 | [controller.fsGroupChangePolicy](./values.yaml#L204) | string |  | `"OnRootMismatch"` |
-| [controller.googlePodMonitor.enabled](./values.yaml#L891) | bool |  | `false` |
-| [controller.googlePodMonitor.scrapeEndpoint](./values.yaml#L896) | string |  | `"/prometheus"` |
-| [controller.googlePodMonitor.scrapeInterval](./values.yaml#L894) | string |  | `"60s"` |
+| [controller.googlePodMonitor.enabled](./values.yaml#L893) | bool |  | `false` |
+| [controller.googlePodMonitor.scrapeEndpoint](./values.yaml#L898) | string |  | `"/prometheus"` |
+| [controller.googlePodMonitor.scrapeInterval](./values.yaml#L896) | string |  | `"60s"` |
 | [controller.healthProbes](./values.yaml#L273) | bool | Enable Kubernetes Probes configuration configured in `controller.probes` | `true` |
-| [controller.hostAliases](./values.yaml#L844) | list | Allows for adding entries to Pod /etc/hosts | `[]` |
+| [controller.hostAliases](./values.yaml#L846) | list | Allows for adding entries to Pod /etc/hosts | `[]` |
 | [controller.hostNetworking](./values.yaml#L80) | bool |  | `false` |
-| [controller.httpRoute.annotations](./values.yaml#L841) | object | HTTPRoute annotations | `{}` |
-| [controller.httpRoute.apiVersion](./values.yaml#L828) | string |  | `"gateway.networking.k8s.io/v1"` |
-| [controller.httpRoute.enabled](./values.yaml#L827) | bool |  | `false` |
-| [controller.httpRoute.extraRules](./values.yaml#L839) | list |  | `[]` |
-| [controller.httpRoute.hostnames](./values.yaml#L837) | list |  | `[]` |
-| [controller.httpRoute.kind](./values.yaml#L829) | string |  | `"HTTPRoute"` |
-| [controller.httpRoute.parentRefs](./values.yaml#L831) | list |  | `[]` |
-| [controller.httpRoute.reuseIngressConfiguration](./values.yaml#L835) | bool |  | `false` |
-| [controller.httpsKeyStore.disableSecretMount](./values.yaml#L912) | bool |  | `false` |
-| [controller.httpsKeyStore.enable](./values.yaml#L903) | bool | Enables HTTPS keystore on jenkins controller | `false` |
-| [controller.httpsKeyStore.fileName](./values.yaml#L920) | string | Jenkins keystore filename which will appear under controller.httpsKeyStore.path | `"keystore.jks"` |
-| [controller.httpsKeyStore.httpPort](./values.yaml#L916) | int | HTTP Port that Jenkins should listen to along with HTTPS, it also serves as the liveness and readiness probes port. | `8081` |
-| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretKey](./values.yaml#L911) | string | Name of the key in the secret that contains the JKS password | `"https-jks-password"` |
-| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName](./values.yaml#L909) | string | Name of the secret that contains the JKS password, if it is not in the same secret as the JKS file | `""` |
-| [controller.httpsKeyStore.jenkinsHttpsJksSecretKey](./values.yaml#L907) | string | Name of the key in the secret that already has SSL keystore | `"jenkins-jks-file"` |
-| [controller.httpsKeyStore.jenkinsHttpsJksSecretName](./values.yaml#L905) | string | Name of the secret that already has SSL keystore | `""` |
-| [controller.httpsKeyStore.jenkinsKeyStoreBase64Encoded](./values.yaml#L925) | string | Base64 encoded Keystore content. Keystore must be converted to base64 then being pasted here | `nil` |
-| [controller.httpsKeyStore.password](./values.yaml#L922) | string | Jenkins keystore password | `"password"` |
-| [controller.httpsKeyStore.path](./values.yaml#L918) | string | Path of HTTPS keystore file | `"/var/jenkins_keystore"` |
+| [controller.httpRoute.annotations](./values.yaml#L843) | object | HTTPRoute annotations | `{}` |
+| [controller.httpRoute.apiVersion](./values.yaml#L830) | string |  | `"gateway.networking.k8s.io/v1"` |
+| [controller.httpRoute.enabled](./values.yaml#L829) | bool |  | `false` |
+| [controller.httpRoute.extraRules](./values.yaml#L841) | list |  | `[]` |
+| [controller.httpRoute.hostnames](./values.yaml#L839) | list |  | `[]` |
+| [controller.httpRoute.kind](./values.yaml#L831) | string |  | `"HTTPRoute"` |
+| [controller.httpRoute.parentRefs](./values.yaml#L833) | list |  | `[]` |
+| [controller.httpRoute.reuseIngressConfiguration](./values.yaml#L837) | bool |  | `false` |
+| [controller.httpsKeyStore.disableSecretMount](./values.yaml#L914) | bool |  | `false` |
+| [controller.httpsKeyStore.enable](./values.yaml#L905) | bool | Enables HTTPS keystore on jenkins controller | `false` |
+| [controller.httpsKeyStore.fileName](./values.yaml#L922) | string | Jenkins keystore filename which will appear under controller.httpsKeyStore.path | `"keystore.jks"` |
+| [controller.httpsKeyStore.httpPort](./values.yaml#L918) | int | HTTP Port that Jenkins should listen to along with HTTPS, it also serves as the liveness and readiness probes port. | `8081` |
+| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretKey](./values.yaml#L913) | string | Name of the key in the secret that contains the JKS password | `"https-jks-password"` |
+| [controller.httpsKeyStore.jenkinsHttpsJksPasswordSecretName](./values.yaml#L911) | string | Name of the secret that contains the JKS password, if it is not in the same secret as the JKS file | `""` |
+| [controller.httpsKeyStore.jenkinsHttpsJksSecretKey](./values.yaml#L909) | string | Name of the key in the secret that already has SSL keystore | `"jenkins-jks-file"` |
+| [controller.httpsKeyStore.jenkinsHttpsJksSecretName](./values.yaml#L907) | string | Name of the secret that already has SSL keystore | `""` |
+| [controller.httpsKeyStore.jenkinsKeyStoreBase64Encoded](./values.yaml#L927) | string | Base64 encoded Keystore content. Keystore must be converted to base64 then being pasted here | `nil` |
+| [controller.httpsKeyStore.password](./values.yaml#L924) | string | Jenkins keystore password | `"password"` |
+| [controller.httpsKeyStore.path](./values.yaml#L920) | string | Path of HTTPS keystore file | `"/var/jenkins_keystore"` |
 | [controller.image.pullPolicy](./values.yaml#L53) | string | Controller image pull policy | `"Always"` |
 | [controller.image.registry](./values.yaml#L43) | string | Controller image registry | `"docker.io"` |
 | [controller.image.repository](./values.yaml#L45) | string | Controller image repository | `"jenkins/jenkins"` |
@@ -228,34 +228,35 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.probes.startupProbe.periodSeconds](./values.yaml#L285) | int | Set the time interval between two startup probes executions in seconds | `10` |
 | [controller.probes.startupProbe.timeoutSeconds](./values.yaml#L287) | int | Set the timeout for the startup probe in seconds | `5` |
 | [controller.projectNamingStrategy](./values.yaml#L450) | string |  | `"standard"` |
-| [controller.prometheus.alertingRulesAdditionalLabels](./values.yaml#L877) | object | Additional labels to add to the PrometheusRule object | `{}` |
-| [controller.prometheus.alertingrules](./values.yaml#L875) | list | Array of prometheus alerting rules | `[]` |
-| [controller.prometheus.enabled](./values.yaml#L860) | bool | Enables prometheus service monitor | `false` |
-| [controller.prometheus.metricRelabelings](./values.yaml#L887) | list |  | `[]` |
-| [controller.prometheus.prometheusRuleNamespace](./values.yaml#L879) | string | Set a custom namespace where to deploy PrometheusRule resource | `""` |
-| [controller.prometheus.relabelings](./values.yaml#L885) | list |  | `[]` |
-| [controller.prometheus.scrapeEndpoint](./values.yaml#L870) | string | The endpoint prometheus should get metrics from | `"/prometheus"` |
-| [controller.prometheus.scrapeInterval](./values.yaml#L866) | string | How often prometheus should scrape metrics | `"60s"` |
-| [controller.prometheus.serviceMonitorAdditionalLabels](./values.yaml#L862) | object | Additional labels to add to the service monitor object | `{}` |
-| [controller.prometheus.serviceMonitorNamespace](./values.yaml#L864) | string | Set a custom namespace where to deploy ServiceMonitor resource | `nil` |
+| [controller.prometheus.alertingRulesAdditionalLabels](./values.yaml#L879) | object | Additional labels to add to the PrometheusRule object | `{}` |
+| [controller.prometheus.alertingrules](./values.yaml#L877) | list | Array of prometheus alerting rules | `[]` |
+| [controller.prometheus.enabled](./values.yaml#L862) | bool | Enables prometheus service monitor | `false` |
+| [controller.prometheus.metricRelabelings](./values.yaml#L889) | list |  | `[]` |
+| [controller.prometheus.prometheusRuleNamespace](./values.yaml#L881) | string | Set a custom namespace where to deploy PrometheusRule resource | `""` |
+| [controller.prometheus.relabelings](./values.yaml#L887) | list |  | `[]` |
+| [controller.prometheus.scrapeEndpoint](./values.yaml#L872) | string | The endpoint prometheus should get metrics from | `"/prometheus"` |
+| [controller.prometheus.scrapeInterval](./values.yaml#L868) | string | How often prometheus should scrape metrics | `"60s"` |
+| [controller.prometheus.serviceMonitorAdditionalLabels](./values.yaml#L864) | object | Additional labels to add to the service monitor object | `{}` |
+| [controller.prometheus.serviceMonitorNamespace](./values.yaml#L866) | string | Set a custom namespace where to deploy ServiceMonitor resource | `nil` |
 | [controller.publishNotReadyAddresses](./values.yaml#L252) | string |  | `nil` |
 | [controller.replicas](./values.yaml#L56) | int | Number of replicas. Max 1. Can be set to 0 for maintenance scenarios. | `1` |
 | [controller.resources](./values.yaml#L124) | object | Resource allocation (Requests and Limits) | `{"limits":{"cpu":"2000m","memory":"4096Mi"},"requests":{"cpu":"50m","memory":"256Mi"}}` |
-| [controller.route.annotations](./values.yaml#L820) | object | Route annotations | `{}` |
-| [controller.route.enabled](./values.yaml#L816) | bool | Enables openshift route | `false` |
-| [controller.route.labels](./values.yaml#L818) | object | Route labels | `{}` |
-| [controller.route.path](./values.yaml#L822) | string | Route path | `nil` |
+| [controller.route.annotations](./values.yaml#L822) | object | Route annotations | `{}` |
+| [controller.route.enabled](./values.yaml#L818) | bool | Enables openshift route | `false` |
+| [controller.route.labels](./values.yaml#L820) | object | Route labels | `{}` |
+| [controller.route.path](./values.yaml#L824) | string | Route path | `nil` |
 | [controller.runAsUser](./values.yaml#L198) | int | Deprecated in favor of `controller.podSecurityContextOverride`. uid that jenkins runs with. | `1000` |
 | [controller.schedulerName](./values.yaml#L672) | string | Name of the Kubernetes scheduler to use | `""` |
 | [controller.scriptApproval](./values.yaml#L462) | list | List of groovy functions to approve | `[]` |
-| [controller.secondaryingress.annotations](./values.yaml#L780) | object | Secondary Ingress annotations | `{}` |
-| [controller.secondaryingress.apiVersion](./values.yaml#L776) | string | Secondary Ingress API version | `"networking.k8s.io/v1"` |
+| [controller.secondaryingress.annotations](./values.yaml#L782) | object | Secondary Ingress annotations | `{}` |
+| [controller.secondaryingress.apiVersion](./values.yaml#L778) | string | Secondary Ingress API version | `"networking.k8s.io/v1"` |
 | [controller.secondaryingress.enabled](./values.yaml#L768) | bool | Enables the Secondary Ingress | `false` |
-| [controller.secondaryingress.hostName](./values.yaml#L789) | string | Secondary Ingress hostname | `nil` |
-| [controller.secondaryingress.ingressClassName](./values.yaml#L786) | string | Secondary Ingress ingressClassName | `nil` |
-| [controller.secondaryingress.labels](./values.yaml#L778) | object | Secondary Ingress labels | `{}` |
+| [controller.secondaryingress.hostName](./values.yaml#L791) | string | Secondary Ingress hostname | `nil` |
+| [controller.secondaryingress.ingressClassName](./values.yaml#L788) | string | Secondary Ingress ingressClassName | `nil` |
+| [controller.secondaryingress.labels](./values.yaml#L780) | object | Secondary Ingress labels | `{}` |
+| [controller.secondaryingress.pathType](./values.yaml#L774) | string | Secondary Ingress rule pathType, choices are: Exact, ImplementationSpecific, Prefix | `"ImplementationSpecific"` |
 | [controller.secondaryingress.paths](./values.yaml#L772) | list | Secondary Ingress paths | `[]` |
-| [controller.secondaryingress.tls](./values.yaml#L791) | string | Secondary Ingress TLS configuration | `nil` |
+| [controller.secondaryingress.tls](./values.yaml#L793) | string | Secondary Ingress TLS configuration | `nil` |
 | [controller.secretClaims](./values.yaml#L505) | list | List of `SecretClaim` resources to create | `[]` |
 | [controller.securityContextCapabilities](./values.yaml#L210) | object |  | `{}` |
 | [controller.serviceAnnotations](./values.yaml#L255) | object | Jenkins controller service annotations | `{}` |
@@ -291,7 +292,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [controller.terminationGracePeriodSeconds](./values.yaml#L682) | string | Set TerminationGracePeriodSeconds | `nil` |
 | [controller.terminationMessagePath](./values.yaml#L684) | string | Set the termination message path | `nil` |
 | [controller.terminationMessagePolicy](./values.yaml#L686) | string | Set the termination message policy | `nil` |
-| [controller.testEnabled](./values.yaml#L899) | bool | Can be used to disable rendering controller test resources when using helm template | `true` |
+| [controller.testEnabled](./values.yaml#L901) | bool | Can be used to disable rendering controller test resources when using helm template | `true` |
 | [controller.tolerations](./values.yaml#L680) | list | Toleration labels for pod assignment | `[]` |
 | [controller.topologySpreadConstraints](./values.yaml#L706) | list | Topology spread constraints | `[]` |
 | [controller.updateStrategy](./values.yaml#L703) | object | Update strategy for StatefulSet | `{}` |
@@ -300,43 +301,43 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [extraLabels](./values.yaml#L33) | object | Configures extra labels for the agent all objects | `{}` |
 | [extraObjects](./values.yaml#L36) | string | Configures extra manifests | `nil` |
 | [fullnameOverride](./values.yaml#L13) | string | Override the full resource names | `jenkins-(release-name)` or `jenkins` if the release-name is `jenkins` |
-| [helmtest.bats.image.registry](./values.yaml#L1431) | string | Registry of the image used to test the framework | `"docker.io"` |
-| [helmtest.bats.image.repository](./values.yaml#L1433) | string | Repository of the image used to test the framework | `"bats/bats"` |
-| [helmtest.bats.image.tag](./values.yaml#L1435) | string | Tag of the image to test the framework | `"1.13.0"` |
+| [helmtest.bats.image.registry](./values.yaml#L1433) | string | Registry of the image used to test the framework | `"docker.io"` |
+| [helmtest.bats.image.repository](./values.yaml#L1435) | string | Repository of the image used to test the framework | `"bats/bats"` |
+| [helmtest.bats.image.tag](./values.yaml#L1437) | string | Tag of the image to test the framework | `"1.13.0"` |
 | [kubernetesURL](./values.yaml#L24) | string | The URL of the Kubernetes API server | `"https://kubernetes.default"` |
 | [nameOverride](./values.yaml#L10) | string | Override the resource name prefix | `Chart.Name` |
 | [namespaceOverride](./values.yaml#L16) | string | Override the deployment namespace | `Release.Namespace` |
-| [networkPolicy.apiVersion](./values.yaml#L1354) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
-| [networkPolicy.enabled](./values.yaml#L1349) | bool | Enable the creation of NetworkPolicy resources | `false` |
-| [networkPolicy.externalAgents.except](./values.yaml#L1369) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
-| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1367) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
-| [networkPolicy.internalAgents.allowed](./values.yaml#L1358) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
-| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1362) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
-| [networkPolicy.internalAgents.podLabels](./values.yaml#L1360) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
-| [persistence.accessMode](./values.yaml#L1324) | string | The PVC access mode | `"ReadWriteOnce"` |
-| [persistence.annotations](./values.yaml#L1320) | object | Annotations for the PVC | `{}` |
-| [persistence.dataSource](./values.yaml#L1330) | object | Existing data source to clone PVC from | `{}` |
-| [persistence.enabled](./values.yaml#L1304) | bool | Enable the use of a Jenkins PVC | `true` |
-| [persistence.existingClaim](./values.yaml#L1310) | string | Provide the name of a PVC | `nil` |
-| [persistence.labels](./values.yaml#L1322) | object | Labels for the PVC | `{}` |
-| [persistence.mounts](./values.yaml#L1342) | list | Additional mounts | `[]` |
-| [persistence.size](./values.yaml#L1326) | string | The size of the PVC | `"8Gi"` |
-| [persistence.storageClass](./values.yaml#L1318) | string | Storage class for the PVC | `nil` |
-| [persistence.subPath](./values.yaml#L1335) | string | SubPath for jenkins-home mount | `nil` |
-| [persistence.volumes](./values.yaml#L1337) | list | Additional volumes | `[]` |
-| [rbac.create](./values.yaml#L1376) | bool | Whether RBAC resources are created | `true` |
-| [rbac.readSecrets](./values.yaml#L1378) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
-| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1380) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
+| [networkPolicy.apiVersion](./values.yaml#L1356) | string | NetworkPolicy ApiVersion | `"networking.k8s.io/v1"` |
+| [networkPolicy.enabled](./values.yaml#L1351) | bool | Enable the creation of NetworkPolicy resources | `false` |
+| [networkPolicy.externalAgents.except](./values.yaml#L1371) | list | A list of IP sub-ranges to be excluded from the allowlisted IP range | `[]` |
+| [networkPolicy.externalAgents.ipCIDR](./values.yaml#L1369) | string | The IP range from which external agents are allowed to connect to controller, i.e., 172.17.0.0/16 | `nil` |
+| [networkPolicy.internalAgents.allowed](./values.yaml#L1360) | bool | Allow internal agents (from the same cluster) to connect to controller. Agent pods will be filtered based on PodLabels | `true` |
+| [networkPolicy.internalAgents.namespaceLabels](./values.yaml#L1364) | object | A map of labels (keys/values) that agents namespaces must have to be able to connect to controller | `{}` |
+| [networkPolicy.internalAgents.podLabels](./values.yaml#L1362) | object | A map of labels (keys/values) that agent pods must have to be able to connect to controller | `{}` |
+| [persistence.accessMode](./values.yaml#L1326) | string | The PVC access mode | `"ReadWriteOnce"` |
+| [persistence.annotations](./values.yaml#L1322) | object | Annotations for the PVC | `{}` |
+| [persistence.dataSource](./values.yaml#L1332) | object | Existing data source to clone PVC from | `{}` |
+| [persistence.enabled](./values.yaml#L1306) | bool | Enable the use of a Jenkins PVC | `true` |
+| [persistence.existingClaim](./values.yaml#L1312) | string | Provide the name of a PVC | `nil` |
+| [persistence.labels](./values.yaml#L1324) | object | Labels for the PVC | `{}` |
+| [persistence.mounts](./values.yaml#L1344) | list | Additional mounts | `[]` |
+| [persistence.size](./values.yaml#L1328) | string | The size of the PVC | `"8Gi"` |
+| [persistence.storageClass](./values.yaml#L1320) | string | Storage class for the PVC | `nil` |
+| [persistence.subPath](./values.yaml#L1337) | string | SubPath for jenkins-home mount | `nil` |
+| [persistence.volumes](./values.yaml#L1339) | list | Additional volumes | `[]` |
+| [rbac.create](./values.yaml#L1378) | bool | Whether RBAC resources are created | `true` |
+| [rbac.readSecrets](./values.yaml#L1380) | bool | Whether the Jenkins service account should be able to read Kubernetes secrets | `false` |
+| [rbac.useOpenShiftNonRootSCC](./values.yaml#L1382) | bool | Whether the Jenkins service account should be able to use the OpenShift "nonroot" Security Context Constraints | `false` |
 | [renderHelmLabels](./values.yaml#L30) | bool | Enables rendering of the helm.sh/chart label to the annotations | `true` |
-| [serviceAccount.annotations](./values.yaml#L1390) | object | Configures annotations for the ServiceAccount | `{}` |
-| [serviceAccount.automountServiceAccountToken](./values.yaml#L1396) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccount.create](./values.yaml#L1384) | bool | Configures if a ServiceAccount with this name should be created | `true` |
-| [serviceAccount.extraLabels](./values.yaml#L1392) | object | Configures extra labels for the ServiceAccount | `{}` |
-| [serviceAccount.imagePullSecretName](./values.yaml#L1394) | string | Controller ServiceAccount image pull secret | `nil` |
-| [serviceAccount.name](./values.yaml#L1388) | string |  | `nil` |
-| [serviceAccountAgent.annotations](./values.yaml#L1406) | object | Configures annotations for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1412) | bool | Auto-mount ServiceAccount token | `true` |
-| [serviceAccountAgent.create](./values.yaml#L1400) | bool | Configures if an agent ServiceAccount should be created | `false` |
-| [serviceAccountAgent.extraLabels](./values.yaml#L1408) | object | Configures extra labels for the agent ServiceAccount | `{}` |
-| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1410) | string | Agent ServiceAccount image pull secret | `nil` |
-| [serviceAccountAgent.name](./values.yaml#L1404) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |
+| [serviceAccount.annotations](./values.yaml#L1392) | object | Configures annotations for the ServiceAccount | `{}` |
+| [serviceAccount.automountServiceAccountToken](./values.yaml#L1398) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccount.create](./values.yaml#L1386) | bool | Configures if a ServiceAccount with this name should be created | `true` |
+| [serviceAccount.extraLabels](./values.yaml#L1394) | object | Configures extra labels for the ServiceAccount | `{}` |
+| [serviceAccount.imagePullSecretName](./values.yaml#L1396) | string | Controller ServiceAccount image pull secret | `nil` |
+| [serviceAccount.name](./values.yaml#L1390) | string |  | `nil` |
+| [serviceAccountAgent.annotations](./values.yaml#L1408) | object | Configures annotations for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.automountServiceAccountToken](./values.yaml#L1414) | bool | Auto-mount ServiceAccount token | `true` |
+| [serviceAccountAgent.create](./values.yaml#L1402) | bool | Configures if an agent ServiceAccount should be created | `false` |
+| [serviceAccountAgent.extraLabels](./values.yaml#L1410) | object | Configures extra labels for the agent ServiceAccount | `{}` |
+| [serviceAccountAgent.imagePullSecretName](./values.yaml#L1412) | string | Agent ServiceAccount image pull secret | `nil` |
+| [serviceAccountAgent.name](./values.yaml#L1406) | string | The name of the agent ServiceAccount to be used by access-controlled resources | `nil` |

--- a/charts/jenkins/templates/jenkins-controller-secondary-ingress.yaml
+++ b/charts/jenkins/templates/jenkins-controller-secondary-ingress.yaml
@@ -38,7 +38,7 @@ spec:
                 name: {{ $serviceName }}
                 port:
                   number: {{ $servicePort }}
-            pathType: ImplementationSpecific
+            pathType: {{ $.Values.controller.secondaryingress.pathType }}
 {{ else }}
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-secondary-ingress-1.19-test.yaml
@@ -76,6 +76,18 @@ tests:
             app.kubernetes.io/instance: my-release
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: jenkins
+  - it: uses the configured path type
+    set:
+      controller.secondaryingress:
+        enabled: true
+        hostName: jenkins.example.com
+        paths:
+          - /github-webhook
+        pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
   - it: hostName with Release.Name template variable
     set:
       controller.secondaryingress:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -770,6 +770,8 @@ controller:
     # ex /github-webhook
     # -- Secondary Ingress paths
     paths: []
+    # -- Secondary Ingress rule pathType, choices are: Exact, ImplementationSpecific, Prefix
+    pathType: ImplementationSpecific
     # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
     # For Kubernetes v1.19+, use 'networking.k8s.io/v1'
     # -- Secondary Ingress API version


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

- Adds `controller.secondaryingress.pathType`, preserving `ImplementationSpecific` as the default.
- Uses the configured path type for Kubernetes 1.19+ secondary ingresses and adds regression coverage for `Prefix`.

Fixes #1711

### Result

With `controller.secondaryingress.pathType: Prefix`, the rendered ingress contains:

```yaml
- path: "/github-webhook"
  pathType: Prefix
```

### Testing

- `helm unittest --strict -f 'unittests/*.yaml' charts/jenkins` (219 passed)
- `ct lint --config ct.yaml` (passed)
- `.github/helm-docs.sh` (passed)

If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist

- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

None.
