### PR TITLE
Preserve zero user and group IDs in agent configurations

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.37
+
+Fix [#1521](https://github.com/jenkinsci/helm-charts/issues/1521): Preserve explicit zero values for agent `runAsUser` and `runAsGroup`
+
 ## 5.9.36
 
 Update `docker.io/kiwigrid/k8s-sidecar` to version `2.8.1`

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.36
+version: 5.9.37
 appVersion: 2.568.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -215,8 +215,18 @@ jenkins:
       {{- $agent := .Values.agent }}
       {{- range $name, $additionalAgent := .Values.additionalAgents }}
         {{- $additionalContainersEmpty := and (hasKey $additionalAgent "additionalContainers") (empty $additionalAgent.additionalContainers)  }}
+        {{- $runAsUser := $additionalAgent.runAsUser }}
+        {{- $runAsUserSet := not (kindIs "invalid" $runAsUser) }}
+        {{- $runAsGroup := $additionalAgent.runAsGroup }}
+        {{- $runAsGroupSet := not (kindIs "invalid" $runAsGroup) }}
         {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
         {{- $additionalAgent := merge $additionalAgent $agent }}
+        {{- if $runAsUserSet }}
+        {{- $_ := set $additionalAgent "runAsUser" $runAsUser }}
+        {{- end }}
+        {{- if $runAsGroupSet }}
+        {{- $_ := set $additionalAgent "runAsGroup" $runAsGroup }}
+        {{- end }}
         {{- /* clear list of additional containers in case it is configured empty for this agent (merge might have overwritten that) */}}
         {{- if $additionalContainersEmpty }}
         {{- $_ := set $additionalAgent "additionalContainers" list }}
@@ -309,8 +319,18 @@ jenkins:
        {{- $agent := .Values.agent }}
        {{- range $name, $additionalAgent := .Values.additionalAgents }}
          {{- $additionalContainersEmpty := and (hasKey $additionalAgent "additionalContainers") (empty $additionalAgent.additionalContainers)  }}
+         {{- $runAsUser := $additionalAgent.runAsUser }}
+         {{- $runAsUserSet := not (kindIs "invalid" $runAsUser) }}
+         {{- $runAsGroup := $additionalAgent.runAsGroup }}
+         {{- $runAsGroupSet := not (kindIs "invalid" $runAsGroup) }}
          {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
          {{- $additionalAgent := merge $additionalAgent $agent }}
+         {{- if $runAsUserSet }}
+         {{- $_ := set $additionalAgent "runAsUser" $runAsUser }}
+         {{- end }}
+         {{- if $runAsGroupSet }}
+         {{- $_ := set $additionalAgent "runAsGroup" $runAsGroup }}
+         {{- end }}
          {{- /* clear list of additional containers in case it is configured empty for this agent (merge might have overwritten that) */}}
          {{- if $additionalContainersEmpty }}
          {{- $_ := set $additionalAgent "additionalContainers" list }}
@@ -428,11 +448,11 @@ Returns kubernetes pod template configuration as code
     {{- with .Values.agent.resources.requests.ephemeralStorage }}
     resourceRequestEphemeralStorage: {{.}}
     {{- end }}
-    {{- with .Values.agent.runAsUser }}
-    runAsUser: {{ . }}
+    {{- if not (kindIs "invalid" .Values.agent.runAsUser) }}
+    runAsUser: {{ .Values.agent.runAsUser }}
     {{- end }}
-    {{- with .Values.agent.runAsGroup }}
-    runAsGroup: {{ . }}
+    {{- if not (kindIs "invalid" .Values.agent.runAsGroup) }}
+    runAsGroup: {{ .Values.agent.runAsGroup }}
     {{- end }}
     ttyEnabled: {{ .Values.agent.TTYEnabled }}
     workingDir: {{ .Values.agent.workingDir }}
@@ -466,11 +486,15 @@ Returns kubernetes pod template configuration as code
     resourceLimitMemory: {{ if $additionalContainers.resources }}{{ $additionalContainers.resources.limits.memory }}{{ else }}{{ $.Values.agent.resources.limits.memory }}{{ end }}
     resourceRequestCpu: {{ if $additionalContainers.resources }}{{ $additionalContainers.resources.requests.cpu }}{{ else }}{{ $.Values.agent.resources.requests.cpu }}{{ end }}
     resourceRequestMemory: {{ if $additionalContainers.resources }}{{ $additionalContainers.resources.requests.memory }}{{ else }}{{ $.Values.agent.resources.requests.memory }}{{ end }}
-    {{- if or $additionalContainers.runAsUser $.Values.agent.runAsUser }}
-    runAsUser: {{ $additionalContainers.runAsUser | default $.Values.agent.runAsUser }}
+    {{- if not (kindIs "invalid" $additionalContainers.runAsUser) }}
+    runAsUser: {{ $additionalContainers.runAsUser }}
+    {{- else if not (kindIs "invalid" $.Values.agent.runAsUser) }}
+    runAsUser: {{ $.Values.agent.runAsUser }}
     {{- end }}
-    {{- if or $additionalContainers.runAsGroup $.Values.agent.runAsGroup }}
-    runAsGroup: {{ $additionalContainers.runAsGroup | default $.Values.agent.runAsGroup }}
+    {{- if not (kindIs "invalid" $additionalContainers.runAsGroup) }}
+    runAsGroup: {{ $additionalContainers.runAsGroup }}
+    {{- else if not (kindIs "invalid" $.Values.agent.runAsGroup) }}
+    runAsGroup: {{ $.Values.agent.runAsGroup }}
     {{- end }}
     ttyEnabled: {{ $additionalContainers.TTYEnabled | default $.Values.agent.TTYEnabled }}
     workingDir: {{ $additionalContainers.workingDir | default $.Values.agent.workingDir }}

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -533,6 +533,73 @@ tests:
     asserts:
       - matchSnapshot:
           path: data["jcasc-default-config.yaml"]
+  - it: preserve zero user and group IDs for the default agent
+    set:
+      agent:
+        runAsUser: 0
+        runAsGroup: 0
+    asserts:
+      - matchRegex:
+          path: data["jcasc-default-config.yaml"]
+          pattern: '(?s)- name: "default".*runAsUser: 0.*runAsGroup: 0'
+  - it: preserve zero user and group IDs for additional containers
+    set:
+      agent:
+        runAsUser: 1000
+        runAsGroup: 1000
+        additionalContainers:
+          - sideContainerName: root-container
+            image:
+              repository: docker
+              tag: dind
+            args: ""
+            runAsUser: 0
+            runAsGroup: 0
+          - sideContainerName: inherited-container
+            image:
+              repository: busybox
+              tag: latest
+            args: ""
+    asserts:
+      - matchRegex:
+          path: data["jcasc-default-config.yaml"]
+          pattern: '(?s)- name: "root-container".*runAsUser: 0.*runAsGroup: 0'
+      - matchRegex:
+          path: data["jcasc-default-config.yaml"]
+          pattern: '(?s)- name: "inherited-container".*runAsUser: 1000.*runAsGroup: 1000'
+  - it: preserve zero user and group IDs for additional agents
+    set:
+      agent:
+        disableDefaultAgent: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      additionalAgents:
+        root-agent:
+          podName: root-agent
+          runAsUser: 0
+          runAsGroup: 0
+    asserts:
+      - matchRegex:
+          path: data["jcasc-default-config.yaml"]
+          pattern: '(?s)- name: "root-agent".*runAsUser: 0.*runAsGroup: 0'
+  - it: preserve zero user and group IDs for additional agents in additional clouds
+    set:
+      agent:
+        disableDefaultAgent: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      additionalAgents:
+        root-agent:
+          podName: root-agent
+          runAsUser: 0
+          runAsGroup: 0
+      additionalClouds:
+        remote-cloud:
+          kubernetesURL: https://api.remote-cloud.com
+    asserts:
+      - matchRegex:
+          path: data["jcasc-default-config.yaml"]
+          pattern: '(?s)name: "remote-cloud".*- name: "root-agent".*runAsUser: 0.*runAsGroup: 0'
   - it: specify additional container and overwrite in additional agent
     release:
       namespace: default


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### What does this PR do?

- Preserves explicit numeric `0` values for `runAsUser` and `runAsGroup` instead of treating them as unset during agent template rendering and inheritance.
- Covers the default agent, additional containers, and additional agents with regression tests.

Fixes #1521

### Result

With global agent user and group IDs set to `1000`, an additional container that explicitly sets both values to `0` now renders the following relevant JCasC excerpt:

```yaml
- name: "root-container"
  runAsUser: 0
  runAsGroup: 0
```

### Testing

- `helm unittest --strict -f 'unittests/*.yaml' charts/jenkins` (218 passed)
- `ct lint --config ct.yaml` (passed)
- `.github/helm-docs.sh` (passed)

If you modified files in the `./charts/jenkins/` directory, please also include the following:

### Submitter checklist

- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

None.
