### PR TITLE
fix(jenkins): evaluate tpl on controller.javaOpts and controller.jenkinsOpts

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.39
+
+Evaluate `tpl` on `controller.javaOpts` and `controller.jenkinsOpts` so values can reference other Helm values or named templates, matching the templating already supported by fields such as `controller.ingress.hostName`, `controller.secondaryIngress.hostName`, and `controller.admin.existingSecret`.
+
 ## 5.9.38
 
 Allow overriding the secondary ingress path type

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.38
+version: 5.9.39
 appVersion: 2.568.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -220,10 +220,10 @@ spec:
                   fieldPath: metadata.name
             - name: JAVA_OPTS
               value: >-
-                {{ if .Values.controller.sidecars.configAutoReload.enabled }} -Dcasc.reload.token=$(POD_NAME) {{ end }}{{ default "" .Values.controller.javaOpts }}
+                {{ if .Values.controller.sidecars.configAutoReload.enabled }} -Dcasc.reload.token=$(POD_NAME) {{ end }}{{ tpl (default "" .Values.controller.javaOpts) . }}
             - name: JENKINS_OPTS
               value: >-
-                {{ if .Values.controller.jenkinsUriPrefix }}--prefix={{ .Values.controller.jenkinsUriPrefix }} {{ end }} --webroot=/var/jenkins_cache/war {{ default "" .Values.controller.jenkinsOpts}}
+                {{ if .Values.controller.jenkinsUriPrefix }}--prefix={{ .Values.controller.jenkinsUriPrefix }} {{ end }} --webroot=/var/jenkins_cache/war {{ tpl (default "" .Values.controller.jenkinsOpts) . }}
             - name: JENKINS_SLAVE_AGENT_PORT
               value: "{{ .Values.controller.agentListenerPort }}"
             {{- if .Values.controller.httpsKeyStore.enable }}

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -244,6 +244,31 @@ tests:
             name: JENKINS_OPTS
             value: >-
               --webroot=/var/jenkins_cache/war -Dtest="custom: 'true'"
+  - it: java & jenkins opts are evaluated with tpl
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        image:
+          registry: docker.io
+          repository: registry/image
+          tag: my-tag
+        javaOpts: >-
+          -Dcontroller.image={{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+        jenkinsOpts: >-
+          -Dcontroller.image={{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: >-
+              -Dcasc.reload.token=$(POD_NAME) -Dcontroller.image=registry/image:my-tag
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JENKINS_OPTS
+            value: >-
+              --webroot=/var/jenkins_cache/war -Dcontroller.image=registry/image:my-tag
   - it: test empty controller.podSecurityContextOverride
     template: jenkins-controller-statefulset.yaml
     set:


### PR DESCRIPTION
## Summary

Wrap `.Values.controller.javaOpts` and `.Values.controller.jenkinsOpts` with `tpl (default "" ...) .` in the controller StatefulSet template so values can reference other Helm values or named templates — matching the pattern already applied to fields such as `controller.ingress` secretName (#1622) and secondary ingress host/tls (#1638).

## Motivation

Today values like:

```yaml
controller:
  javaOpts: "-Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage={{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
```

render literally into the manifest:

```yaml
- name: JAVA_OPTS
  value: >-
    -Dcasc.reload.token=$(POD_NAME) -Dorg.csanchez...defaultImage={{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
```

which the JVM passes to Jenkins verbatim, producing a broken system property. Users must instead hardcode the fully composed URL or apply post-render patches. After this change the value expands to the composed string, e.g. `-Dorg.csanchez...defaultImage=myrepo:mytag`.

## Backward compatibility

- `default ""` is preserved, so unset opts continue to render an empty string.
- Values without any `{{ ... }}` syntax render byte-for-byte identically — `tpl` on a plain string is a no-op.
- No new required values; no changes to `values.yaml` schema.
- Existing snapshot tests pass without regeneration (50 snapshots).

## Changes

- `charts/jenkins/templates/jenkins-controller-statefulset.yaml` — 2 lines wrapped with `tpl (default "" ...) .`.
- `charts/jenkins/Chart.yaml` — patch bump `5.9.38` → `5.9.39`.
- `charts/jenkins/CHANGELOG.md` — new `## 5.9.39` entry.
- `charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml` — new test `java & jenkins opts are evaluated with tpl` asserting that `{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}` inside opts resolves to `registry/image:my-tag` in both JAVA_OPTS and JENKINS_OPTS.

## Test plan

- [x] `helm lint charts/jenkins` — PASS
- [x] `helm unittest --strict -f 'unittests/*.yaml' charts/jenkins` — 220 tests / 28 suites / 50 snapshots PASS
- [x] `helm template charts/jenkins --set 'controller.javaOpts=-Dfoo={{ .Values.controller.image.tag }}' --set controller.image.tag=abc` — rendered JAVA_OPTS contains `-Dfoo=abc`
- [ ] chart-testing CI (`ct install`) — will run via GitHub Actions on push

## Related

- Prior tpl-wrap fixes accepted upstream: #1622 (secretName templating, merged 2026-02-27), #1638 (secondary ingress host/tls templating, merged 2026-04-13).
- No open issue existed for this specific gap; happy to file one retroactively if preferred.