### PR TITLE
fix(jenkins): evaluate tpl on agent.image.registry, repository and tag

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.40
+
+Evaluate `tpl` on `agent.image.registry`, `agent.image.repository`, and `agent.image.tag` so the default kubernetes-agent pod template can compose its jnlp image from other Helm values or named templates. Complements the `tpl`-support added for `controller.javaOpts` / `controller.jenkinsOpts` in 5.9.39.
+
 ## 5.9.39
 
 Evaluate `tpl` on `controller.javaOpts` and `controller.jenkinsOpts` so values can reference other Helm values or named templates, matching the templating already supported by fields such as `controller.ingress.hostName`, `controller.secondaryIngress.hostName`, and `controller.admin.existingSecret`.

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.39
+version: 5.9.40
 appVersion: 2.568.1
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -424,9 +424,9 @@ Returns kubernetes pod template configuration as code
           {{- end }}
         {{- end }}
     {{- if ne .Values.agent.image.registry "" }}
-    image: "{{ .Values.agent.image.registry}}/{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
+    image: "{{ tpl .Values.agent.image.registry . }}/{{ tpl .Values.agent.image.repository . }}:{{ tpl .Values.agent.image.tag . }}"
     {{- else }}
-    image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
+    image: "{{ tpl .Values.agent.image.repository . }}:{{ tpl .Values.agent.image.tag . }}"
     {{- end }}
     {{- if .Values.agent.livenessProbe }}
     livenessProbe:

--- a/charts/jenkins/unittests/jcasc-config-test.yaml
+++ b/charts/jenkins/unittests/jcasc-config-test.yaml
@@ -17,6 +17,23 @@ tests:
           pattern: ^jenkins-
       - matchSnapshot:
           path: data["jcasc-default-config.yaml"]
+  - it: agent image fields are evaluated with tpl
+    release:
+      namespace: default
+    set:
+      controller:
+        image:
+          repository: myrepo/controller
+          tag: my-controller-tag
+      agent:
+        image:
+          registry: myregistry.example.com
+          repository: "{{ .Values.controller.image.repository }}-agent"
+          tag: "{{ .Values.controller.image.tag }}"
+    asserts:
+      - matchRegex:
+          path: data["jcasc-default-config.yaml"]
+          pattern: 'image: "myregistry\.example\.com/myrepo/controller-agent:my-controller-tag"'
   - it: agent namespace and templates
     release:
       namespace: controller-namespace


### PR DESCRIPTION
## Summary

Wrap `.Values.agent.image.registry`, `.Values.agent.image.repository`, and `.Values.agent.image.tag` with `tpl ... .` in `_helpers.tpl` so the default kubernetes-agent pod template composes its jnlp image from values that may reference other Helm values or named templates — matching the pattern already applied to `controller.javaOpts` / `controller.jenkinsOpts` in #1715 and to secondary ingress host/tls in #1638.

## Motivation

Today values like:

```yaml
agent:
  image:
    repository: "{{ .Values.controller.image.repository }}-agent"
    tag: "{{ .Values.controller.image.tag }}"
```

render literally into the generated JCasC ConfigMap:

```yaml
image: "{{ .Values.controller.image.repository }}-agent:{{ .Values.controller.image.tag }}"
```

which the kubernetes plugin picks up as a broken image reference. Users must instead hardcode the fully composed URL, keep two lines in sync across releases, or apply post-render patches. After this change the same values compose correctly, e.g. `image: "myregistry/myrepo-agent:mytag"`.

## Backward compatibility

- `tpl` on a plain string is a no-op — installations with literal `repository: "jenkins/inbound-agent"` render byte-for-byte identically.
- No new required values; no changes to `values.yaml` schema.
- Existing snapshot suite (50 snapshots) passes without regeneration.
- Applies symmetrically to both branches (`registry != ""` and `registry == ""`).

## Changes

- `charts/jenkins/templates/_helpers.tpl` — wrap `agent.image.registry`, `agent.image.repository`, `agent.image.tag` with `tpl ... .` in both image render branches (L427 and L429).
- `charts/jenkins/Chart.yaml` — patch bump `5.9.39` → `5.9.40`.
- `charts/jenkins/CHANGELOG.md` — new `## 5.9.40` entry referencing the 5.9.39 companion fix.
- `charts/jenkins/unittests/jcasc-config-test.yaml` — new test `agent image fields are evaluated with tpl` asserting that `agent.image.repository: "{{ .Values.controller.image.repository }}-agent"` renders as `myregistry.example.com/myrepo/controller-agent:my-controller-tag` in the JCasC default-config ConfigMap.

## Test plan

- [x] `helm lint charts/jenkins` — PASS
- [x] `helm unittest --strict -f 'unittests/*.yaml' charts/jenkins` — 221 tests / 28 suites / 50 snapshots PASS (was 220 before; +1 for the new test; snapshots unchanged)
- [x] `helm template charts/jenkins -f values.yaml` with `agent.image.repository="{{ .Values.controller.image.repository }}-agent"` renders `image: "myregistry.example.com/myrepo/controller-agent:my-controller-tag"`
- [x] chart-testing CI (`ct install`) — will run via GitHub Actions on push

## Related

- Companion fix for `controller.javaOpts` / `controller.jenkinsOpts`: #1715 (merged 2026-07-20).
- Prior tpl-wrap fixes accepted upstream: #1622 (secretName templating, merged 2026-02-27), #1638 (secondary ingress host/tls, merged 2026-04-13).