### PR TITLE
fix(jenkins): hash only ConfigMap data in checksum/* pod annotations

### DIFF
--- a/charts/jenkins/CHANGELOG.md
+++ b/charts/jenkins/CHANGELOG.md
@@ -12,6 +12,10 @@ Use the following links to reference issues, PRs, and commits prior to v2.6.0.
 The changelog until v1.5.7 was auto-generated based on git commits.
 Those entries include a reference to the git commit to be able to get more details.
 
+## 5.9.58
+
+Hash only the ConfigMap data in the `checksum/config` and `checksum/config-init-scripts` pod annotations, so a chart version bump alone no longer restarts the controller. Upgrading to this version restarts the controller once as the annotations change.
+
 ## 5.9.57
 
 Add support for `imagePullSecret` in helmtest.bats image pull

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jenkins
 type: application
 home: https://www.jenkins.io/
-version: 5.9.57
+version: 5.9.58
 appVersion: 2.568.3
 description: >
   Jenkins - Build great things at any scale! As the leading open source automation server, Jenkins provides over 2000 plugins to support building, deploying and automating any project.

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -30,6 +30,16 @@ Common labels for all Jenkins resources
 {{- end -}}
 
 {{/*
+sha256sum of the data of a rendered ConfigMap, for checksum/* pod annotations.
+The full manifest is not hashed: its metadata.labels carry helm.sh/chart, which changes on every
+chart version bump.
+*/}}
+{{- define "jenkins.configChecksum" -}}
+{{- $rendered := include (print .context.Template.BasePath .path) .context | fromYaml -}}
+{{- merge (dict) (dig "data" dict $rendered) (dig "stringData" dict $rendered) | toYaml | sha256sum -}}
+{{- end -}}
+
+{{/*
 Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
 */}}
 {{- define "jenkins.namespace" -}}

--- a/charts/jenkins/templates/jenkins-controller-statefulset.yaml
+++ b/charts/jenkins/templates/jenkins-controller-statefulset.yaml
@@ -38,9 +38,9 @@ spec:
         {{ $key }}: {{ $val | quote }}
         {{- end}}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        checksum/config: {{ include "jenkins.configChecksum" (dict "context" $ "path" "/config.yaml") }}
         {{- if .Values.controller.initScripts }}
-        checksum/config-init-scripts: {{ include (print $.Template.BasePath "/config-init-scripts.yaml") . | sha256sum }}
+        checksum/config-init-scripts: {{ include "jenkins.configChecksum" (dict "context" $ "path" "/config-init-scripts.yaml") }}
         {{- end }}
         {{- if .Values.controller.podAnnotations }}
 {{ tpl (toYaml .Values.controller.podAnnotations | indent 8) . }}

--- a/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
+++ b/charts/jenkins/unittests/__snapshot__/jenkins-controller-statefulset-test.yaml.snap
@@ -29,7 +29,7 @@ default values:
     template:
       metadata:
         annotations:
-          checksum/config: e403e9024dcadfd9b46094ed6ee8230718f424720125bc4425883bbe914c3cfb
+          checksum/config: efe4ac0c957c9c6e69d54a4b3d662d984e130afca972eaaa67bfc86439b89caf
         labels:
           app.kubernetes.io/component: jenkins-controller
           app.kubernetes.io/instance: my-release
@@ -245,7 +245,7 @@ default values:
             name: tmp-volume
 render pod annotations:
   1: |
-    checksum/config: e403e9024dcadfd9b46094ed6ee8230718f424720125bc4425883bbe914c3cfb
+    checksum/config: efe4ac0c957c9c6e69d54a4b3d662d984e130afca972eaaa67bfc86439b89caf
     fixed-annotation: some-fixed-annotation
     templated-annotations: my-release
 test scheme for config-reload:
@@ -259,7 +259,7 @@ test scheme for config-reload:
     template:
       metadata:
         annotations:
-          checksum/config: e403e9024dcadfd9b46094ed6ee8230718f424720125bc4425883bbe914c3cfb
+          checksum/config: efe4ac0c957c9c6e69d54a4b3d662d984e130afca972eaaa67bfc86439b89caf
         labels:
           app.kubernetes.io/component: jenkins-controller
           app.kubernetes.io/instance: my-release

--- a/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
+++ b/charts/jenkins/unittests/jenkins-controller-statefulset-test.yaml
@@ -858,7 +858,20 @@ tests:
       - isSubset:
           path: spec.template.metadata.annotations
           content:
-            checksum/config-init-scripts: 7bbfa764cae3f479cabae93c236604a2ff72b8a79c2977606f75f46f730084eb
+            checksum/config-init-scripts: fdc4dd4c6600130ea2a45366f5bc600ffa0e29aaf284bce3d85118291f7c96ce
+  - it: test checksum is unaffected by the helm labels
+    template: jenkins-controller-statefulset.yaml
+    set:
+      controller:
+        initScripts:
+          test: |-
+            This is a test script
+      renderHelmLabels: true
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            checksum/config-init-scripts: fdc4dd4c6600130ea2a45366f5bc600ffa0e29aaf284bce3d85118291f7c96ce
   - it: config values
     template: config-init-scripts.yaml
     set:


### PR DESCRIPTION
### What does this PR do?

Adds a `jenkins.configChecksum` helper that hashes only the `data` of the rendered ConfigMap, and uses it for the `checksum/config` and `checksum/config-init-scripts` pod annotations on the controller StatefulSet.

Until now those annotations hashed the whole rendered manifest, whose `metadata.labels` include `helm.sh/chart`. That label changes on every chart version bump, so the controller pod was rolled on every upgrade even when no configuration had changed — e.g. 5.9.56 → 5.9.57, which only touched the helmtest image pull secret, still flipped `checksum/config`.

A pure version bump is now a no-op for the controller; any real change to the config data still rolls it. Upgrading to this version restarts the controller once, as the annotation values change. Same approach as argoproj/argo-helm#4044.

### Submitter checklist

- [x] I bumped the "version" key in `./charts/jenkins/Chart.yaml`.
- [x] I added a new changelog entry to `./charts/jenkins/CHANGELOG.md`.
- [x] I followed the [technical requirements](https://github.com/jenkinsci/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements).
- [x] I ran `.github/helm-docs.sh` from the project root.

### Special notes for your reviewer

The existing `test checksum for config-init-script` test set `renderHelmLabels: false` to keep the hash stable — that workaround is no longer needed, and there is now a second case rendering with the labels on that expects the same hash. Snapshots regenerated with helm-unittest v1.1.1.
